### PR TITLE
Update FDP_ETC_EXT.2

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -1325,7 +1325,7 @@ There are no KMD evaluation activities for this component.
 
 ====== TSS
 
-The evaluator shall examine the TSS to ensure that it describes how it protects the SDO references, authorization data, against access from unauthorized entities. If [.underline]#the TSF# is selected, then it should describe how it provides confidentiality of the data while it resides outside the TOE. 
+The evaluator shall examine the TSS to ensure that it describes how it protects the SDO references, authorization data, against access from unauthorized entities. In particular, it should describe how it provides confidentiality of the data while it resides outside the TOE after export.
 
 ====== AGD
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1473,9 +1473,9 @@ _The DSC may contain pre-installed SDOs. The DSC will enforce access control for
 
 FDP_ETC_EXT.2 Propagation of SDOs
 
-FDP_ETC_EXT.2.1:: The TSF shall propagate only SDO references, wrapped authorization data, and wrapped SDOs such that only [.underline]#[selection: the TSF, authorized users]# can access them.
+FDP_ETC_EXT.2.1:: The TSF shall propagate only SDO references, wrapped authorization data, and wrapped SDOs such that only [.underline]#[selection: the TOE, authorized users]# can access them.
 
-_Application Note {counter:remark_count}_:: _The "SDO reference" is a pointer to an object that resides in the TOE; this can be thought of as a token to the object. The "only the TSF can unwrap the data" selection refers to data that is stored outside the TOE boundary (i.e., data that has been propagated)._
+_Application Note {counter:remark_count}_:: _This SFR imposes security requirements on data being propagated (exported) outside the TOE. The "SDO reference" is a pointer to an object that resides in the TOE; this can be thought of as a token to the object. The "users" in the "authorized users" selection includes all roles (i.e. ADM-R, MFGADM-R, CApp-R)._
 
 ==== FDP_FRS_EXT.1 Factory Reset
 
@@ -3419,7 +3419,7 @@ Hierarchical to:: No other components.
 
 Dependencies:: FCS_COP.1 Cryptographic Operation
 [vertical]
-FDP_ETC_EXT.2.1:: The TSF shall propagate only SDO references, wrapped authorization data, and wrapped SDOs such that only [.underline]#[selection: the TSF, authorized users]# can access them.
+FDP_ETC_EXT.2.1:: The TSF shall propagate only SDO references, wrapped authorization data, and wrapped SDOs such that only [.underline]#[selection: the TOE, authorized users]# can access them.
 
 ==== FDP_FRS_EXT Factory Reset
 


### PR DESCRIPTION
The current wording of this EA is very puzzling to me. According to Section 1.3.1 in the SD, TSF is defined as: "A set consisting of all hardware, software, and firmware of the TOE that must be relied upon for the correct enforcement of the SFRs. [CC1]"

That seems to imply to me that the TSF is part of the TOE boundary, so why is the EA talking about "data while it resides outside the TOE"? Perhaps I'm just mistaken about my interpretation of TSF.