### PR TITLE
FCS_CKM_EXT.8 change

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -24,6 +24,8 @@ This collaborative Protection Profile (cPP) was developed by the {iTC-longame} i
 [.text-center]
 Apple Inc.
 [.text-center]
+Google, LLC
+[.text-center]
 Samsung Electronics Co., Ltd.
 [.text-center]
 *Common Criteria Test Laboratories*
@@ -620,8 +622,6 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/KeyEnc !Cryptographic Operation (Key Encryption)
 
-!FCS_COP.1/PBKDF !Cryptographic Operation (Password-Based Key Derivation Functions)
-
 !FCS_COP.1/SKC !Cryptographic Operation (Symmetric Key Cryptography)
 
 !FDP_ACC.1 !Subset Access Control
@@ -653,6 +653,8 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 !FCS_CKM.1/KEK !Cryptographic Key Generation Key Encryption Key (KEK)
 
 !FCS_CKM_EXT.5 !Cryptographic Key Derivation
+
+!FCS_CKM_EXT.8 !Password-Based Cryptographic Key Derivation
 
 !FCS_COP.1/Hash !Cryptographic Operation (Hashing)
 
@@ -749,6 +751,8 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 !FIA_AFL_EXT.1 !Authorization Failure Handling
 
 !FIA_SOS.2 !TSF Generation of Secrets
+
+!FIA_TRT_EXT.1 !Authorization Throttling
 
 !FIA_UAU.2 !User Authentication before any Action
 
@@ -1717,6 +1721,14 @@ FIA_SOS.2.2:: The TSF shall be able to enforce the use of TSF generated *authori
 
 _Application Note {counter:remark_count}_:: _This SFR expects the TSF must generate authorization data from a sufficiently large key space to ensure that users cannot employ random guessing as a statistically plausible method of authorizing actions within the TOE, both for a single event and over a session._
 
+==== FIA_TRT_EXT.1 Authorization Throttling
+
+FIA_TRT_EXT.1 Authorization Throttling
+
+FIA_TRT_EXT.1.1:: The TSF shall limit the number of authorization attempts to no more than 10 attempts per 500 milliseconds.
+
+_Application Note {counter:remark_count}_:: _The authorization throttling applies to every authorization mechanism. The attempts may be counted according to FIA_AFL_EXT.1.1 per each counter that is available. The developer can implement the timing of the delays in the requirements using unequal or equal timing of delays. The minimum delay specified in this requirement provides defense against brute forcing._
+
 ==== FIA_UAU.2 User Authentication before Any Action
 
 FIA_UAU.2 User Authentication before Any Action
@@ -2120,7 +2132,7 @@ The following rationale provides justification for each security objective for t
 |Addressed by
 |Rationale
 
-.4+|O.AUTH_FAILURES 
+.5+|O.AUTH_FAILURES 
 |FIA_AFL_EXT.1 
 |This requirement enforces authentication failure handling capabilities to ensure that brute force attacks on the TSF are not possible.
 
@@ -2130,7 +2142,10 @@ The following rationale provides justification for each security objective for t
 |FPT_STM.1 
 |This requirement provides reliable system time services that may be used to determine when excessive authentication failure attempts have been made.
 
-| FIA_AFL_EXT.2 (selection-based)
+|FIA_TRT_EXT.1
+|This requirement provides a limit to the number of attempts within a time period to prevent hammering attacks.
+
+|FIA_AFL_EXT.2 (selection-based)
 |This requirement defines how access to an SDO is restored if excessive authentication failures trigger a lock on it.
 
 .10+|O.AUTHORIZATION 
@@ -2385,7 +2400,7 @@ The following rationale provides justification for each security objective for t
 |This requirement ensures the use of strong mechanism to perform key derivation.
 
 .4+|O.STRONG_CRYPTO 
