### PR TITLE
Fix typo in component number

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -3202,7 +3202,7 @@ FCS_STG_EXT.1.1:: The TSF shall provide [_assignment: protection method_] protec
 
 FCS_STG_EXT.1.2:: The TSF shall support the capability of {empty}[selection: [.underline]#importing keys/secrets into the TOE, causing the TOE to generate keys/secrets]# upon request of [_assignment: authorized subject_].
 
-FCS_STG_EXT.1.4:: The TSF shall have the capability to allow only the user that [selection: imported the key/secret, caused the key/secret to be generated] to use the key/secret. Exceptions may only be explicitly authorized by [_assignment: authorized subject_].
+FCS_STG_EXT.1.3:: The TSF shall have the capability to allow only the user that [selection: imported the key/secret, caused the key/secret to be generated] to use the key/secret. Exceptions may only be explicitly authorized by [_assignment: authorized subject_].
 
 FCS_STG_EXT.1.4:: The TSF shall have the capability to allow only the user that {empty}[selection: [.underline]#imported the key/secret, caused the key/secret to be generated]# to use the key/secret. Exceptions may only be explicitly authorized by [_assignment: authorized subject_].
 


### PR DESCRIPTION
Original comment:

Content. There is no definition of SFR component FCS_STG_EXT.1.3. There are 2 duplicate FCS_STG_EXT.1.4 components.