### PR TITLE
Consistent grammar in R.AUTHDATA first sentence

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -477,7 +477,7 @@ The PPs and PP-Modules that are allowed to be specified in a PP-Configuration wi
 
 === Assets
 
-*R.AUTHDATA:* Authorization Data that the TOE manages in support of the authorization services that it offers, including both user-provided authentication tokens and authorization values and those created by the TOE. Authorization Data may be special cases of SDEs, or they may be attributes in an SDO. The TSF may use Authorization Data to manage the use and disposition of a single SDE, or a broad class of SDEs. The TOE protects the integrity of Authorization Data, and in some cases, may protect their confidentiality.
+*R.AUTHDATA:* Authorization Data is managed by the TOE in support of the authorization services that it offers, including both user-provided authentication tokens and authorization values and those created by the TOE. Authorization Data may be special cases of SDEs, or they may be attributes in an SDO. The TSF may use Authorization Data to manage the use and disposition of a single SDE, or a broad class of SDEs. The TOE protects the integrity of Authorization Data, and in some cases, may protect their confidentiality.
 
 *R.CONFKEY:* Confidential (or secret) keys used in symmetric cryptographic functions and private keys used in asymmetric cryptographic functions are managed and used by the TOE in support of the cryptographic services that it offers. This includes user keys that are owned and used by a specific user (which are a special case of an SDE), and support keys used in the implementation and operation of the TOE. The confidentiality and integrity of these keys must be protected.
 


### PR DESCRIPTION
Original comment:

R.AUTHDATA: The first "sentence" is not a sentence in grammar. There is not a verb.