### PR TITLE
Dependencies changes for non-FCS_ SFRs

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -4194,12 +4194,6 @@ FCS_CKM.6
 FCS_CKM.6 
 |FCS_CKM.1 and FCS_CKM.6 are required by the PP. FDP_ITC_EXT.1 and FDP_ITC_EXT.2 are also required by the PP and equivalent to FDP_ITC.1 in this case because they all relate to a mechanism by which key data can be imported into the TSF.
 
-|FCS_COP.1/KAT 
-|[FDP_ITC.1, FDP_ITC.2, or FCS_CKM.1] 
-
-FCS_CKM.6 
-|FCS_CKM.1 and FCS_CKM.6 are required by the PP. FDP_ITC_EXT.1 and FDP_ITC_EXT.2 are also required by the PP and equivalent to FDP_ITC.1 in this case because they all relate to a mechanism by which key data can be imported into the TSF.
-
 |FCS_COP.1/KeyWrap
 |[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, or FCS_CKM.5, FCS_CKM_EXT.7, or FCS_CKM_EXT.8]
 
@@ -4243,8 +4237,8 @@ FCS_CKM.6
 |FDP_ACF.1 
 |FDP_ACC.1 
 
-FMT_MSA.1 
-|FDP_ACC.1 and FMT_MSA.1 are required by the PP.
+FMT_MSA.3
+|FDP_ACC.1 and FMT_MSA.3 are required by the PP.
 
 |FDP_ETC_EXT.2 
 |FCS_COP.1 
@@ -4266,19 +4260,13 @@ FMT_MSA.1
 [FTP_ITC_EXT.1, FTP_ITE_EXT.1, or FTP_ITP_EXT.1] 
 |FCS_COP.1 is required by the PP. FTP_ITC_EXT.1, FTP_ITE_EXT.1, and FTP_ITP_EXT.1 are each selection-based SFRs in the PP but the PP's definition of FDP_ITC_EXT.1 requires at least one of them to be selected so the dependency is always addressed.
 
-|FPT_MFW_EXT.1 
-|No dependencies. 
-|N/A
-
 |FDP_RIP.1 
 |No dependencies. 
 |N/A
 
 |FDP_SDC.2 
-|FCS_COP.1 or FPT_PHP.3
+|FCS_COP.1
 |FCS_COP.1 is required by this PP.
-
-When Protected storage is used for storing SDEs and SDOs, FPT_PHP.3 provides equivalent protection by ensuring data storage is tamper resistant instead of cryptogrpahic storage.
 
 |FDP_SDI.2 
 |No dependencies. 
@@ -4334,6 +4322,10 @@ FMT_SMR.1
 |No dependencies. 
 |N/A
 
+|FPT_MFW_EXT.1
+|No dependencies.
+|N/A
+
 |FPT_MOD_EXT.1 
 |No dependencies. 
 |N/A
@@ -4355,10 +4347,6 @@ FMT_SMR.1
 |FPT_PRO_EXT.1 is required by this PP.
 
 |FPT_RPL.1/Authorization
-|No dependencies. 
-|N/A
-
-|FPT_STM_EXT.1 
 |No dependencies. 
 |N/A
 
@@ -4465,6 +4453,14 @@ FCS_CKM.6
 |FDP_FRS_EXT.1 
 |FDP_FRS_EXT.1 is required by the PP.
 
+|FIA_AFL_EXT.2
+|FIA_AFL_EXT.1
+|FIA_AFL_EXT.1 is required by the PP.
+
+|FPT_FLS.1/FW
+|No dependencies.
+|N/A
+
 |FPT_MFW_EXT.2 
 |FPT_MFW_EXT.1 
 
@@ -4477,16 +4473,12 @@ FCS_COP.1
 FCS_COP.1 
 |FPT_MFW_EXT.1 and FCS_COP.1 are required by the PP.
 
-|FIA_AFL_EXT.2 
-|FIA_AFL_EXT.1 
-|FIA_AFL_EXT.1 is required by the PP.
-
-|FPT_FLS.1/FW 
+|FPT_RPL.1/Rollback 
 |No dependencies. 
 |N/A
 
-|FPT_RPL.1/Rollback 
-|No dependencies. 
+|FPT_STM_EXT.1
+|No dependencies.
 |N/A
 
 |FTP_CCMP_EXT.1 


### PR DESCRIPTION
Partially addresses #160. There's still quite a few problems with the FCS_ SFRs, but we can leave those until the Crypto WG comes back to us. The only exception is FCS_COP.1/KAT which was removed entirely so we can just remove it from the dependency table too.
Other changes:

- FDP_ACF.1 should depend on FMT_MSA.3 according to CC 3.1 and CC 2022
- FPT_MFW_EXT.1 was moved down for ordering
- FDP_SDC.2 doesn't depend on FPT_PHP.3 according to CC 2022
- FPT_STM_EXT.1 was moved to selection-based (it's not mandatory)
- FIA_AFL_EXT.2 and FPT_FLS.1/FW were moved up for ordering