### PR TITLE
Direct rationale PP

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -458,7 +458,7 @@ As defined by the references [CC1], [CC2], [CC3], [CC4], [CC5] and [CC-E&I], thi
 * is Part 2 extended, Part 3 conformant
 * does not claim conformance to any other PP or package.
 
-The methodology applied for the cPP evaluation is defined in [CEM] and refined by the Evaluation Activities in [DSC SD]. This cPP satisfies the following Assurance Families: APE_CCL.1, APE_ECD.1, APE_INT.1, APE_OBJ.2, APE_REQ.2 and APE_SPD.1.
+The methodology applied for the cPP evaluation is defined in [CEM] and refined by the Evaluation Activities in [DSC SD]. This cPP satisfies the following Assurance Families: APE_CCL.1, APE_ECD.1, APE_INT.1, APE_OBJ.1, APE_REQ.1 and APE_SPD.1.
 
 In order to be conformant to this cPP, a TOE must demonstrate Exact Conformance. Exact Conformance is defined as the ST containing all of the requirements in <<Security Functional Requirements>> of this cPP (these are the mandatory SFRs), and potentially requirements from <<Optional Requirements>> (these are optional SFRs) or <<Selection-Based Requirements>> (these are selection-based SFRs, some of which will be mandatory according to the selections made in other SFRs) of this cPP. While iteration is allowed, no additional requirements (from CC Parts 2 or 3, or definitions of extended components not already included in this cPP) are allowed to be included in the ST. Further, no requirements in <<Security Functional Requirements>> of this cPP are allowed to be omitted.
 
@@ -2249,9 +2249,9 @@ The actions for ALC Class (ALC_CMC.1 and ALC_CMS.1) are specified solely within 
 
 | ST Introduction (ASE_INT.1)
 
-| Security Objectives (ASE_OBJ.2)
+| Security Objectives for the Operational Environment (ASE_OBJ.1)
 
-| Derived Security Requirements (ASE_REQ.2)
+| Direct Rationale Security Requirements (ASE_REQ.1)
 
 | Security Problem Definition (ASE_SPD.1)
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1948,7 +1948,7 @@ _Application Note {counter:remark_count}_:: _TSF data may be protected in respon
 
 The following rationale provides justification for each security problem definition (SPD) aspect of the TOE, showing that the SFRs are suitable to meet and achieve the SPD aspect - this mapping follows CC:2022 Part 1 Appendix B.5:
 
-.SFR-Objective Rationale
+.SFR Rationale
 [cols=".^1,.^1,.^2",options=header]
 |===
 
@@ -2000,7 +2000,7 @@ The following rationale provides justification for each security problem definit
 |FMT_MSA.3 
 |This requirement defines the default access restrictions that are enforced on SDO attributes if not overridden by specific access control policy rules.
 
-.8+|T.UNAUTHORIZED_ACCESS
+.7+|T.UNAUTHORIZED_ACCESS
 |FMT_SMF.1 
 |This requirement defines the management functions that are provided by the TOE to authorized subjects.
 
@@ -2019,13 +2019,10 @@ The following rationale provides justification for each security problem definit
 |FPT_ROT_EXT.2 
 |This requirement enforces the RoT for Storage to enforce access control against SDOs.
 
-|FRU_FLT.1 
-|This requirement ensures that fault injection attempts do not interfere with the enforcement of access control against protected data.
-
 |FIA_AFL_EXT.2 (selection-based)
 |This requirement defines the access control that is enforced on an SDO if excessive authentication failures block access to it.
 
-.3+|T.HW_ATTACK
+.4+|T.HW_ATTACK
 |FPT_FLS.1/FI
 |This requirement ensures that fault injections cannot be used to circumvent access control policy restrictions preventing a user from accessing protected functions or data.
 
@@ -2034,6 +2031,9 @@ The following rationale provides justification for each security problem definit
 
 |FDP_FRS_EXT.2 (selection-based)
 |This requirement ensures that all user-specific SDOs are purged upon factory reset and may indicate any factory default SDOs that are reset to their initial values.
+
+|FRU_FLT.1
+|This requirement ensures that fault injection attempts do not interfere with the enforcement of access control against protected data.
 
 .11+|T.SDE_TRANSIT_COMPROMISE
 |FCS_COP.1/SKC

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1961,7 +1961,7 @@ The following rationale provides justification for each security problem definit
 |This requirement enforces authentication failure handling capabilities to ensure that brute force attacks on the TSF are not possible.
 
 |FIA_SOS.2 
-|This requirement protects against brute force authentication by generating secrets that are statistically impossible to guess.
+|This requirement protects against brute force authentication by generating secrets that are statistically difficult to guess.
 
 |FPT_STM_EXT.1 
 |This requirement provides reliable system time services that may be used to determine when excessive authentication failure attempts have been made.
