### PR TITLE
Add missing hyphen

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -2226,7 +2226,7 @@ The actions for ALC Class (ALC_CMC.1 and ALC_CMS.1) are specified solely within 
 
 | Preparative Procedures (AGD_PRE.1)
 
-.2+| Life cycle Support (ALC) 
+.2+| Life-cycle Support (ALC)
 | Labelling of the TOE (ALC_CMC.1)
 
 | TOE CM Coverage (ALC_CMS.1)


### PR DESCRIPTION
Original comment:

Editorial. Life cycle → Life-cycle.  "Life-cycle" is the term used in CC:2022.