### PR TITLE
Remove unused identifier AK1

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -644,7 +644,7 @@ FCS_CKM.1 Cryptographic Key Generation
 
 FCS_CKM.1.1:: The TSF shall generate cryptographic keys in accordance with a specified cryptographic key generation algorithm *corresponding to [.underline]#[selection:*#
 +
-* [.underline]#*Asymmetric keys generated in accordance with FCS_CKM.1/AKG identifier AK1,*#
+* [.underline]#*Asymmetric keys generated in accordance with FCS_CKM.1/AKG,*#
 * [.underline]#*Symmetric keys generated in accordance with FCS_CKM.1/SKG,*#
 * [.underline]#*Derived keys generated in accordance with FCS_CKM.5*#
 +


### PR DESCRIPTION
This was a leftover from an older version of the Crypto Catalog; that "identifier" column has since been removed from the relevant table.