### PR TITLE
Consolidate FCS_CKM.1

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -441,17 +441,17 @@ The evaluator shall confirm that the KMD describes:
 
 If the TOE uses the generated key in a key chain/hierarchy then the KMD shall describe how the key is used as part of the key chain/hierarchy. 
 
-===== FCS_CKM.1/KEK Cryptographic Key Generation (Key Encryption Key)
+===== FCS_CKM.1 Cryptographic Key Generation
 
 ====== TSS
 
-The evaluator shall examine the key hierarchy section of the TSS to ensure that the formation of all KEKs is described and that the key sizes match that described by the ST author. The evaluator shall examine the key hierarchy section of the TSS to ensure that each KEK encrypts keys of equal or lesser security strength using one of the selected methods.
+The evaluator shall examine the TSS to determine whether it describes any supported key generation or derivation functionality consistent with the claims made in FCS_CKM.1.1.
 
-[conditional] If the KEK is generated according to an asymmetric key scheme, the evaluator shall review the TSS to determine that it describes how the functionality described by FCS_CKM.1/AK is invoked. The evaluator uses the description of the key generation functionality in FCS_CKM.1/AK or documentation available for the operational environment to determine that the key strength being requested is greater than or equal to 112 bits.
+[conditional] If the key is generated according to an asymmetric key scheme, the evaluator shall review the TSS to determine that it describes how the functionality described by FCS_CKM.1/AKG is invoked. The evaluator uses the description of the key generation functionality in FCS_CKM.1/AKG or documentation available for the operational environment to determine that the key strength being requested is greater than or equal to 112 bits.
 
-[conditional] If the KEK is generated according to a symmetric key scheme, the evaluator shall review the TSS to determine that it describes how the functionality described by FCS_CKM.1/SK is invoked. The evaluator uses the description of the RBG functionality in FCS_RBG_EXT.1, or the key derivation functionality in either FCS_CKM_EXT.5 or FCS_COP.1/PBKDF, depending on the key generation method claimed, to determine that the key size being requested is greater than or equal to the key size and mode to be used for the encryption/decryption of the data.
+[conditional] If the key is generated according to a symmetric key scheme, the evaluator shall review the TSS to determine that it describes how the functionality described by FCS_CKM.1/SKG is invoked. The evaluator uses the description of the RBG functionality in FCS_RBG_EXT.1, or the key derivation functionality in either FCS_CKM.5 or FCS_COP.1/PBKDF, depending on the key generation method claimed, to determine that the key size being requested is greater than or equal to the key size and mode to be used for the encryption/decryption of the data.
 
-[conditional] If the KEK is formed from derivation, the evaluator shall verify that the TSS describes the method of derivation and that this method is consistent with FCS_CKM_EXT.5.
+[conditional] If the key is formed from derivation, the evaluator shall verify that the TSS describes the method of derivation and that this method is consistent with FCS_CKM.5.
 
 ====== AGD
 
@@ -2048,7 +2048,7 @@ There are no AGD evaluation activities for this component.
 
 *_Root of Trust for Storage_*
 
-The evaluator shall confirm a successful evaluation of FCS_CKM.1/KEK, FCS_STG_EXT.1, FCS_STG_EXT.2, FCS_STG_EXT.3, FPT_PHP.3.
+The evaluator shall confirm a successful evaluation of FCS_CKM.1, FCS_STG_EXT.1, FCS_STG_EXT.2, FCS_STG_EXT.3, FPT_PHP.3.
 
 *_Root of Trust for Authorization_*
 
@@ -2078,7 +2078,7 @@ There are no AGD evaluation activities for this component.
 
 ====== Test
 
-Testing for this component is completed through evaluation of FCS_CKM.1/KEK, FCS_STG_EXT.1, FCS_STG_EXT.2, FCS_STG_EXT.3, and FPT_PHP.3.
+Testing for this component is completed through evaluation of FCS_CKM.1, FCS_STG_EXT.1, FCS_STG_EXT.2, FCS_STG_EXT.3, and FPT_PHP.3.
 
 ====== KMD
 