-|FCS_COP.1/PBKDF (selection-based)
+|FCS_CKM_EXT.8 (selection-based)
 |This requirement ensures the use of strong methods to derive keys from password data.
 
 |FTP_CCMP_EXT.1 (selection-based)
@@ -2666,9 +2681,9 @@ FCS_CKM.1.1/SK:: The TSF shall generate *symmetric* cryptographic keys *[.underl
 
 |PBK 
 |[.underline]#[selection: submask, authentication token, authorization value]# 
-|Derived from a Password Based Key Derivation Function as specified in FCS_COP.1/PBKDF 
-|[.underline]#[selection: key sizes as specified in FCS_COP.1/PBKDF]#
-|[.underline]#[selection: standards as specified in FCS_COP.1/PBKDF]#
+|Derived from a Password Based Key Derivation Function as specified in FCS_CKM_EXT.8 
+|[.underline]#[selection: key sizes as specified in FCS_CKM_EXT.8]#
+|[.underline]#[selection: standards as specified in FCS_CKM_EXT.8]#
 
 |===
 
@@ -2680,7 +2695,7 @@ _The ST author selects at least one algorithm from the RSK row if the ST support
 +
 _If [.underline]#DSK# is selected, the selection-based SFR FCS_CKM_EXT.5 must be claimed by the TOE._
 +
-_If [.underline]#PBK# is selected, the selection-based SFR FCS_COP.1/PBKDF must be claimed by the TOE._
+_If [.underline]#PBK# is selected, the selection-based SFR FCS_CKM_EXT.8 must be claimed by the TOE._
 +
 _This requirement must be claimed by the TOE if at least one of FCS_CKM.1 or FCS_CKM.1/KEK chooses a selection related to generation of symmetric keys._
 
@@ -2796,21 +2811,19 @@ _SP 800-56C specifies a two-step key derivation procedure that employs an extrac
 +
 _This requirement must be claimed by the TOE if at least one of FCS_CKM.1/KEK, FCS_CKM.1/SK, or FCS_COP.1/KeyEnc chooses a selection related to key derivation._
 +
-_If at least one of [.underline]#KeyDrv4#, [.underline]#KeyDrv5#, or [.underline]#KeyDrv6#  is selected AND password-based key derivation is used to create at least one of the inputs, the selection-based SFR FCS_COP.1/PBKDF must also be claimed._
+_If at least one of [.underline]#KeyDrv4#, [.underline]#KeyDrv5#, or [.underline]#KeyDrv6#  is selected AND password-based key derivation is used to create at least one of the inputs, the selection-based SFR FCS_CKM_EXT.8 must also be claimed._
 
-==== FCS_COP.1/PBKDF Cryptographic Operation (Password-Based Key Derivation Functions)
+==== FCS_CKM_EXT.8 Password-Based Cryptographic Key Derivation
 
-FCS_COP.1/PBKDF Cryptographic Operation (Password-Based Key Derivation Functions)
+FCS_CKM_EXT.8 Password-Based Cryptographic Key Derivation
 
-FCS_COP.1.1/PBKDF:: The TSF shall perform [_password-based key derivation functions_] in accordance with a specified cryptographic algorithm [_HMAC-[selection: SHA-256, SHA-384, SHA-512]_ ], *with [selection: _[assignment: integer number greater than or equal to 1000 iterations], at least 1 iteration followed by a function equivalent to the workload of at least 1000 iterations_], and output* cryptographic key sizes [selection: 128, 192, 256] bits that meet the following standard: [_NIST SP 800-132_].
+FCS_CKM_EXT.8.1:: The TSF shall perform password-based key derivation functions in accordance with a specified cryptographic algorithm &#91; HMAC-[.underline]#[selection: SHA-256, SHA-384, SHA-512#]], with iteration count of [_assignment: number of iterations_] using a randomly generated salt of length [_assignment: length of salt_] and output cryptographic key sizes [.underline]#[selection: 128, 192, 256#] bits that meet the following standard: [_NIST SP 800-132_].
 
 _Application Note {counter:remark_count}_:: _The TSF must condition a password into a string of bits prior to using it as input to algorithms that form SKs and KEKs. The TSF can perform conditioning using one of the identified hash functions or the process described in NIST SP 800-132; the ST author selects the method used. NIST SP 800-132 requires the use of a pseudo-random function (PRF) consisting of HMAC with an approved hash function._
 +
 _Appendix A of NIST SP 800-132 recommends setting the iteration count in order to increase the computation needed to derive a key from a password and, therefore, increase the workload of performing a dictionary attack._
 +
 _The TOE must claim this requirement if it claims FCS_CKM.1/SK and selects an algorithm in the PBK row or claims FCS_CKM_EXT.5 and selects at least one of [.underline]#KeyDrv4#, [.underline]#KeyDrv5#, or [.underline]#KeyDrv6# AND uses password-based key derivation to create at least one of the inputs._
-+
-_If less than 1000 PBKDF iterations are used, the ST must specify the workload equivalence to at least 1000 PBKDF iterations._
 
 === User Data Protection
 ==== FDP_DAU.1/Prove Basic Data Authentication (for Use with The Prove Service)
@@ -3054,28 +3067,31 @@ This family defines requirements for key life cycle operations.
 [#img-FCS_CKM_EXT] 
 [ditaa,"FCS_CKM_EXT"]
 ....
-                                                     
-                                                    
                                                        +---+
-    +--------------------------------------------+  |->| 4 |
+                                                    +->| 4 |
+                                                    |  +---+
+    +--------------------------------------------+  |
     |                                            |  |  +---+
-    | FCS_CKM_EXT Cryptographic Key Management   +--+
+    | FCS_STG_EXT Cryptographic Key Management   +--+->| 5 |
     |                                            |  |  +---+
-    +--------------------------------------------+  |->| 5 |
+    +--------------------------------------------+  |
+                                                    |  +---+
+                                                    +->| 8 |
                                                        +---+
-                                                    
-                                                    
+                                                
 ....
 
 FCS_CKM_EXT.4 Cryptographic Key and Key Material Destruction Timing, requires the TSF to destroy keys when no longer used.
 
 FCS_CKM_EXT.5 Cryptographic Key Derivation, requires the TSF to perform key derivation using a defined method.
 
-*Management: FCS_CKM_EXT.4, FCS_CKM_EXT.5*
+FCS_CKM_EXT.8 Password-Based Cryptographic Key Derication, requires the TSF to perform key derivation using a defined method.
+
+*Management: FCS_CKM_EXT.4, FCS_CKM_EXT.5, FCS_CKM_EXT.8*
 
 No specific management functions are identified.
 
-*Audit: FCS_CKM_EXT.4, FCS_CKM_EXT.5*
+*Audit: FCS_CKM_EXT.4, FCS_CKM_EXT.5, FCS_CKM_EXT.8*
 
 There are no auditable events foreseen.
 
@@ -3097,6 +3113,17 @@ FDP_SDC_EXT.1 Confidentiality of SDEs
 
 [vertical]
 FCS_CKM_EXT.5.1:: The TSF shall generate cryptographic keys with[_assignment: key types_] using [_assignment: input parameters_], key derivation algorithm [_assignment: key derivation algorithms_], and specified cryptographic key sizes [_assignment: key sizes_] that meet the following: [_assignment: list of standards_].
+
+*FCS_CKM_EXT.8 Cryptographic Key Derivation*
+[horizontal]
+Hierarchical to:: No other components.
+
+Dependencies:: FCS_CKM.1 Cryptographic Key Generation +
+FCS_COP.1 Cryptographic Operation +
+FDP_SDC_EXT.1 Confidentiality of SDEs
+
+[vertical]
+FCS_CKM_EXT.8.1:: The TSF shall perform password-based key derivation functions in accordance with a specified cryptographic algorithm &#91; HMAC-[.underline]#[selection: SHA-256, SHA-384, SHA-512#]], with iteration count of [_assignment: number of iterations_] using a randomly generated salt of length [_assignment: length of salt_] and output cryptographic key sizes [.underline]#[selection: 128, 192, 256#] bits that meet the following standard: [_NIST SP 800-132_].
 
 ==== FCS_ENT_EXT Entropy for External IT Entities
 
@@ -3647,6 +3674,45 @@ Hierarchical to:: No other components.
 Dependencies:: FIA_AFL_EXT.1 Authorization Failure Handling
 [vertical]
 FIA_AFL_EXT.2.1:: When the TSF locks an object (i.e. prevents authorization attempts for an object) due to a user exceeding the allowed threshold for unsuccessful authorization attempts, then only an administrator may unlock access to the object and reset the corresponding failed authorization attempt counter.
+
+==== FIA_TRT_EXT Authorization Throttling
+
+*Family Behavior*
+
+This family defines requirements for the TOE's behavior related to repeated authorization attempts within a limited time.
+
+*Component Leveling*
+
+[#img-FIA_TRT_EXT] 
+[ditaa,"FIA_TRT_EXT"]
+....
+
+    +--------------------------------------------+ 
+    |                                            |     +---+
+    | FIA_TRT_EXT Authorization Throttling       +---->| 1 |
+    |                                            |     +---+
+    +--------------------------------------------+ 
+....
+
+FIA_TRT_EXT.1 Authorization Throttling, requires the TSF to monitor authorization attempts and limit the number of possible attempts allowed.
+
+*Management: FIA_TRT_EXT.1*
+
+The following actions could be considered for the management functions in FMT:
+
+* None
+
+*Audit: FIA_TRT_EXT.1*
+
+There are no auditable events foreseen.
+
+*FIA_TRT_EXT.1 Authorization Throttling*
+[horizontal]
+Hierarchical to:: No other components.
+
+Dependencies:: No dependencies.
+[vertical]
+FIA_TRT_EXT.1.1:: The TSF shall limit the number of authorization attempts to no more than 10 attempts per 500 milliseconds.
 
 === Class FMT: Security Management
 ==== FMT_MOF_EXT Management of Functions in TSF
@@ -4269,6 +4335,10 @@ FMT_MSA.1
 |No dependencies. 
 |N/A
 
+|FIA_TRT_EXT.1
+|No dependencies.
+|N/A
+
 |FIA_UAU.2 
 |FIA_UID.1 
 |This dependency is not present in the PP because all of the methods used to access the TSF (physically protected channels, encrypted data buffers, or cryptographically protected data channels) all implicitly identify the subject that is attempting to authenticate to the TOE. Therefore, it is not necessary to include a separate SFR that requires subjects to be identified.
@@ -4412,7 +4482,7 @@ FCS_COP.1
 FDP_SDC_EXT.1 
 |All of FCS_CKM.1, FCS_COP.1, and FDP_SDC_EXT.1 are required by the PP.
 
-|FCS_COP.1/PBKDF 
+|FCS_CKM_EXT.8 
 |[FDP_ITC.1, FDP_ITC.2, or FCS_CKM.1] 
 
 FCS_CKM.4 


### PR DESCRIPTION
This is to resolve #124.

I have added FCS_CKM_EXT.8 according to the recommendation from @jdonndelinger

To resolve the issue about hammering I added a simplified version of FIA_TRT_EXT.1 from the PP_MDF that just specifies that a max attempts allowed of 10 per 500ms, but without any specific options for how this would be done.

I think I have all the dependencies and such properly added here. The SD update for the FIA_TRT_EXT.1 would largely be what is in the PP_MDF. We would still need the info for the new crypto SFR though as it seems likely to be different than FCS_COP.1/PBKDF (though maybe not too much).