### PR TITLE
PP structure is in Annex B, not Annex C

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -52,7 +52,7 @@ The DSC international Technical Community (iTC) designed the DSC cPP as a standa
 
 === Scope of Document
 
-The scope of the cPP within the development and evaluation process is described in the Common Criteria for Information Technology Security Evaluation [CC]. In particular, a cPP defines the IT security requirements of a generic type of Target of Evaluation (TOE) and specifies the functional and assurance security measures that the ITSEF must apply to the TOE to demonstrate that it meets the cPP's stated requirements [CC1, Section C.1].
+The scope of the cPP within the development and evaluation process is described in the Common Criteria for Information Technology Security Evaluation [CC]. In particular, a cPP defines the IT security requirements of a generic type of Target of Evaluation (TOE) and specifies the functional and assurance security measures that the ITSEF must apply to the TOE to demonstrate that it meets the cPP's stated requirements [CC1, Annex B].
 
 === Intended Readership
 


### PR DESCRIPTION
Original comment:

Don't understand why there is a reference to [CC1, Section C.1].

CC:2022 Annex C talks about the structure of  PP-Modules and PP-Configurations. Instead, CC:2022 Section 6.3.3.2 summarizes the information delivered in a  Protection Profile.  Moreover, CC:2022 Annex B talks about the structure of Protection Profiles.