@@ -3059,10 +3059,10 @@ However, if the evaluator is unable to perform some other required EA because th
 |DSC SFR
 
 |Asymmetric-Key Generation 
-|[FCS_CKM.1/AK]
+|[FCS_CKM.1/AKG]
 
 |Symmetric-Key Generation 
-|[FCS_CKM.1/SK]
+|[FCS_CKM.1/SKG]
 
 |Private-Key Cryptography 
 |FCS_CKM.2
@@ -3073,8 +3073,8 @@ However, if the evaluator is unable to perform some other required EA because th
 |Symmetric-Key Cryptography 
 |FCS_COP.1/SKC, [FTP_CCMP_EXT.1, FTP_GCMP_EXT.1]
 
-|KEK Creation 
-|FCS_CKM.1/KEK
+|Key Creation 
+|FCS_CKM.1
 
 |Random-Bit Generation 
 |FCS_RBG_EXT.1, [FCS_ENT_EXT.1]

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -648,8 +648,6 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_CKM.1/AKG !Cryptographic key generation - Asymmetric Key
 
-!FCS_CKM.1/KEK !Cryptographic Key Generation Key Encryption Key (KEK)
-
 !FCS_CKM.5 !Cryptographic Key Derivation
 
 !FCS_COP.1/Hash !Cryptographic Operation (Hashing)
@@ -987,19 +985,7 @@ Extended SFRs (i.e. those SFRs that are not defined in [CC2]) are identified by 
 
 FCS_CKM.1 Cryptographic Key Generation
 
-FCS_CKM.1.1:: The TSF shall generate cryptographic keys by {empty}[_parsing in accordance with FDP_ITC_EXT.1 and FDP_ITC_EXT.2,_ [.underline]#[_selection: asymmetric key generation in accordance with FCS_CKM.1/AKG, symmetric key generation in accordance to FCS_CKM.1/SKG, no other methods_#]] [.line-through]#in accordance with a specified cryptographic key generation algorithm [assignment: _cryptographic key generation algorithm_] and specified cryptographic key sizes [assignment: _cryptographic key sizes_] that meet the following: [assignment: _list of standards_#]. 
-
-_Application Note {counter:remark_count}_:: _Parsing of keys can refer to both the act of importing keys from outside the TOE boundary and to the act of issuing commands or parameters to the TOE that trigger the TSF to perform a key generation function._
-+
-_If asymmetric key generation in accordance with FCS_CKM.1/AKG is selected, the selection-based SFR FCS_CKM.1/AKG must be claimed by the TOE._
-+
-_If symmetric key generation in accordance with FCS_CKM.1/SKG is selected, the selection-based SFR FCS_CKM.1/SKG must be claimed by the TOE._
-
-==== FCS_CKM.1/KEK Cryptographic Key Generation (Key Encryption Key)
-
-FCS_CKM.1/KEK Cryptographic Key Generation (Key Encryption Key)
-
-FCS_CKM.1.1/KEK:: The TSF shall generate *key encryption keys* in accordance with a specified cryptographic key generation algorithm *corresponding to [.underline]#[selection:*#
+FCS_CKM.1.1:: The TSF shall generate cryptographic keys in accordance with a specified cryptographic key generation algorithm *corresponding to [.underline]#[selection:*#
 +
 * [.underline]#*Asymmetric KEKs generated in accordance with FCS_CKM.1/AKG identifier AK1,*#
 * [.underline]#*Symmetric KEKs generated in accordance with FCS_CKM.1/SKG,*#
@@ -1007,7 +993,7 @@ FCS_CKM.1.1/KEK:: The TSF shall generate *key encryption keys* in accordance wit
 +
 ] [.line-through]#and specified cryptographic key sizes [_assignment: cryptographic key sizes_] that meet the following: [_assignment: list of standards_]#.
 
