### PR TITLE
fpt_rot_ext.1 update

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -2276,7 +2276,7 @@ _A unique identifiable owner is assumed to be one with an administrative role; h
 
 FPT_ROT_EXT.1 Root of Trust Services
 
-FPT_ROT_EXT.1.1:: The TSF shall provide a Root of Trust for Storage, a Root of Trust for Authorization, and [.underline]#[selection: Root of Trust for Measurement, Root of Trust for Reporting, no others]#.
+FPT_ROT_EXT.1.1:: The TSF shall provide a Root of Trust for Storage, a Root of Trust for Authorization, and [.underline]#[selection: Root of Trust for Measurement, Root of Trust for Reporting, no others]# based on the Root of Trust identified in FPT_PRO_EXT.1.1.
 
 _Application Note {counter:remark_count}_:: _This document uses the [GP_ROT] definitions for RoT for Storage (denoted as the combination of RoT for Confidentiality and RoT for Integrity), Authorization, Measurement, and Reporting. DSCs use Roots of Trust for Storage to protect SDOs. Section 6.5 has a number of requirements for ensuring the TSF has functionality to authorize a user in order to access an SDO, including FIA_UAU.6._
 +


### PR DESCRIPTION
This is to close #200 by clarifying that only the RoT identified in the other SFR can be used here.