### PR TITLE
adding "OS" to DSC description

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -115,7 +115,7 @@ PP Date: {revdate}
 
 === TOE Overview
 
-The Target of Evaluation (TOE) is a Dedicated Security Component (DSC). In the context of this cPP, a DSC is the combination of a hardware component and its controlling firmware. The firmware should be dedicated to providing the encompassing platform with services for the provisioning, protection, and use of Security Data Objects (SDOs), which include keys, identities, attributes, and other types of Security Data Elements (SDEs). See <<RepofTOE>> for an example of a TOE representation.
+The Target of Evaluation (TOE) is a Dedicated Security Component (DSC). In the context of this cPP, a DSC is the combination of a hardware component and its controlling OS or firmware. The firmware should be dedicated to providing the encompassing platform with services for the provisioning, protection, and use of Security Data Objects (SDOs), which include keys, identities, attributes, and other types of Security Data Elements (SDEs). See <<RepofTOE>> for an example of a TOE representation.
 
 .Representation of the Target of Evaluation (TOE)
 [[RepofTOE]]


### PR DESCRIPTION
This is to close #4. This adds "OS or" to match with the description of the SD. I think this is needed since some DSCs may encompass some sort of OS (like a TEE) that is more than just firmware. This may be a meaningless distinction and OS could be as easily removed from the SD, but when I think firmware I don't tend to think of larger systems like a TEE but smaller ones like on an eSE.