### PR TITLE
Update for FIA_UAU.5

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -1594,15 +1594,15 @@ There are no KMD evaluation activities for this component.
 
 ====== TSS
 
-The evaluator shall examine the TSS and ensure that it describes the authentication mechanisms used to support user authentication for the Prove service as well as how each authentication mechanism provides authentication for the Prove service.
+The evaluator shall examine the TSS and ensure that it describes the authentication mechanisms used to support user authentication, including how each mechanism enforces the authentication.
 
 ====== AGD
 
-If the supported authentication mechanisms are configurable, the evaluator shall examine the operational guidance to verify that it describes how to configure the authentication mechanisms used to provide authentication for the Prove service.
+If the supported authentication mechanisms are configurable, the evaluator shall examine the operational guidance to verify that it describes how to configure the authentication mechanisms used to provide authentication.
 
 ====== Test
 
-For each supported authentication mechanism, the evaluator shall verify that valid credentials result in successful authentication and invalid credentials result in a rejected authentication attempt. If the supported authentication mechanisms are configurable, the evaluator shall follow the operational guidance to enable/disable the various mechanisms and ensure that valid credentials do not result in successful authentication if that mechanism is disabled, or that there is no interface to provide authentication credentials over an external interface when that mechanism is disabled.
+For each supported authentication mechanism, the evaluator shall verify that valid credentials result in successful authentication and invalid credentials result in a rejected authentication attempt. If the supported authentication mechanisms are configurable, the evaluator shall follow the operational guidance to enable/disable the various mechanisms and ensure that valid credentials do not result in successful authentication if that mechanism is disabled, or that there is no interface to provide authentication credentials if that mechanism is disabled.
 
 ====== KMD
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1675,7 +1675,7 @@ FIA_UAU.5 Multiple Authentication Mechanisms
 
 FIA_UAU.5.1:: The TSF shall provide [.underline]#*[selection: no mechanism, an authentication token mechanism, a cryptographic signature mechanism, [_assignment: list of authentication mechanisms_]]*# to support user authentication.
 
-FIA_UAU.5.2:: The TSF shall authenticate any user's claimed identity according to the *following rules: [.underline]#[selection: all subject users and SDO owners shall successfully authenticate themselves using one of the mechanisms listed in FIA_UAU.5.1, the Prove service shall not accept "no mechanism" as an authentication method, [_assignment: rules describing how each authentication mechanism provides authentication_]]#*.
+FIA_UAU.5.2:: The TSF shall authenticate any user's claimed identity according to the *following rule(s): [.underline]#[selection: all subject users and SDO owners shall successfully authenticate themselves using one of the mechanisms listed in FIA_UAU.5.1, the Prove service shall not accept "no mechanism" as an authentication method, [_assignment: rules describing how each authentication mechanism provides authentication_]]#*.
 
 _Application Note {counter:remark_count}_:: _This SFR describes the authentication mechanisms required for any user of any service as a precondition for providing authorization to execute the service. This includes the authentication of the owner of the SDOs of the service._
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1673,9 +1673,9 @@ _The means of validation may vary based on the type of authentication token._
 
 FIA_UAU.5 Multiple Authentication Mechanisms
 
-FIA_UAU.5.1:: The TSF shall provide [.underline]#*[selection: none, authentication token mechanism, cryptographic signature mechanism, [_assignment: list of authentication mechanisms_]]*# to support user authentication.
+FIA_UAU.5.1:: The TSF shall provide [.underline]#*[selection: no mechanism, an authentication token mechanism, a cryptographic signature mechanism, [_assignment: list of authentication mechanisms_]]*# to support user authentication.
 
-FIA_UAU.5.2:: The TSF shall authenticate any user's claimed identity according to the [.underline]#*[selection: all subject users and SDO owners shall successfully authenticate themselves using one of the mechanisms listed in FIA_UAU.5.1, the Prove service shall not accept "none" as an authentication method, [_assignment: rules describing how each authentication mechanism provides authentication_]]*#.
+FIA_UAU.5.2:: The TSF shall authenticate any user's claimed identity according to the *following rules: [.underline]#[selection: all subject users and SDO owners shall successfully authenticate themselves using one of the mechanisms listed in FIA_UAU.5.1, the Prove service shall not accept "no mechanism" as an authentication method, [_assignment: rules describing how each authentication mechanism provides authentication_]]#*.
 
 _Application Note {counter:remark_count}_:: _This SFR describes the authentication mechanisms required for any user of any service as a precondition for providing authorization to execute the service. This includes the authentication of the owner of the SDOs of the service._
 


### PR DESCRIPTION
Closes #274

In the SD:
* I'm not sure why the TSS EA only calls out the authentication mechanism used for the Prove service. This SFR seems more general to me, so the TSS should include all authentication mechanisms. Also the wording "how each authentication mechanism provides authentication" doesn't really make sense to me, so I changed it to "how each mechanism enforces the authentication".
* AGD EA: same as the TSS, why would only the Prove service be listed here?
* Test EA: "no interface to provide authentication credentials over an external interface" says the same thing twice (interface), so I just removed "over an external interface"

In the cPP:
* For FIA_UAU.5.1, change "none" to "no mechanism".
* For FIA_UAU.5.2, try to work around the awkward sentence construction from CC. I'm not sure if this will render correctly though.