### PR TITLE
Selection should be underlined rather than italic

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1455,7 +1455,7 @@ _If [.underline]#cryptographically protected data channels as specified in FTP_I
 
 FDP_RIP.1 Subset Residual Information Protection
 
-FDP_RIP.1.1:: The TSF shall ensure that any previous information content of a resource is made unavailable upon the [_deallocation of the resource from_] the following objects: [
+FDP_RIP.1.1:: The TSF shall ensure that any previous information content of a resource is made unavailable upon the [.underline]#[deallocation of the resource from]# the following objects: [
 +
 * _SDOs_
 * _SDEs_].


### PR DESCRIPTION
Original comment:

Editorial.

A selection operation has been performed on this SFR to get the following text

[deallocation of the resource from] in the SFR.

The text style should be underlined rather than italicized, because this is a selection.