### PR TITLE
Clean up wording in FDP_ACC.1

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -1263,7 +1263,7 @@ There are no KMD evaluation activities for this component.
 
 ====== TSS
 
-The evaluator shall confirm that the TSS contain the access control policy implemented by the TOE. I.e., the ST author lists each object and identifies for each object, which operations the TSF permits for each subject (i.e. what can "admins" do vs "users").
+The evaluator shall confirm that the TSS contains the access control policy implemented by the TOE. In other words, the ST shall list each object and identify for each object, which operations the TSF permits for each subject (i.e. what can "admins" do vs "users").
 
 ====== AGD
 
@@ -1271,7 +1271,7 @@ There are no guidance evaluation activities for this component.
 
 ====== Test
 
-Testing for FDP_ACF includes testing this component.
+This component is tested as part of FDP_ACF.1.
 
 ====== KMD
 


### PR DESCRIPTION
I feel like "Testing for FDP_ACF includes testing this component" is slightly ambiguous and might give the impression that the test procedure for FDP_ACC.1 is described there. I think the updated text better reflects the intent.