### PR TITLE
Clarify App Notes for FPT_MFW_EXT.2 and FPT_MFW_EXT.3

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -2861,7 +2861,7 @@ _Verifying the integrity of the firmware could be accomplished by guaranteeing t
 +
 _This requirement covers the case of ensuring the firmware is trustworthy in immutable form or mutable through any firmware updates, since the integrity and authenticity are checked prior to execution._
 +
-_FCS_COP.1/SigVer applies if the TOE provides the capability to update the TOE firmware and uses digital signatures and MAC verification for update verification. The ST Author should choose the algorithm implemented to perform digital signatures. For the algorithms chosen, the ST author should make the appropriate assignments/selections to specify the parameters that are implemented for that algorithm._
+_FCS_COP.1/SigVer applies if the TOE provides the capability to update the TOE firmware and uses digital signatures for update verification. FCS_COP.1/CMAC or FCS_COP.1/KeyedHash applies if the TOE provides the capability to update the TOE firmware and uses MAC verification for update verification. The ST author should choose the algorithm implemented to perform digital signatures or MAC verification. For the algorithms chosen, the ST author should make the appropriate assignments/selections to specify the parameters that are implemented for that algorithm._
 
 ==== FPT_MFW_EXT.3 Firmware Authentication with Identity of Guarantor
 
@@ -2879,7 +2879,7 @@ _Verifying the authenticity of the firmware could be accomplished by guaranteein
 +
 _This requirement covers the case of ensuring the firmware is trustworthy in immutable form or mutable through any firmware updates, since the integrity and authenticity are checked prior to execution._
 +
-_FCS_COP.1/SigVer applies if the TOE provides the capability to update the TOE firmware and uses digital signatures and MAC verification for update verification. The ST Author should choose the algorithm implemented to perform digital signatures. For the algorithms chosen, the ST author should make the appropriate assignments/selections to specify the parameters that are implemented for that algorithm._
+_FCS_COP.1/SigVer applies if the TOE provides the capability to update the TOE firmware and uses digital signatures for update verification. The ST author should choose the algorithm implemented to perform digital signatures. For the algorithms chosen, the ST author should make the appropriate assignments/selections to specify the parameters that are implemented for that algorithm._
 
 ==== FPT_RPL.1/Rollback Replay Detection (Rollback)
 


### PR DESCRIPTION
For FPT_MFW_EXT.2, the intent seems to be to allow MAC verification. Note the App Note says "The TOE guarantees the integrity of the firmware by verifying its integrity." and later "FCS_COP.1/SigVer applies if the TOE provides the capability to update the TOE firmware and uses digital signatures and MAC verification for update verification."

Obviously, FCS_COP.1/SigVer does not apply for MAC verification, so it should be clarified.

For FPT_MFW_EXT.3, the intent seems to be to only allow signature verification. Note the App Note says "The TOE guarantees the authenticity of the firmware by verifying its signature."

Then, the later reference to "MAC verification" in the App Note needs to be removed.