### PR TITLE
Change e.g. starting sentence to For example

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -590,12 +590,12 @@ Note that a refinement is also used to indicate cases where the PP replaces an a
 
 ** Wholly or partially completed in the PP: the selection values (i.e. the selection values adopted in the PP or the remaining selection values available for the ST) are indicated with [.underline]#underlined text#;
 +
-e.g. "[_selection: disclosure, modification, loss of use_]" in [CC2] or an ECD might become "[.underline]#disclosure#" (completion) or "selection: [.underline]#disclosure, modification#" (partial completion) in the PP;
+For example, "[_selection: disclosure, modification, loss of use_]" in [CC2] or an ECD might become "[.underline]#disclosure#" (completion) or "selection: [.underline]#disclosure, modification#" (partial completion) in the PP;
 
 * Assignment wholly or partially completed in the PP: indicated with _italicized text_;
 * Assignment completed within a selection in the PP: the completed assignment text is indicated with _[.underline]#italicized and underlined text#_
 +
-e.g. "{empty}[selection: [.underline]#change_default, query, modify, delete, [_assignment: other operations_#]]" in [CC2] or an ECD might become "[.underline]#[change_default, [_select_tag_#]]" (completion of both selection and assignment) or "{empty}[selection: [.underline]#change_default, select_tag, [_select_value_#]]" (partial completion of selection, and completion of assignment) in the PP;
+For example, "{empty}[selection: [.underline]#change_default, query, modify, delete, [_assignment: other operations_#]]" in [CC2] or an ECD might become "[.underline]#[change_default, [_select_tag_#]]" (completion of both selection and assignment) or "{empty}[selection: [.underline]#change_default, select_tag, [_select_value_#]]" (partial completion of selection, and completion of assignment) in the PP;
 
 * Iteration: indicated by adding a string starting with "/" (e.g. "FCS_COP.1/Hash").
 
@@ -605,7 +605,7 @@ If the selection or assignment is to be completed by the ST author, it is preced
 
 Some SFRs include selections that determine or constrain other assignments or selections. In these cases, a table follows the requirement in which each row of the table defines a permitted set of choices. Individual entries in these tables may also require further selections or assignments. Within the tables, the selections and assignments just follow the normal conventions as the specific modifications applied to the SFR are included in the SFR itself, and the table will only follow the normal conventions under that specified within the SFR.
 
-e.g. for the example <<SampleCrypto>>, the ST for a TOE that supports RSA keys must include the entries for 'Cryptographic Key Generation Algorithm', 'Cryptographic Algorithm Parameters', and 'List of Standards'. For 'Cryptographic Algorithm Parameters', the ST author must further select which of the required parameter information are supported. Likewise, if the TOE supports ECC the ST must include the entries from row for ECC along with the appropriate selections. The row identifiers (where applicable) are merely intended as quick reference handles; there is no expectation that the TSF actually refer to keys using this identifier (or that they are used within the ST except where useful).
+For example, for the <<SampleCrypto>>, the ST for a TOE that supports RSA keys must include the entries for 'Cryptographic Key Generation Algorithm', 'Cryptographic Algorithm Parameters', and 'List of Standards'. For 'Cryptographic Algorithm Parameters', the ST author must further select which of the required parameter information are supported. Likewise, if the TOE supports ECC the ST must include the entries from row for ECC along with the appropriate selections. The row identifiers (where applicable) are merely intended as quick reference handles; there is no expectation that the TSF actually refer to keys using this identifier (or that they are used within the ST except where useful).
 
 .Sample Cryptographic Table
 [[SampleCrypto]]


### PR DESCRIPTION
Original comment:

Editorial. Grammar: At the beginning of a sentence, "e.g." should be written as "E.g.,".