@@ -2000,7 +2000,7 @@ The following rationale provides justification for each security problem definit
 |FMT_MSA.3 
 |This requirement defines the default access restrictions that are enforced on SDO attributes if not overridden by specific access control policy rules.
 
-.7+|T.UNAUTHORIZED_ACCESS
+.8+|T.UNAUTHORIZED_ACCESS
 |FMT_SMF.1 
 |This requirement defines the management functions that are provided by the TOE to authorized subjects.
 
@@ -2019,31 +2019,40 @@ The following rationale provides justification for each security problem definit
 |FPT_ROT_EXT.2 
 |This requirement enforces the RoT for Storage to enforce access control against SDOs.
 
+|FPT_RPL.1/Authorization
+|This requirement ensures that access control restrictions cannot be bypassed through replay of operations.
+
 |FIA_AFL_EXT.2 (selection-based)
 |This requirement defines the access control that is enforced on an SDO if excessive authentication failures block access to it.
 
-.4+|T.HW_ATTACK
-|FPT_FLS.1/FI
-|This requirement ensures that fault injections cannot be used to circumvent access control policy restrictions preventing a user from accessing protected functions or data.
-
+.5+|T.HW_ATTACK
 |FDP_RIP.1
 |This requirement ensures that any purged SDEs/SDOs are erased in residual memory so that their future recovery is prevented.
 
-|FDP_FRS_EXT.2 (selection-based)
-|This requirement ensures that all user-specific SDOs are purged upon factory reset and may indicate any factory default SDOs that are reset to their initial values.
+|FPT_FLS.1/FI
+|This requirement ensures that fault injections cannot be used to circumvent access control policy restrictions preventing a user from accessing protected functions or data.
+
+|FPT_PHP.3
+|This requirement ensures that some mechanism is in place to thwart physical tampering of the TOE.
 
 |FRU_FLT.1
 |This requirement ensures that fault injection attempts do not interfere with the enforcement of access control against protected data.
 
+|FDP_FRS_EXT.2 (selection-based)
+|This requirement ensures that all user-specific SDOs are purged upon factory reset and may indicate any factory default SDOs that are reset to their initial values.
+
 .11+|T.SDE_TRANSIT_COMPROMISE
+|FCS_CKM.6
+|This requirement ensures that key data is destroyed in a manner that prevents its future recovery.
+
 |FCS_COP.1/SKC
 |This requirement provides a cryptographic operation for maintaining the confidentiality of SDOs.
 
 |FDP_ETC_EXT.2
 |This requirement ensures that the confidentiality of protected data propagated outside the TOE is maintained.
 
-|FPT_ITT.1 (optional)
-|This requirement ensures that confidentiality and integrity is maintained in cases where data is transmitted between physically separate parts of a distributed TOE.
+|FDP_FRS_EXT.1
+|This requirement defines the condition in which a factory reset will be initiated, which triggers a purge of stored SDEs.
 
 |FDP_ITC_EXT.1
 |This requirement ensures that all SDEs parsed by the TOE are transmitted over a secure channel.
@@ -2054,6 +2063,9 @@ The following rationale provides justification for each security problem definit
 |FDP_SDC.2
 |This requirement ensures that the confidentiality of authorization data is protected prior to storage.
 
+|FPT_ITT.1 (optional)
+|This requirement ensures that confidentiality and integrity is maintained in cases where data is transmitted between physically separate parts of a distributed TOE.
+
 |FTP_ITC_EXT.1 (selection-based)
 |This requirement defines a cryptographically protected channel that the TSF can use to securely parse data being imported into it.
 
@@ -2063,17 +2075,7 @@ The following rationale provides justification for each security problem definit
 |FTP_ITP_EXT.1 (selection-based)
 |This requirement defines a physically protected channel that the TSF can use to securely parse data being imported into it.
 
-|FCS_CKM.6
-|This requirement ensures that key data is destroyed in a manner that prevents its future recovery.
-
-|FDP_FRS_EXT.1
-|This requirement defines the condition in which a factory reset will be initiated, which triggers a purge of stored SDEs.
-
-|T.UNAUTHORIZED_ACCESS
-|FCS_STG_EXT.1
-|This requirement ensures that key data is placed into protected storage and cannot be modified by untrusted subjects.
-
-.8+|T.WEAK_ELEMENT_BINDING
+.9+|T.WEAK_ELEMENT_BINDING
 |FCS_COP.1/Hash
 |This requirement provides a cryptographic operation for asserting the integrity of SDOs.
 
@@ -2089,16 +2091,19 @@ The following rationale provides justification for each security problem definit
 |FDP_SDI.2
 |This requirement ensures that SDEs/SDOs are monitored for integrity violations.
 
+|FPT_TST.1
+|This requirement defines the mechanisms used to verify and attest to the integrity of the TSF.
+
 |FPT_PRO_EXT.2 (optional)
 |This requirement ensures that the TSF can measure the integrity of its stored data.
 
