### PR TITLE
Align FDP_FRS_EXT.2 SFR text with tests

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -1497,7 +1497,7 @@ Test 1: The evaluator shall use the operational guidance to configure the number
 
 Test 2: After reaching the limit for unsuccessful authorization attempts as in Test 1 above, the evaluator shall proceed as follows. If the action selected in FIA_AFL_EXT.1.3 is included in the ST then the evaluator shall confirm by testing that following the operational guidance and performing each action specified in the ST to re-enable access results in successful access. If the time period selection in FIA_AFL_EXT.1.3 is included in the ST, then the evaluator shall wait for just less than the time period configured in Test 1 and show that an authorization attempt using valid credentials does not result in successful access. The evaluator shall then wait until just after the time period configured in Test 1 and show that an authorization attempt using valid credentials results in successful access.
 
-Test 3 [conditional]: If [.underline]#factory reset the TOE wiping out all non-permanent SDOs, as described by FDP_FRS_EXT.2# is selected in FIA_AFL_EXT.1.3, the evaluator shall perform the test required by FDP_FRS_EXT.2 with step 5 replaced with "The evaluator shall initiate a factory reset by deliberately meeting or surpassing the threshold for unsuccessful authorization attempts, depending on whether [.underline]#meets# or [.underline]#surpasses# is selected in FIA_AFL_EXT.1.3."
+Test 3 [conditional]: If [.underline]#factory reset the TOE wiping out all non-permanent SDEs and SDOs, as described by FDP_FRS_EXT.2# is selected in FIA_AFL_EXT.1.3, the evaluator shall perform the test required by FDP_FRS_EXT.2 with step 5 replaced with "The evaluator shall initiate a factory reset by deliberately meeting or surpassing the threshold for unsuccessful authorization attempts, depending on whether [.underline]#meets# or [.underline]#surpasses# is selected in FIA_AFL_EXT.1.3."
 
 ====== KMD
 
@@ -2641,7 +2641,7 @@ There are no KMD evaluation activities for this component.
 
 ====== TSS
 
-The evaluator shall examine the TSS to determine the pre-installed SDOs that are reverted to their factory settings when a factory reset occurs, what the factory settings are for those SDOs, and that the TSS states that all non-permanent SDOs are destroyed.
+The evaluator shall examine the TSS to determine the pre-installed SDOs that are reverted to their factory settings when a factory reset occurs, what the factory settings are for those SDOs, and that the TSS states that all non-permanent SDEs and SDOs are destroyed.
 
 ====== AGD
 
@@ -2653,10 +2653,10 @@ The evaluator shall perform the following test:
 
 . The evaluator shall use each supported role to create or import an SDE or SDO that has known data. 
 . The evaluator shall then verify that the created SDE/SDO resides either within the DSC, or under the control of the DSC. 
-. The evaluator shall perform some action for each created or imported SDE/SDO in step 1 that demonstrates that the SDE/SDO has been set to the indicated value.
-. For each pre-installed SDO that is identified in FDP_FRS_EXT.2.1, the evaluator shall perform some action to verify what the current value of that SDO is.
+. The evaluator shall perform some operation for each created or imported SDE/SDO in step 1 that demonstrates that the SDE/SDO has been set to the indicated value.
+. For each pre-installed SDO that is identified in FDP_FRS_EXT.2.1, the evaluator shall perform some operation to verify what the current value of that SDO is.
 . The evaluator shall initiate a factory reset.
-. For each operation in step 3, the evaluator shall re-attempt the operation and verify that it no longer completes successfully because the SDE/SDO data has been erased.
+. For each created or imported SDE/SDO that is identified in step 3, the evaluator shall re-attempt the operation and verify that it no longer completes successfully because the SDE/SDO data has been erased.
 . For each pre-installed SDO that is identified in step 4, the evaluator shall re-attempt the operation and verify that the SDOs have been set to their factory default values.
 
 ====== KMD

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1602,7 +1602,7 @@ FIA_AFL_EXT.1.3:: When the failed authorization attempt counters [.underline]#[s
 * [.underline]#prevent future authorization attempts for a static prescribed amount of time as determined using FPT_STM_EXT.1;# 
 * [.underline]#prevent future authorization attempts for an administrator configurable amount of time as determined using FPT_STM_EXT.1;#
 * [.underline]#prevent all future authorization attempts indefinitely (i.e., lock), as described by FIA_AFL_EXT.2;#
