### PR TITLE
open samples update

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -390,7 +390,7 @@ For definitions of standard CC terminology, see [CC] part 1.
 
 === Test Environment Note
 
-Many of the test EAs in this Supporting Document require the evaluator to directly exercise low-level interfaces to the DSC to manipulate it in a manner that may not be feasible with the commercially-available (production) model of the DSC and associated tools. When this is the case, the TOE developer may provide models of the DSC and associated tools which allow for the required tests to be executed. 
+Many of the test EAs in this Supporting Document require the evaluator to directly exercise low-level interfaces to the DSC to manipulate it in a manner that may not be feasible with the commercially-available (production) model of the DSC and associated tools. When this is the case, the TOE developer may provide models of the DSC and associated tools which allow for the required tests to be executed by the evaluator (or as necessary, executed by the TOE developer and observed by the evaluator). 
 
 For any tests that are executed using non-commercially-available versions of the TOE provided by the developer, the evaluator shall ensure the following:
 

--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -390,7 +390,9 @@ For definitions of standard CC terminology, see [CC] part 1.
 
 === Test Environment Note
 
-Many of the test EAs in this Supporting Document require the evaluator to directly exercise low-level interfaces to the DSC to manipulate it in a manner that may not be feasible with a commercially-available model of the DSC and associated tools. In such cases it is acceptable for the TOE developer to produce materials that allow for the required tests to be executed. As such materials may be proprietary to the vendor, it is sufficient for the evaluator to execute these tests (or observe the execution of these tests) at the TOE developer's facility. For any tests that are executed in this manner, the evaluator shall ensure the following:
+Many of the test EAs in this Supporting Document require the evaluator to directly exercise low-level interfaces to the DSC to manipulate it in a manner that may not be feasible with the commercially-available (production) model of the DSC and associated tools. When this is the case, the TOE developer may provide models of the DSC and associated tools which allow for the required tests to be executed. 
+
+For any tests that are executed using non-commercially-available versions of the TOE provided by the developer, the evaluator shall ensure the following:
 
 * The test report shall document the measures the evaluator took to gain assurance that if the TOE itself is modified to allow for certain tests to be performed, the security of the TOE is not reduced in the unmodified TOE (i.e. if the TOE is modified to use a special firmware build, this should not create a situation where the modified build enforces required security functionality that the unmodified build does not).
 * Any tools used to conduct the required testing shall produce sufficient evidence to demonstrate that the test was successful (e.g., if a tool is designed to erase a particular key, it should also attempt to perform some operation that requires the use of that key to provide evidence that the key destruction succeeded).


### PR DESCRIPTION
This is to close #43.

The text around the open samples was adjusted and now says "may" as opposed to in such cases, so this should be clear that it is not necessary at all.

I removed the sentence about the location of the testing. I think this is something the vendor, lab and scheme will need to work out for an evaluation and putting it here as a statement up front clearly causes a lot of questions about whether this is sufficient or not. Given that the iTC cannot answer the question about it being sufficient adequately for all evaluations and circumstances, I think it is best to remove that sentence and just be clear about the purposes of this test environment, which is really about the samples being used, and should not be about where they are located.

The point about whether all devices need to be tested is handled in Appendix B, and so does not need to be noted here. A note about looking there could be added, but I do not think this is relevant for consideration under the topic here (bringing that in only confuses the reader, like the location does).

Lastly, I checked several other iTC SDs and do not see anything in them about that the scheme can accept or not. I think this is just expected based on endorsements and general use as to what a scheme will accept, I do not thing we should call it out here.