-|FPT_TST.1
-|This requirement defines the mechanisms used to verify and attest to the integrity of the TSF.
+|FCS_COP.1/CMAC (selection-based)
+|This requirement provides a cryptographic operation for asserting the authenticity of SDOs.
 
 |FPT_FLS.1/FW (selection-based)
 |This requirement requires the TSF to take action to preserve its secure operation if any violations to its firmware integrity are detected.
 
-.12+|T.WEAK_OWNERSHIP_BINDING
+.7+|T.WEAK_OWNERSHIP_BINDING
 |FDP_ITC_EXT.1
 |This requirement ensures that all SDEs parsed by the TOE have verifiable integrity.
 
@@ -2111,8 +2116,8 @@ The following rationale provides justification for each security problem definit
 |FPT_ROT_EXT.1
 |This requirement defines the RoT services that are available for the protection of data.
 
-|FPT_RPL.1/Authorization
-|This requirement ensures that access control restrictions cannot be bypassed through replay of operations.
+|FDP_ITC_EXT.1
+|This requirement ensures that all SDEs parsed by the TOE include appropriate binding metadata.
 
 |FPT_ROT_EXT.3 (optional)
 |This requirement allows the TSF to provide a RoT for Reporting that can provide assured information about the stored SDEs.
@@ -2120,11 +2125,12 @@ The following rationale provides justification for each security problem definit
 |FDP_DAU.1/Prove (selection-based)
 |This requirement defines the Prove service that can be used to invoke the Roots of Trust for Measurement and Reporting and provide affirmation of the validity of TSF and stored data.
 
-|FPT_MFW_EXT.1
-|This requirement specifies whether the TOE's firmware is mutable or immutable, to determine the extent to which this is objective must be satisfied by other SFRs.
+.5+|T.UNAUTH_UPDATE
+|FPT_MFW_EXT.1 
+|This requirement specifies whether the TOE's firmware is mutable or immutable.
 
-|FPT_ROT_EXT.1
-|This requirement defines the RoT services that are available in the TOE, which can include Roots of Trust for measurement and reporting.
+|FPT_FLS.1/FW (selection-based)
+|This requirement requires the TSF to take action to preserve its secure operation if a rollback attempt or invalid firmware update is detected.
 
 |FPT_MFW_EXT.2 (selection-based)
 |This requirement ensures that the TSF can generate evidence that its mutable firmware integrity remains intact.
@@ -2132,22 +2138,15 @@ The following rationale provides justification for each security problem definit
 |FPT_MFW_EXT.3 (selection-based)
 |This requirement ensures that any firmware updates to the TSF are genuine.
 
-|FDP_ITC_EXT.1
-|This requirement ensures that all SDEs parsed by the TOE include appropriate binding metadata.
-
-.3+|T.UNAUTH_UPDATE
-|FPT_MFW_EXT.1 
-|This requirement specifies whether the TOE's firmware is mutable or immutable.
-
-|FPT_FLS.1/FW (selection-based)
-|This requirement requires the TSF to take action to preserve its secure operation if a rollback attempt or invalid firmware update is detected.
-
 |FPT_RPL.1/Rollback (selection-based)
 |This requirement ensures that the TSF will not permit rollback attempts of its firmware.
 
 .10+|T.WEAK_CRYPTO
 |FCS_CKM.1
 |This requirement specifies the supported methods of key generation.
+
+|FCS_CKM.2
+|This requirement specifies the supported methods of key distribution.
 
 |FCS_CKM_EXT.7 
 |This requirement ensures the use of strong key agreement mechanisms.
@@ -2158,12 +2157,6 @@ The following rationale provides justification for each security problem definit
 |FCS_COP.1/KeyedHash 
 |This requirement ensures the use of strong HMAC mechanisms.
 
-|FCS_COP.1/KeyEncap 
-|This requirement ensures the use of strong methods to perform key encapsulation.
-
-|FCS_COP.1/KeyWrap 
-|This requirement ensures the use of strong methods to perform key wrapping.
-
 |FCS_COP.1/SigGen 
 |This requirement ensures the use of strong digital signature services.
 
@@ -2173,14 +2166,13 @@ The following rationale provides justification for each security problem definit
 |FCS_COP.1/SKC 
 |This requirement ensures the use of strong methods to encrypt sensitive data.
 
-|FCS_RBG.1 
+|FCS_RBG.1
 |This requirement ensures the use of strong random bit generation mechanisms.
 
-.10+|T.WEAK_CRYPTO
-
-|FCS_OTV_EXT.1 
+|FCS_OTV_EXT.1
 |This requirement ensures that salts and nonces used by the TOE do not negatively impact key strength.
 
+.10+|T.WEAK_CRYPTO
 |FPT_STM_EXT.1 
 |This requirement provides reliable system time services that may be used as inputs to cryptographic functions.
 
@@ -2197,7 +2189,7 @@ The following rationale provides justification for each security problem definit
 |This requirement ensures that combining multiple sources of noise are combined in a way that enforces strong cryptography by requiring a minimum amount of input to the random bit generator.
 
 |FCS_RBG.6 (optional)
