### PR TITLE
Expand scope of FPT_ROT_EXT.2 and update tests

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -1916,7 +1916,7 @@ There are no AGD evaluation activities for this component.
 
 *_Root of Trust for Storage_*
 
-Testing for this component is performed through evaluation of FCS_CKM.1, FCS_STG_EXT.1 and FPT_PHP.3.
+Testing for this component is performed through evaluation of FCS_STG_EXT.1 and FPT_PHP.3.
 
 *_Root of Trust for Authorization_*
 
@@ -1938,7 +1938,7 @@ There are no KMD evaluation activities for this component.
 
 ====== TSS
 
-The evaluator shall ensure that the TSS describes how the Root of Trust for Storage prevents unauthorized access to SDOs. The evaluator shall also examine the TSS to verify that it uses approved mechanisms to protect the integrity of SDOs. 
+The evaluator shall ensure that the TSS describes how the Root of Trust for Storage prevents unauthorized access (including unauthorized disclosure and unauthorized modification) to SDOs. The evaluator shall also examine the TSS to verify that it uses approved mechanisms to protect the confidentiality of secret SDOs and to protect the integrity of secret and non-secret SDOs.
 
 ====== AGD
 
@@ -1946,7 +1946,7 @@ There are no AGD evaluation activities for this component.
 
 ====== Test
 
-Testing for this component is performed through evaluation of FCS_CKM.1, FCS_STG_EXT.1, FDP_SDI.2 and FPT_PHP.3.
+Testing for this component is performed through evaluation of FCS_STG_EXT.1, FDP_SDC.2, FDP_SDI.2 and FPT_PHP.3.
 
 ====== KMD
 

--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -1938,7 +1938,7 @@ There are no KMD evaluation activities for this component.
 
 ====== TSS
 
-The evaluator shall ensure that the TSS describes how the Root of Trust for Storage prevents unauthorized access (including unauthorized disclosure and unauthorized modification) to SDOs. The evaluator shall also examine the TSS to verify that it uses approved mechanisms to protect the confidentiality of secret SDOs and to protect the integrity of secret and non-secret SDOs.
+The evaluator shall ensure that the TSS describes how the Root of Trust for Storage prevents unauthorized access (including unauthorized disclosure and unauthorized modification) to SDOs. The evaluator shall also examine the TSS to verify that it uses approved mechanisms to protect the confidentiality of secret SDOs and to protect the integrity of SDOs.
 
 ====== AGD
 

--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -1916,7 +1916,7 @@ There are no AGD evaluation activities for this component.
 
 *_Root of Trust for Storage_*
 
-Testing for this component is performed through evaluation of FCS_STG_EXT.1 and FPT_PHP.3.
+Testing for this component is performed through evaluation of FCS_CKM.1, FCS_STG_EXT.1 and FPT_PHP.3.
 
 *_Root of Trust for Authorization_*
 
@@ -1946,7 +1946,7 @@ There are no AGD evaluation activities for this component.
 
 ====== Test
 
-Testing for this component is performed through evaluation of FCS_STG_EXT.1, FDP_SDC.2, FDP_SDI.2 and FPT_PHP.3.
+Testing for this component is performed through evaluation of FCS_CKM.1, FCS_STG_EXT.1, FDP_SDC.2, FDP_SDI.2 and FPT_PHP.3.
 
 ====== KMD
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1975,9 +1975,9 @@ _If both [.underline]#Root of Trust for Measurement# and [.underline]#Root of Tr
 
 FPT_ROT_EXT.2 Root of Trust for Storage
 
-FPT_ROT_EXT.2.1:: The TSF shall prevent unauthorized access to SDOs associated with the Root of Trust for Storage.
+FPT_ROT_EXT.2.1:: The TSF shall prevent unauthorized access to SDOs stored in the Root of Trust for Storage.
 
-_Application Note {counter:remark_count}_:: _TOEs may use shielded locations or cryptographic protections to prevent unauthorized access to SDOs. Use FDP_SDI.2 to protect the integrity of SDOs stored in the RoT for Storage._
+_Application Note {counter:remark_count}_:: _TOEs may use shielded locations or cryptographic protections to prevent unauthorized access to SDOs. Unauthorized access includes unauthorized disclosure of secret SDOs (e.g. secret keys, private keys) and unauthorized modification of both secret and non-secret SDOs (e.g. public keys, certificates). Use FDP_SDC.2 to protect the confidentiality of secret SDOs stored in the RoT for Storage. Use FDP_SDI.2 to protect the integrity of SDOs stored in the RoT for Storage._
 
 ==== FPT_RPL.1/Authorization Replay Prevention
 
@@ -3902,7 +3902,7 @@ This family defines requirements for individual Root of Trust services that the 
 
 FPT_ROT_EXT.1 Root of Trust Services, requires the TSF to identify the specific Roots of Trust it provides.
 
-FPT_ROT_EXT.2 Root of Trust for Storage, requires the TSF to prevent unauthorized access to data associated with its Root of Trust for Storage.
+FPT_ROT_EXT.2 Root of Trust for Storage, requires the TSF to prevent unauthorized access to SDOs stored in its Root of Trust for Storage.
 
 FPT_ROT_EXT.3 Root of Trust for Reporting Mechanisms, requires the TSF to implement a Root of Trust for Reporting in the specified manner.
 
