### PR TITLE
Fix typoes

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -13,7 +13,7 @@
 :appendix-refsig: Appendix
 :title-logo-image: image:cclogo_small.png[top=15%,align=center,pdfwidth=4.5in]
 
-:iTC-longame: Dediated Security Components
+:iTC-longame: Dedicated Security Components
 :iTC-shortname: DSC-iTC
 
 :sectnums!:

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -11,7 +11,7 @@
 :doctype: book
 :chapter-refsig: Section
 
-:iTC-longame: Dediated Security Components
+:iTC-longame: Dedicated Security Components
 :iTC-shortname: DSC-iTC
 
 :sectnums!:


### PR DESCRIPTION
Original comment description:

Editorial. Typo: Dediated Security Components.