-|This requirement provides an interface to access entropy data so that the TSF can support the use of strong cryptography in its operational environment.
+|This requirement provides an interface to access RBG output so that the TSF can support the use of strong cryptography in its operational environment.
 
 |FCS_CKM.1/AKG (selection-based)
 |This requirement ensures the generation of strong asymmetric keys.
@@ -2205,10 +2197,22 @@ The following rationale provides justification for each security problem definit
 |FCS_CKM.1/SKG (selection-based)
 |This requirement ensures the generation of strong symmetric keys.
 
+|FCS_CKM_EXT.3 (selection-based)
+|This requirement ensures the use of strong methods to perform key encapsulation, key wrawpping, or key encryption when accessing keys.
+
 |FCS_CKM.5 (selection-based)
 |This requirement ensures the use of strong mechanisms to perform key derivation.
 
-.4+|T.WEAK_CRYPTO
+.6+|T.WEAK_CRYPTO
+|FCS_COP.1/CMAC (selection-based)
+|This requirement ensures the use of strong methods to perform CMAC.
+
+|FCS_COP.1/KeyEncap (selection-based)
+|This requirement ensures the use of strong methods to perform key encapsulation.
+
+|FCS_COP.1/KeyWrap (selection-based)
+|This requirement ensures the use of strong methods to perform key wrapping.
+
 |FCS_CKM_EXT.8 (selection-based)
 |This requirement ensures the use of strong methods to derive keys from password data.
 
@@ -2217,9 +2221,6 @@ The following rationale provides justification for each security problem definit
 
 |FTP_GCMP_EXT.1 (selection-based)
 |This requirement defines the implementation of GCMP (IEEE 802.11ad) using strong cryptography.
-
-|FTP_ITE_EXT.1 (selection-based)
-|This requirement defines the cryptographic method used to transfer data between the TOE and external entities.
 
 |===
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -526,7 +526,7 @@ The Operational Environment of the TOE implements technical and procedural measu
 
 === Security Objectives Rationale
 
-<<SPDMappingtoSO>> shows the mapping of Security Objectives for the TOE Operational Environment to Threats and Assumptions, along with rationale for these mappings. This mapping is provided in compliance with CC2022 Part 1 Appendix D.4.
+<<SPDMappingtoSO>> shows the mapping of Security Objectives for the Operational Environment to Threats and Assumptions, along with rationale for these mappings. This mapping is provided in compliance with CC:2022 Part 1 Appendix B.5.
 
 .Security Problem Definition Mapping to Security Objectives
 [[SPDMappingtoSO]]
@@ -1946,7 +1946,7 @@ _Application Note {counter:remark_count}_:: _TSF data may be protected in respon
 
 === TOE Security Functional Requirements Rationale
 
-The following rationale provides justification for each security problem definition (SPD) aspect of the TOE, showing that the SFRs are suitable to meet and achieve the SPD aspect - this mapping follows CC2022 Part 1 Appendix D.4:
+The following rationale provides justification for each security problem definition (SPD) aspect of the TOE, showing that the SFRs are suitable to meet and achieve the SPD aspect - this mapping follows CC:2022 Part 1 Appendix B.5:
 
 .SFR-Objective Rationale
 [cols=".^1,.^1,.^2",options=header]

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -460,7 +460,7 @@ As defined by the references [CC1], [CC2], [CC3], [CC4], [CC5] and [CC-E&I], thi
 
 The methodology applied for the cPP evaluation is defined in [CEM] and refined by the Evaluation Activities in [DSC SD]. This cPP satisfies the following Assurance Families: APE_CCL.1, APE_ECD.1, APE_INT.1, APE_OBJ.2, APE_REQ.2 and APE_SPD.1.
 
-In order to be conformant to this cPP, a TOE must demonstrate Exact Conformance. Exact Conformance is defined as the ST containing all of the requirements in <<Security Objectives>> of this cPP (these are the mandatory SFRs), and potentially requirements from <<Optional Requirements>> (these are optional SFRs) or <<Selection-Based Requirements>> (these are selection-based SFRs, some of which will be mandatory according to the selections made in other SFRs) of this cPP. While iteration is allowed, no additional requirements (from CC Parts 2 or 3, or definitions of extended components not already included in this cPP) are allowed to be included in the ST. Further, no requirements in <<Security Objectives>> of this cPP are allowed to be omitted.
+In order to be conformant to this cPP, a TOE must demonstrate Exact Conformance. Exact Conformance is defined as the ST containing all of the requirements in <<Security Functional Requirements>> of this cPP (these are the mandatory SFRs), and potentially requirements from <<Optional Requirements>> (these are optional SFRs) or <<Selection-Based Requirements>> (these are selection-based SFRs, some of which will be mandatory according to the selections made in other SFRs) of this cPP. While iteration is allowed, no additional requirements (from CC Parts 2 or 3, or definitions of extended components not already included in this cPP) are allowed to be included in the ST. Further, no requirements in <<Security Functional Requirements>> of this cPP are allowed to be omitted.
 
 The PPs and PP-Modules that are allowed to be specified in a PP-Configuration with this cPP are specified on the https://dsc-itc.github.io/[DSC-iTC website] Allowed Components page.
 
