### PR TITLE
remove table numbers from SFRs

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1662,6 +1662,7 @@ FMT_MOF_EXT.1 Management of Security Functions Behavior
 FMT_MOF_EXT.1.1:: The TSF shall restrict the ability to perform the functions in FMT_SMF.1 to authenticated administrators.
 
 ==== FMT_MSA.1 Management of Security Attributes
+:xrefstyle: basic
 
 FMT_MSA.1 Management of Security Attributes
 


### PR DESCRIPTION
This is to simply remove table numbers from SFRs. It appears only 2 FMT ones still had it (I think the rest had been replaced with the FCS changes).

This is to close #220