-* [.underline]#factory reset the TOE wiping out all non-permanent SDOs, as described by FDP_FRS_EXT.2#
+* [.underline]#factory reset the TOE wiping out all non-permanent SDEs and SDOs, as described by FDP_FRS_EXT.2#
 +
 ] for these *SDOs*.
 
@@ -1616,7 +1616,7 @@ _If [.underline]#prevent all future authorization attempts indefinitely (i.e., l
 +
 _If either [.underline]#prevent future authorization attempts for a static prescribed amount of time as determined using FPT_STM_EXT.1# or [.underline]#prevent future authorization attempts for an administrator configurable amount of time as determined using FPT_STM_EXT.1# is selected, then the selection-based SFR FPT_STM_EXT.1 must be claimed._
 +
-_If [.underline]#factory reset the TOE wiping out all non-permanent SDOs, as described by FDP_FRS_EXT.2# is selected in FIA_AFL_EXT.1.3, the selection-based SFR FDP_FRS_EXT.2 must be claimed._
+_If [.underline]#factory reset the TOE wiping out all non-permanent SDEs and SDOs, as described by FDP_FRS_EXT.2# is selected in FIA_AFL_EXT.1.3, the selection-based SFR FDP_FRS_EXT.2 must be claimed._
 
 ==== FIA_SOS.2 TSF Generation of Secrets
 
@@ -2892,9 +2892,9 @@ _For data that is validity-stamped, the DSC does nothing but respond to a reques
 
 FDP_FRS_EXT.2 Factory Reset Behavior
 
-FDP_FRS_EXT.2.1:: Upon initiation of a factory reset, the TSF shall destroy [_all non-permanent SDOs_] and restore the following *pre-installed SDOs* to their factory settings: [_assignment: pre-installed SDOs to be restored during a factory reset_].
+FDP_FRS_EXT.2.1:: Upon initiation of a factory reset, the TSF shall destroy [_all non-permanent SDEs and SDOs_] and restore the following *pre-installed SDOs* to their factory settings: [_assignment: pre-installed SDOs to be restored during a factory reset_].
 
-_Application Note {counter:remark_count}_:: _Not all DSCs permit a factory reset of the TOE, or perform a factory reset in response to excessive failed authentication or authorization attempts. Those that do are expected to perform a factory reset in a manner that prevents any inadvertent disclosure of security-relevant data that was present on the DSC prior to the factory reset. For DSCs that permit factory reset functionality (as indicated by selection of [.underline]#factory reset the TOE wiping out all non-permanent SDOs, as described by FDP_FRS_EXT.2# in FIA_AFL_EXT.1.3, or by [.underline]#no actions or conditions# NOT being selected in FDP_FRS_EXT.1.1), this SFR must be included in the TOE boundary._
+_Application Note {counter:remark_count}_:: _Not all DSCs permit factory reset functionality. Those that do are expected to perform a factory reset in a manner that prevents any inadvertent disclosure of security-relevant data that was present on the DSC prior to the factory reset. For DSCs that permit factory reset functionality (as indicated by selection of [.underline]#factory reset the TOE wiping out all non-permanent SDEs and SDOs, as described by FDP_FRS_EXT.2# in FIA_AFL_EXT.1.3, or by [.underline]#no actions or conditions# NOT being selected in FDP_FRS_EXT.1.1), this SFR must be included in the TOE boundary._
 
 === Identification and Authentication
 ==== FIA_AFL_EXT.2 Authorization Failure Response


### PR DESCRIPTION
The tests for FDP_FRS_EXT.2 talk about "an SDE or SDO". However, the SFR text for FDP_FRS_EXT.2 actually only requires non-permanent SDOs to be wiped.

I believe that wiping non-permanent SDEs should also be part of the factory reset, so I added it to the cPP requirement rather than changing the SD tests.

Some other wording in the FDP_FRS_EXT.2 cPP and SD text was also slightly changed.