@@ -512,27 +512,7 @@ This section describes the assumptions made in identification of the threats and
 
 There are no organizational security policies defined in this cPP.
 
-== Security Objectives 
-
-=== Security Objectives for the TOE
-
-*O.AUTH_FAILURES:* The TOE resists repeated attempts to guess authorization data by responding to consecutive failed attempts in a way that prevents an attacker from exploring a significant amount of the space of possible authorization data values.
-
-*O.AUTHORIZATION:* The TOE authorizes only authenticated subjects to access SDOs stored by authenticated users of the TOE, pre-installed SDOs stored in the RoT by the manufacturer of the TOE, and management functions that are used to manipulate the TSF and its stored data.
-
-*O.DATA_PROTECTION:* The TOE provides authenticity, confidentiality, and integrity services for SDOs.
-
-*O.FW_INTEGRITY:* The TOE ensures its own integrity has remained intact and attests its integrity to outside parties on request.
-
-*O.PARSE_PROTECTION:* All SDEs are received by the TOE over a secure channel for parsing, protecting confidentiality and integrity of the SDEs while in transit. The TOE authenticates the source of all SDEs received, and authenticates itself to the remote peer.
-
-*O.PURGE_PROTECTION:* The TOE provides secure destruction of SDEs when they are deleted, so that the previous value of the SDE can no longer be accessed (and cannot be restored).
-
-*O.SECURE_UPDATE:* The TOE software/firmware either does not allow update, or else implements a mechanism that ensures only authorized updates are applied. If the TOE allows updating its firmware, it is required to implement a mechanism that ensures only authorized firmware can be loaded into the TOE. A secure update mechanism ensures the firmware is authorized through verification of its integrity and authenticity while also preventing rollback to a previous and potentially vulnerable firmware instance.
-
-*O.STRONG_BINDING:* The TOE provides a mechanism for binding data to its attributes (including the identity of its owner) and prevents unauthorized changes to data attributes.
-
-*O.STRONG_CRYPTO:* The TOE implements strong cryptographic mechanisms and algorithms according to recognized standards, including support for random bit generation based on recognized standards and a source of sufficient entropy. The TOE uses key sizes that are recognized as providing sufficient resistance to current attack capabilities.
+== Security Objectives
 
 === Security Objectives for the Operational Environment
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -546,7 +546,7 @@ The Operational Environment of the TOE implements technical and procedural measu
 
 === Security Objectives Rationale
 
-<<SPDMappingtoSO>> shows the mapping of Security Objectives for the TOE and for its Operational Environment to Threats and Assumptions, along with rationale for these mappings.
+<<SPDMappingtoSO>> shows the mapping of Security Objectives for the TOE Operational Environment to Threats and Assumptions, along with rationale for these mappings. This mapping is provided in compliance with CC2022 Part 1 Appendix D.4.
 
 .Security Problem Definition Mapping to Security Objectives
 [[SPDMappingtoSO]]
@@ -555,61 +555,6 @@ The Operational Environment of the TOE implements technical and procedural measu
 |Objective
 |Threat or Assumption
 |Rationale
-
-|O.AUTH_FAILURES
-|T.BRUTE_FORCE_AUTH
-|This objective ensures that the TSF has a method to thwart brute-force authorization attempts.
-
-.2+|O.AUTHORIZATION
-|T.UNAUTHORIZED_ACCESS
-|This objective defines and enforces policies that govern access to SDOs.
-
-|T.HW_ATTACK
-|This objective ensures that the access control policy is not thwarted by physical attacks on the TOE.
-
-.4+|O.DATA_PROTECTION
-|T.SDE_TRANSIT_COMPROMISE
-|This objective ensures that the confidentiality of SDEs is enforced.
-
-|T.UNAUTHORIZED_ACCESS
-|This objective ensures that SDOs have adequate protections.
-
-|T.WEAK_ELEMENT_BINDING
-|This objective assures the authenticity and integrity of SDEs.
-
-|T.WEAK_OWNERSHIP_BINDING
-|This objective protects SDEs from unauthorized access.
-
-.2+|O.FW_INTEGRITY
-
-|T.WEAK_ELEMENT_BINDING
-|This objective ensures that the TOE's firmware cannot be corrupted in a way that allows the unauthorized substitution of SDEs.
-
-|T.WEAK_OWNERSHIP_BINDING
-|This objective ensures that the TOE's firmware cannot be corrupted in a way that causes ownership bindings not to be enforced.
-
-|O.PARSE_PROTECTION
-|T.SDE_TRANSIT_COMPROMISE
-| This objective ensures that SDEs are not transmitted into the TOE over an insecure channel.
-
-.2+|O.PURGE_PROTECTION
-|T.HW_ATTACK
-|This objective ensures that a hardware attack does not expose SDE remnants that could compromise the TOE or any of its stored data.
-
-|T.SDE_TRANSIT_COMPROMISE
-|This objective ensures that residual data associated with SDEs do not remain when the SDEs themselves are deleted.
-
-|O.SECURE_UPDATE
-|T.UNAUTH_UPDATE
-|This objective prevents the application of untrusted firmware updates to the TOE.
-
-|O.STRONG_BINDING
-|T.WEAK_OWNERSHIP_BINDING
-|This objective establishes ownership of SDEs to determine the users that may interact with them.
-
-|O.STRONG_CRYPTO
-|T.WEAK_CRYPTO
-|This objective ensures that the TOE implements cryptographic algorithms that are not subject to compromise.
 
 |OE.AUTH_USERS
 |A.AUTH_USERS
