### PR TITLE
fmt_smf.1 edit

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -2202,7 +2202,8 @@ FMT_SMF.1.1:: The TSF shall be capable of performing the following management fu
 +
 _[.underline]#[selection:#_
 +
-** _[.underline]#update TOE firmware and pre-installed SDOs,#_
+** _[.underline]#update TOE firmware,#_
+** _[.underline]#update pre-installed SDOs,#_
 ** _[.underline]#unlock access to SDO following excessive failed authorization attempts,#_
 ** _[.underline]#no other functions]#_].
 


### PR DESCRIPTION
On reading the requirements and comments it seemed that it may be that pre-installed SDOs may not be able to be changed by updates, and splitting it into two separate selections would provide better granularity.