@@ -3928,7 +3928,7 @@ Hierarchical to:: No other components.
 
 Dependencies:: FPT_PRO_EXT.1 Root of Trust
 [vertical]
-FPT_ROT_EXT.2.1:: The TSF shall prevent unauthorized access to SDOs associated with the Root of Trust for Storage.
+FPT_ROT_EXT.2.1:: The TSF shall prevent unauthorized access to SDOs stored in the Root of Trust for Storage.
 
 *FPT_ROT_EXT.3 Root of Trust for Reporting Mechanisms*
 [horizontal]

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1975,9 +1975,9 @@ _If both [.underline]#Root of Trust for Measurement# and [.underline]#Root of Tr
 
 FPT_ROT_EXT.2 Root of Trust for Storage
 
-FPT_ROT_EXT.2.1:: The TSF shall prevent unauthorized access to SDOs stored in the Root of Trust for Storage.
+FPT_ROT_EXT.2.1:: The TSF shall prevent unauthorized access to SDOs associated with the Root of Trust for Storage.
 
-_Application Note {counter:remark_count}_:: _TOEs may use shielded locations or cryptographic protections to prevent unauthorized access to SDOs. Unauthorized access includes unauthorized disclosure of secret SDOs (e.g. secret keys, private keys) and unauthorized modification of both secret and non-secret SDOs (e.g. public keys, certificates). Use FDP_SDC.2 to protect the confidentiality of secret SDOs stored in the RoT for Storage. Use FDP_SDI.2 to protect the integrity of SDOs stored in the RoT for Storage._
+_Application Note {counter:remark_count}_:: _TOEs may use shielded locations or cryptographic protections to prevent unauthorized access to SDOs. Unauthorized access includes unauthorized disclosure of secret SDOs (e.g. secret keys, private keys) and unauthorized modification of both secret and non-secret SDOs (e.g. public keys, certificates). Use FDP_SDC.2 to protect the confidentiality of secret SDOs associated with the RoT for Storage. Use FDP_SDI.2 to protect the integrity of SDOs associated with the RoT for Storage._
 
 ==== FPT_RPL.1/Authorization Replay Prevention
 
@@ -3902,7 +3902,7 @@ This family defines requirements for individual Root of Trust services that the 
 
 FPT_ROT_EXT.1 Root of Trust Services, requires the TSF to identify the specific Roots of Trust it provides.
 
-FPT_ROT_EXT.2 Root of Trust for Storage, requires the TSF to prevent unauthorized access to SDOs stored in its Root of Trust for Storage.
+FPT_ROT_EXT.2 Root of Trust for Storage, requires the TSF to prevent unauthorized access to SDOs associated with its Root of Trust for Storage.
 
 FPT_ROT_EXT.3 Root of Trust for Reporting Mechanisms, requires the TSF to implement a Root of Trust for Reporting in the specified manner.
 
@@ -3928,7 +3928,7 @@ Hierarchical to:: No other components.
 
 Dependencies:: FPT_PRO_EXT.1 Root of Trust
 [vertical]
-FPT_ROT_EXT.2.1:: The TSF shall prevent unauthorized access to SDOs stored in the Root of Trust for Storage.
+FPT_ROT_EXT.2.1:: The TSF shall prevent unauthorized access to SDOs associated with the Root of Trust for Storage.
 
 *FPT_ROT_EXT.3 Root of Trust for Reporting Mechanisms*
 [horizontal]


### PR DESCRIPTION
This PR might be more controversial than the previous two.

Currently, my understanding is that the glossary in the cPP defines that an RoT for Storage is the combination of an RoT for Confidentiality and an RoT for Integrity. The RoT for Confidentiality means that the DSC protects sensitive data (i.e., SDEs and SDOs) against disclosure. The RoT for Integrity means the DSC protects sensitive data (i.e., SDEs and SDOs) and platform characteristics against tampering. At the very least, it sounds like the RoT for Storage must make sure that secret/private keys remain secret/private and are not modified, and public keys are not modified.

However, this SFR (FPT_ROT_EXT.2) is very vague in the requirements it imposes on the RoT of Storage. It simply says "prevents unauthorized access". The application note refers to "FDP_SDI.2 to protect the integrity of SDOs", but the issue of confidentiality is never addressed. 

I propose that this SFR explicitly states that "unauthorized access" includes unauthorized disclosure for SDOs that are supposed to remain secret, and unauthorized modification for every SDO. I think this is a reasonable interpretation, but maybe I'm being too strict. Then in the Application Note, I add FDP_SDC.2 as a way to meet the confidentiality requirements. I think that cryptographic or non-cryptographic ways to maintain confidentiality are both equally suitable.

In the SD, I removed the reference to FSC_CKM.1, because I don't believe these SFRs (key generation) serve any purpose in protecting the security of stored SDOs. Maybe I'm wrong though, so I'd be willing to revert this change. I also added FDP_SDC.2 as a reference for the tests.

Finally, I think "associated with" could be changed to "stored in" to be more explicit. The Application Note already used that usage, so I assume that's the intended meaning. I'd be willing to revert this change too if "associated with" is intended to be broader than "stored in". 

The issue of FPT_ROT_EXT.2 will be addressed in a separate PR.