@@ -2021,17 +1966,17 @@ _Application Note {counter:remark_count}_:: _TSF data may be protected in respon
 
 === TOE Security Functional Requirements Rationale
 
-The following rationale provides justification for each security objective for the TOE, showing that the SFRs are suitable to meet and achieve the security objectives:
+The following rationale provides justification for each security problem definition (SPD) aspect of the TOE, showing that the SFRs are suitable to meet and achieve the SPD aspect - this mapping follows CC2022 Part 1 Appendix D.4:
 
 .SFR-Objective Rationale
 [cols=".^1,.^1,.^2",options=header]
 |===
 
-|Objective
+|SPD
 |Addressed by
 |Rationale
 
-.4+|O.AUTH_FAILURES 
+.4+|T.BRUTE_FORCE_AUTH
 |FIA_AFL_EXT.1 
 |This requirement enforces authentication failure handling capabilities to ensure that brute force attacks on the TSF are not possible.
 
@@ -2044,7 +1989,7 @@ The following rationale provides justification for each security objective for t
 |FIA_AFL_EXT.2 (selection-based)
 |This requirement defines how access to an SDO is restored if excessive authentication failures trigger a lock on it.
 
-.10+|O.AUTHORIZATION 
+.10+|T.UNAUTHORIZED_ACCESS
 |FCS_STG_EXT.1 
 |This requirement ensures that key data is placed into protected storage and cannot be modified by untrusted subjects.
 
@@ -2075,17 +2020,14 @@ The following rationale provides justification for each security objective for t
 |FMT_MSA.3 
 |This requirement defines the default access restrictions that are enforced on SDO attributes if not overridden by specific access control policy rules.
 
-.9+|O.AUTHORIZATION 
+.8+|T.UNAUTHORIZED_ACCESS
 |FMT_SMF.1 
 |This requirement defines the management functions that are provided by the TOE to authorized subjects.
 
 |FMT_SMR.1 
 |This requirement defines the roles used by the TSF for enforcement of access control to protected functions and data.
 
-|FPT_FLS.1/FI 
-|This requirement ensures that fault injections cannot be used to circumvent access control policy restrictions preventing a user from accessing protected functions or data.
-
-|FPT_MOD_EXT.1 
+|FPT_MOD_EXT.1
 |This requirement ensures that there are no accessible debug modes that could be used to circumvent access control policy restrictions preventing a user from accessing protected functions or data.
 
 |FPT_PHP.3 
@@ -2103,89 +2045,33 @@ The following rationale provides justification for each security objective for t
 |FIA_AFL_EXT.2 (selection-based)
 |This requirement defines the access control that is enforced on an SDO if excessive authentication failures block access to it.
 
-.8+|O.DATA_PROTECTION 
-|FCS_COP.1/Hash 
-|This requirement provides a cryptographic operation for asserting the integrity of SDOs.
+.3+|T.HW_ATTACK
+|FPT_FLS.1/FI
+|This requirement ensures that fault injections cannot be used to circumvent access control policy restrictions preventing a user from accessing protected functions or data.
 
-|FCS_COP.1/KeyedHash 
-|This requirement provides a cryptographic operation for asserting the authenticity of SDOs.
+|FDP_RIP.1
+|This requirement ensures that any purged SDEs/SDOs are erased in residual memory so that their future recovery is prevented.
 
-|FCS_COP.1/SigGen 
-|This requirement provides a cryptographic operation for preserving the authenticity of SDOs.
+|FDP_FRS_EXT.2 (selection-based)
+|This requirement ensures that all user-specific SDOs are purged upon factory reset and may indicate any factory default SDOs that are reset to their initial values.
 
-|FCS_COP.1/SigVer 
-|This requirement provides a cryptographic operation for asserting the authenticity of SDOs.
-
-|FCS_COP.1/SKC 
+.11+|T.SDE_TRANSIT_COMPROMISE
+|FCS_COP.1/SKC
 |This requirement provides a cryptographic operation for maintaining the confidentiality of SDOs.
 