-_Application Note {counter:remark_count}_:: _KEKs protect KEKs and Symmetric Keys (SKs). DSCs should use key strengths commensurate with protecting the chosen symmetric encryption key strengths._
+_Application Note {counter:remark_count}_:: _Cryptographic keys can include KEKs that protect keys as well as the keys used to protect SDEs and SDOs. DSCs should use key strengths commensurate with protecting the chosen symmetric encryption key strengths._
 +
 _If [.underline]#Asymmetric KEKs generated in accordance with FCS_CKM.1/AKG# is selected, the selection-based SFR FCS_CKM.1/AKG must be claimed by the TOE._
 +
@@ -2675,9 +2661,6 @@ The following rationale provides justification for each security objective for t
 .10+|O.STRONG_CRYPTO 
 |FCS_CKM.1 
 |This requirement specifies the supported methods of key generation.
-
-|FCS_CKM.1/KEK 
-|This requirement ensures the generation of strong key encryption keys.
 
 |FCS_CKM_EXT.7 
 |This requirement ensures the use of strong key agreement mechanisms.
@@ -4487,9 +4470,6 @@ The dependencies between SFRs implemented by the TOE are addressed as follows.
 
 FCS_CKM.6 
 |All of FCS_CKM_EXT.7, FCS_CKM.6, and FCS_COP.1 are required by the PP.
-
-|FCS_CKM.1/KEK 
-|[FCS_CKM_EXT.7 or FCS_COP.1] 
 
 FCS_CKM.6 
 |All of FCS_CKM_EXT.7, FCS_CKM.6, and FCS_COP.1 are required by the PP.

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -987,19 +987,19 @@ FCS_CKM.1 Cryptographic Key Generation
 
 FCS_CKM.1.1:: The TSF shall generate cryptographic keys in accordance with a specified cryptographic key generation algorithm *corresponding to [.underline]#[selection:*#
 +
-* [.underline]#*Asymmetric KEKs generated in accordance with FCS_CKM.1/AKG identifier AK1,*#
-* [.underline]#*Symmetric KEKs generated in accordance with FCS_CKM.1/SKG,*#
-* [.underline]#*Derived KEKs generated in accordance with FCS_CKM.5*#
+* [.underline]#*Asymmetric keys generated in accordance with FCS_CKM.1/AKG identifier AK1,*#
+* [.underline]#*Symmetric keys generated in accordance with FCS_CKM.1/SKG,*#
+* [.underline]#*Derived keys generated in accordance with FCS_CKM.5*#
 +
 ] [.line-through]#and specified cryptographic key sizes [_assignment: cryptographic key sizes_] that meet the following: [_assignment: list of standards_]#.
 
 _Application Note {counter:remark_count}_:: _Cryptographic keys can include KEKs that protect keys as well as the keys used to protect SDEs and SDOs. DSCs should use key strengths commensurate with protecting the chosen symmetric encryption key strengths._
 +
-_If [.underline]#Asymmetric KEKs generated in accordance with FCS_CKM.1/AKG# is selected, the selection-based SFR FCS_CKM.1/AKG must be claimed by the TOE._
+_If [.underline]#Asymmetric keys generated in accordance with FCS_CKM.1/AKG# is selected, the selection-based SFR FCS_CKM.1/AKG must be claimed by the TOE._
 +
-_If [.underline]#Symmetric KEKs generated in accordance with FCS_CKM.1/SKG# is selected, the selection-based SFR FCS_CKM.1/SKG must be claimed by the TOE._
+_If [.underline]#Symmetric keys generated in accordance with FCS_CKM.1/SKG# is selected, the selection-based SFR FCS_CKM.1/SKG must be claimed by the TOE._
 +
-_If [.underline]#Derived KEKs generated in accordance with FCS_CKM.5# is selected, the selection-based SFR FCS_CKM.5 must be claimed by the TOE._
+_If [.underline]#Derived keys generated in accordance with FCS_CKM.5# is selected, the selection-based SFR FCS_CKM.5 must be claimed by the TOE._
 
 ==== FCS_CKM.2 Cryptographic Key Distribution
 


### PR DESCRIPTION
This removes FCS_CKM.1/KEK, but uses that SFR as the FCS_CKM.1 SFR (with appropriate changes).