### PR TITLE
Fix typo in FCS_CKM_EXT.3 and update reference

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -2607,11 +2607,11 @@ _There are several reasons for granting access to keys or restricting access to 
 +
 _This SFR lists several methods for protecting the confidentiality of keys prior to authorizing their use, archival, backup, escrow, or recovery. This protection is often afforded only to the private or secret portion of cryptographic keys. Some methods offer integrity protection as well. These methods may not apply to modification of attributes especially if the attributes do not need confidentiality. These methods may not apply to destruction since a TOE can only destroy keys within its boundaries, and it is premused these keys are already in the boundary._
 +
-*_Key encapsulation* - If the STF claims key encapsulation, then it should use approved methods such as those listed in FCS_CKM.2._
+*_Key encapsulation* - If the TSF claims key encapsulation, then it should use approved methods such as those listed in FCS_CKM.2._
 +
-*_Key wrapping* - If the STF claims key wrapping, then it should use approved methods such as KW, or KWP._
+*_Key wrapping* - If the TSF claims key wrapping, then it should use approved methods such as those listed in FCS_COP.1/KeyWrap._
 +
-*_Key encryption* - If the STF claims key encryption, then it should use approved methods such as those in FCS_COP.1/SKC combined with either a hash using approved methods such as those in FCS_COP.1/Hash or a keyed hash using approved methods such as those in FCS_COP.2/KeyedHash._
+*_Key encryption* - If the TSF claims key encryption, then it should use approved methods such as those in FCS_COP.1/SKC combined with either a hash using approved methods such as those in FCS_COP.1/Hash or a keyed hash using approved methods such as those in FCS_COP.2/KeyedHash._
 
 ==== FCS_CKM.5 Cryptographic Key Derivation
 


### PR DESCRIPTION
I believe "STF" is a typo for "TSF", at least I'm not  familiar with the terminology.

Also, since the PP defines `FCS_COP.1/KeyWrap`, I think it makes sense to refer to it here.