-|FCS_STG_EXT.1 
-|This requirement ensures that key data is placed into protected storage and cannot be modified by untrusted subjects.
-
-|FDP_ETC_EXT.2 
+|FDP_ETC_EXT.2
 |This requirement ensures that the confidentiality of protected data propagated outside the TOE is maintained.
-
-|FDP_ITC_EXT.1 
-|This requirement ensures that all SDEs parsed by the TOE have verifiable integrity.
-
-.9+|O.DATA_PROTECTION 
-|FDP_ITC_EXT.2 
-|This requirement ensures that all SDOs parsed by the TOE have verifiable integrity.
-
-|FDP_SDC.2 
-|This requirement ensures that SDEs/SDOs are stored with confidentiality and that all authorization data is protected prior to storage.
-
-|FDP_SDI.2 
-|This requirement ensures that SDEs/SDOs are monitored for integrity violations.
-
-|FPT_ROT_EXT.1 
-|This requirement defines the RoT services that are available for the protection of data.
-
-|FPT_RPL.1/Authorization
-|This requirement ensures that access control restrictions cannot be bypassed through replay of operations.
 
 |FPT_ITT.1 (optional)
 |This requirement ensures that confidentiality and integrity is maintained in cases where data is transmitted between physically separate parts of a distributed TOE.
 
-|FPT_PRO_EXT.2 (optional)
-|This requirement ensures that the TSF can measure the integrity of its stored data.
-
-|FPT_ROT_EXT.3 (optional)
-|This requirement allows the TSF to provide a RoT for Reporting that can provide assured information about the stored SDEs.
-
-|FDP_DAU.1/Prove (selection-based)
-|This requirement defines the Prove service that can be used to invoke the Roots of Trust for Measurement and Reporting and provide affirmation of the validity of stored data.
-
-.7+|O.FW_INTEGRITY 
-|FPT_MFW_EXT.1 
-|This requirement specifies whether the TOE's firmware is mutable or immutable, to determine the extent to which this is objective must be satisfied by other SFRs.
-
-|FPT_ROT_EXT.1 
-|This requirement defines the RoT services that are available in the TOE, which can include Roots of Trust for measurement and reporting.
-
-|FPT_TST.1 
-|This requirement defines the mechanisms used to verify and attest to the integrity of the TSF.
-
-|FDP_DAU.1/Prove (selection-based)
-|This requirement defines the Prove service that can be used to invoke the Roots of Trust for Measurement and Reporting and provide affirmation of the validity of the TSF.
-
-|FPT_MFW_EXT.2 (selection-based)
-|This requirement ensures that the TSF can generate evidence that its mutable firmware integrity remains intact.
-
-|FPT_MFW_EXT.3 (selection-based)
-|This requirement ensures that any firmware updates to the TSF are genuine.
-
-|FPT_FLS.1/FW (selection-based)
-|This requirement requires the TSF to take action to preserve its secure operation if any violations to its firmware integrity are detected.
-
-.6+|O.PARSE_PROTECTION 
-|FDP_ITC_EXT.1 
+|FDP_ITC_EXT.1
 |This requirement ensures that all SDEs parsed by the TOE are transmitted over a secure channel.
 
-|FDP_ITC_EXT.2 
+|FDP_ITC_EXT.2
 |This requirement ensures that all SDOs parsed by the TOE are transmitted over a secure channel.
 
-|FDP_SDC.2 
+|FDP_SDC.2
 |This requirement ensures that the confidentiality of authorization data is protected prior to storage.
 
 |FTP_ITC_EXT.1 (selection-based)
@@ -2197,20 +2083,79 @@ The following rationale provides justification for each security objective for t
 |FTP_ITP_EXT.1 (selection-based)
 |This requirement defines a physically protected channel that the TSF can use to securely parse data being imported into it.
 
-.4+|O.PURGE_PROTECTION 
-|FCS_CKM.6 
+|FCS_CKM.6
 |This requirement ensures that key data is destroyed in a manner that prevents its future recovery.
 
-|FDP_FRS_EXT.1 
+|FDP_FRS_EXT.1
 |This requirement defines the condition in which a factory reset will be initiated, which triggers a purge of stored SDEs.
 
-|FDP_RIP.1 
-|This requirement ensures that any purged SDEs/SDOs are erased in residual memory so that their future recovery is prevented.
+|T.UNAUTHORIZED_ACCESS
+|FCS_STG_EXT.1
+|This requirement ensures that key data is placed into protected storage and cannot be modified by untrusted subjects.
 
-|FDP_FRS_EXT.2 (selection-based)
-|This requirement ensures that all user-specific SDOs are purged upon factory reset and may indicate any factory default SDOs that are reset to their initial values.
+.8+|T.WEAK_ELEMENT_BINDING
+|FCS_COP.1/Hash
+|This requirement provides a cryptographic operation for asserting the integrity of SDOs.
 
-.3+|O.SECURE_UPDATE 
+|FCS_COP.1/KeyedHash
+|This requirement provides a cryptographic operation for asserting the authenticity of SDOs.
+
+|FCS_COP.1/SigGen
+|This requirement provides a cryptographic operation for preserving the authenticity of SDOs.
+
+|FCS_COP.1/SigVer
+|This requirement provides a cryptographic operation for asserting the authenticity of SDOs.
+
+|FDP_SDI.2
+|This requirement ensures that SDEs/SDOs are monitored for integrity violations.
+
+|FPT_PRO_EXT.2 (optional)
+|This requirement ensures that the TSF can measure the integrity of its stored data.
+
+|FPT_TST.1
+|This requirement defines the mechanisms used to verify and attest to the integrity of the TSF.
+
+|FPT_FLS.1/FW (selection-based)
+|This requirement requires the TSF to take action to preserve its secure operation if any violations to its firmware integrity are detected.
+
+.12+|T.WEAK_OWNERSHIP_BINDING
+|FDP_ITC_EXT.1
+|This requirement ensures that all SDEs parsed by the TOE have verifiable integrity.
+
+|FDP_ITC_EXT.2
+|This requirement ensures that all SDOs parsed by the TOE have verifiable integrity.
+
+|FDP_SDC.2
+|This requirement ensures that SDEs/SDOs are stored with confidentiality and that all authorization data is protected prior to storage.
+
+|FPT_ROT_EXT.1
+|This requirement defines the RoT services that are available for the protection of data.
+
+|FPT_RPL.1/Authorization
+|This requirement ensures that access control restrictions cannot be bypassed through replay of operations.
+
+|FPT_ROT_EXT.3 (optional)
+|This requirement allows the TSF to provide a RoT for Reporting that can provide assured information about the stored SDEs.
+
+|FDP_DAU.1/Prove (selection-based)
+|This requirement defines the Prove service that can be used to invoke the Roots of Trust for Measurement and Reporting and provide affirmation of the validity of TSF and stored data.
+
+|FPT_MFW_EXT.1
+|This requirement specifies whether the TOE's firmware is mutable or immutable, to determine the extent to which this is objective must be satisfied by other SFRs.
+
+|FPT_ROT_EXT.1
+|This requirement defines the RoT services that are available in the TOE, which can include Roots of Trust for measurement and reporting.
+
+|FPT_MFW_EXT.2 (selection-based)
+|This requirement ensures that the TSF can generate evidence that its mutable firmware integrity remains intact.
+
+|FPT_MFW_EXT.3 (selection-based)
+|This requirement ensures that any firmware updates to the TSF are genuine.
+
+|FDP_ITC_EXT.1
+|This requirement ensures that all SDEs parsed by the TOE include appropriate binding metadata.
+
+.3+|T.UNAUTH_UPDATE
 |FPT_MFW_EXT.1 
 |This requirement specifies whether the TOE's firmware is mutable or immutable.
 
@@ -2220,12 +2165,8 @@ The following rationale provides justification for each security objective for t
 |FPT_RPL.1/Rollback (selection-based)
 |This requirement ensures that the TSF will not permit rollback attempts of its firmware.
 
-|O.STRONG_BINDING 
-|FDP_ITC_EXT.1 
-|This requirement ensures that all SDEs parsed by the TOE include appropriate binding metadata.
-
-.10+|O.STRONG_CRYPTO 
-|FCS_CKM.1 
+.10+|T.WEAK_CRYPTO
+|FCS_CKM.1
 |This requirement specifies the supported methods of key generation.
 
 |FCS_CKM_EXT.7 
@@ -2255,7 +2196,7 @@ The following rationale provides justification for each security objective for t
 |FCS_RBG.1 
 |This requirement ensures the use of strong random bit generation mechanisms.
 
-.10+|O.STRONG_CRYPTO 
+.10+|T.WEAK_CRYPTO
 
 |FCS_OTV_EXT.1 
 |This requirement ensures that salts and nonces used by the TOE do not negatively impact key strength.
@@ -2287,7 +2228,7 @@ The following rationale provides justification for each security objective for t
 |FCS_CKM.5 (selection-based)
 |This requirement ensures the use of strong mechanisms to perform key derivation.
 
-.4+|O.STRONG_CRYPTO 
+.4+|T.WEAK_CRYPTO
 |FCS_CKM_EXT.8 (selection-based)
 |This requirement ensures the use of strong methods to derive keys from password data.
 


### PR DESCRIPTION
As specified in https://github.com/DSC-iTC/cPP/issues/35 the approach of the direct rationale PP/ST shall be taken. The change removes the objectives for the TOE and replaces the objectives to SFR mapping with the SPD to SFR mapping as defined in CC2022 Appendix Part 1 B.5.

The approach to the mapping was to apply the threads mapped to objectives when replacing the objectives in the SFR mapping table.