### PR TITLE
Make ECD formatting consistent with CC:2022

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -3146,7 +3146,7 @@ FCS_COP.1/KeyedHash Cryptographic Operation (Keyed Hash) +
 FCS_CKM.6 Timing and event of cryptographic key destruction 
 
 [vertical]
-FCS_CKM_EXT.8.1:: The TSF shall perform password-based key derivation functions in accordance with a specified cryptographic algorithm {empty}[HMAC-[selection: _SHA-256, SHA-384, SHA-512_]], with iteration count of [assignment: _number of iterations_] using a randomly generated salt of length [selection: _128, [assignment: greater than 128]_] and output cryptographic key sizes [selection: _128, 192, 256 [assignment: greater than 128]_] bits that meet the following standard: [NIST SP 800-132 Section 5.3 (PBKDF2)].
+FCS_CKM_EXT.8.1:: The TSF shall perform password-based key derivation functions in accordance with a specified cryptographic algorithm [HMAC-[selection: _SHA-256, SHA-384, SHA-512_]], with iteration count of [assignment: _number of iterations_] using a randomly generated salt of length [selection: _128, [assignment: greater than 128]_] and output cryptographic key sizes [selection: _128, 192, 256 [assignment: greater than 128]_] bits that meet the following standard: [NIST SP 800-132 Section 5.3 (PBKDF2)].
 
 ==== FCS_OTV_EXT One-Time Value
 
@@ -3183,7 +3183,7 @@ Hierarchical to:: No other components.
 
 Dependencies:: FCS_RBG.1 Random Bit Generation (RBG)
 [vertical]
-FCS_OTV_EXT.1.1:: The TSF shall perform cryptographic one-time value generation for [selection: _algorithm or mode_] using the output of a {empty}[selection: _random bit generator as defined in FCS_RBG.1, deterministic IV construction, [assignment: OTV construction method]_] and sizes of length that meet the following: [selection: _list of standards_].
+FCS_OTV_EXT.1.1:: The TSF shall perform cryptographic one-time value generation for [selection: _algorithm or mode_] using the output of a [selection: _random bit generator as defined in FCS_RBG.1, deterministic IV construction, [assignment: OTV construction method]_] and sizes of length that meet the following: [selection: _list of standards_].
 
 ==== FCS_STG_EXT Cryptographic Key Storage
 
@@ -3222,15 +3222,15 @@ Hierarchical to:: No other components.
 
 Dependencies:: No dependencies.
 [vertical]
-FCS_STG_EXT.1.1:: The TSF shall provide [assignment: _protection method_] protected storage for asymmetric private keys and {empty}[selection: _symmetric keys, persistent secrets, no other keys_].
+FCS_STG_EXT.1.1:: The TSF shall provide [assignment: _protection method_] protected storage for asymmetric private keys and [selection: _symmetric keys, persistent secrets, no other keys_].
 
-FCS_STG_EXT.1.2:: The TSF shall support the capability of {empty}[selection: _importing keys/secrets into the TOE, causing the TOE to generate keys/secrets_] upon request of [assignment: _authorized subject_].
+FCS_STG_EXT.1.2:: The TSF shall support the capability of [selection: _importing keys/secrets into the TOE, causing the TOE to generate keys/secrets_] upon request of [assignment: _authorized subject_].
 
 FCS_STG_EXT.1.3:: The TSF shall have the capability to allow only the user that [selection: _imported the key/secret, caused the key/secret to be generated_] to use the key/secret. Exceptions may only be explicitly authorized by [assignment: _authorized subject_].
 
-FCS_STG_EXT.1.4:: The TSF shall have the capability to allow only the user that {empty}[selection: _imported the key/secret, caused the key/secret to be generated_] to use the key/secret. Exceptions may only be explicitly authorized by [assignment: _authorized subject_].
+FCS_STG_EXT.1.4:: The TSF shall have the capability to allow only the user that [selection: _imported the key/secret, caused the key/secret to be generated_] to use the key/secret. Exceptions may only be explicitly authorized by [assignment: _authorized subject_].
 
-FCS_STG_EXT.1.5:: The TSF shall allow only the user that {empty}[selection: _imported the key/secret, caused the key/secret to be generated_] to request that the key/secret be destroyed. Exceptions may only be explicitly authorized by [assignment: _authorized subject_].
+FCS_STG_EXT.1.5:: The TSF shall allow only the user that [selection: _imported the key/secret, caused the key/secret to be generated_] to request that the key/secret be destroyed. Exceptions may only be explicitly authorized by [assignment: _authorized subject_].
 
 === Class FDP: User Data Protection
 ==== FDP_ETC_EXT Export from the TOE
@@ -3268,7 +3268,7 @@ Hierarchical to:: No other components.
 
 Dependencies:: FCS_COP.1 Cryptographic Operation
 [vertical]
-FDP_ETC_EXT.2.1:: The TSF shall propagate only SDO references, wrapped authorization data, and wrapped SDOs such that only {empty}[selection: _the TOE, authorized users_] can access them.
+FDP_ETC_EXT.2.1:: The TSF shall propagate only SDO references, wrapped authorization data, and wrapped SDOs such that only [selection: _the TOE, authorized users_] can access them.
 
 ==== FDP_FRS_EXT Factory Reset
 
@@ -3451,7 +3451,7 @@ Hierarchical to:: No other components.
 
 Dependencies:: No dependencies.
 [vertical]
-FIA_AFL_EXT.1.1:: The TSF shall maintain {empty}[selection: _a unique counter for [assignment: multiple separate objects each requiring authorization], one global counter covering [assignment: objects requiring authorization]_], called the failed authorization attempt counters, that counts of the number of unsuccessful authorization attempts that occur related to authorizing access to these objects.
+FIA_AFL_EXT.1.1:: The TSF shall maintain [selection: _a unique counter for [assignment: multiple separate objects each requiring authorization], one global counter covering [assignment: objects requiring authorization]_], called the failed authorization attempt counters, that counts of the number of unsuccessful authorization attempts that occur related to authorizing access to these objects.
 
 FIA_AFL_EXT.1.2:: The TSF shall maintain a [selection, choose one of: _static, administrator configurable variable_] threshold of the minimal acceptable number of unsuccessful authorization attempts that occur related to authorizing access to these objects.
 
@@ -3556,7 +3556,7 @@ Hierarchical to:: No other components.
 
 Dependencies:: No dependencies.
 [vertical]
-FPT_MFW_EXT.1.1:: The TSF shall be maintained as {empty}[selection: _immutable, mutable_] firmware.
+FPT_MFW_EXT.1.1:: The TSF shall be maintained as [selection: _immutable, mutable_] firmware.
 
 *FPT_MFW_EXT.2 Basic Firmware Integrity*
 [horizontal]
@@ -3661,7 +3661,7 @@ Dependencies:: No dependencies.
 [vertical]
 FPT_PRO_EXT.1.1:: The TSF shall contain an SDO that contains the identity of the Root of Trust.
 
-FPT_PRO_EXT.1.2:: The TSF shall maintain Root of Trust data as {empty}[selection: _immutable, mutable if and only if its mutability is controlled by a unique identifiable owner_].
+FPT_PRO_EXT.1.2:: The TSF shall maintain Root of Trust data as [selection: _immutable, mutable if and only if its mutability is controlled by a unique identifiable owner_].
 
 *FPT_PRO_EXT.2 Data Integrity Measurements*
 [horizontal]
@@ -3717,7 +3717,7 @@ Hierarchical to:: No other components.
 
 Dependencies:: FPT_PRO_EXT.1 Root of Trust
 [vertical]
-FPT_ROT_EXT.1.1:: The TSF shall provide a Root of Trust for Storage, a Root of Trust for Authorization, and {empty}[selection: _Root of Trust for Measurement, Root of Trust for Reporting, no others_].
+FPT_ROT_EXT.1.1:: The TSF shall provide a Root of Trust for Storage, a Root of Trust for Authorization, and [selection: _Root of Trust for Measurement, Root of Trust for Reporting, no others_].
 
 *FPT_ROT_EXT.2 Root of Trust for Storage*
 [horizontal]
@@ -3735,7 +3735,7 @@ Dependencies:: FCS_COP.1 Cryptographic Operation +
 FPT_PRO_EXT.1 Root of Trust +
 FPT_ROT_EXT.1 Root of Trust Services
 [vertical]
-FPT_ROT_EXT.3.1:: The TSF shall be able to attest to a state as represented by platform characteristics with a Root of Trust for Reporting mechanism that uses for its identity {empty}[selection: _a cryptographically verifiable identity in FPT_PRO_EXT.1, an alias key bound to the cryptographically verifiable identity in FPT_PRO_EXT.1_] and using a signature algorithm as specified in FCS_COP.1.
+FPT_ROT_EXT.3.1:: The TSF shall be able to attest to a state as represented by platform characteristics with a Root of Trust for Reporting mechanism that uses for its identity [selection: _a cryptographically verifiable identity in FPT_PRO_EXT.1, an alias key bound to the cryptographically verifiable identity in FPT_PRO_EXT.1_] and using a signature algorithm as specified in FCS_COP.1.
 
 ==== FPT_STM_EXT Reliable Time Counting
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -3131,7 +3131,7 @@ or FCS_COP.1 Cryptographic operation] +
 FCS_CKM.6 Timing and event of cryptographic key destruction 
 
 [vertical]
-FCS_CKM_EXT.7.1:: The TSF shall derive shared cryptographic keys with input from multiple parties in accordance with specified cryptographic key derivation algorithms [*selection*: _cryptographic algorithm_] and specified key sizes [*selection*: _key sizes_] that meets the following: [*selection*: _list of standards_].
+FCS_CKM_EXT.7.1:: The TSF shall derive shared cryptographic keys with input from multiple parties in accordance with specified cryptographic key derivation algorithms [selection: _cryptographic algorithm_] and specified key sizes [selection: _key sizes_] that meets the following: [selection: _list of standards_].
 
 *FCS_CKM_EXT.8 Password-Based Key Derivation*
 [horizontal]
@@ -3146,7 +3146,7 @@ FCS_COP.1/KeyedHash Cryptographic Operation (Keyed Hash) +
 FCS_CKM.6 Timing and event of cryptographic key destruction 
 
 [vertical]
-FCS_CKM_EXT.8.1:: The TSF shall perform password-based key derivation functions in accordance with a specified cryptographic algorithm {empty}[_HMAC-[selection: SHA-256, SHA-384, SHA-512]_], with iteration count of _[assignment: number of iterations]_ using a randomly generated salt of length _[selection: 128, [assignment: greater than 128]]_ and output cryptographic key sizes _[selection: 128, 192, 256]_ bits that meet the following standard: [NIST SP 800-132 Section 5.3 (PBKDF2)].
+FCS_CKM_EXT.8.1:: The TSF shall perform password-based key derivation functions in accordance with a specified cryptographic algorithm {empty}[HMAC-[selection: _SHA-256, SHA-384, SHA-512_]], with iteration count of [assignment: _number of iterations_] using a randomly generated salt of length [selection: _128, [assignment: greater than 128]_] and output cryptographic key sizes [selection: _128, 192, 256 [assignment: greater than 128]_] bits that meet the following standard: [NIST SP 800-132 Section 5.3 (PBKDF2)].
 
 ==== FCS_OTV_EXT One-Time Value
 
@@ -3183,7 +3183,7 @@ Hierarchical to:: No other components.
 
 Dependencies:: FCS_RBG.1 Random Bit Generation (RBG)
 [vertical]
-FCS_OTV_EXT.1.1:: The TSF shall perform cryptographic one-time value generation for [*selection*: _algorithm or mode_] using the output of a {empty}[*selection*: _random bit generator as defined in FCS_RBG.1, deterministic IV construction, [assignment: OTV construction method]_] and sizes of length that meet the following: [*selection*: _list of standards_].
+FCS_OTV_EXT.1.1:: The TSF shall perform cryptographic one-time value generation for [selection: _algorithm or mode_] using the output of a {empty}[selection: _random bit generator as defined in FCS_RBG.1, deterministic IV construction, [assignment: OTV construction method]_] and sizes of length that meet the following: [selection: _list of standards_].
 
 ==== FCS_STG_EXT Cryptographic Key Storage
 
@@ -3222,15 +3222,15 @@ Hierarchical to:: No other components.
 
 Dependencies:: No dependencies.
 [vertical]
-FCS_STG_EXT.1.1:: The TSF shall provide [_assignment: protection method_] protected storage for asymmetric private keys and {empty}[selection: [.underline]#symmetric keys, persistent secrets, no other keys]#.
+FCS_STG_EXT.1.1:: The TSF shall provide [assignment: _protection method_] protected storage for asymmetric private keys and {empty}[selection: _symmetric keys, persistent secrets, no other keys_].
 
-FCS_STG_EXT.1.2:: The TSF shall support the capability of {empty}[selection: [.underline]#importing keys/secrets into the TOE, causing the TOE to generate keys/secrets]# upon request of [_assignment: authorized subject_].
+FCS_STG_EXT.1.2:: The TSF shall support the capability of {empty}[selection: _importing keys/secrets into the TOE, causing the TOE to generate keys/secrets_] upon request of [assignment: _authorized subject_].
 
-FCS_STG_EXT.1.3:: The TSF shall have the capability to allow only the user that [selection: imported the key/secret, caused the key/secret to be generated] to use the key/secret. Exceptions may only be explicitly authorized by [_assignment: authorized subject_].
+FCS_STG_EXT.1.3:: The TSF shall have the capability to allow only the user that [selection: _imported the key/secret, caused the key/secret to be generated_] to use the key/secret. Exceptions may only be explicitly authorized by [assignment: _authorized subject_].
 
-FCS_STG_EXT.1.4:: The TSF shall have the capability to allow only the user that {empty}[selection: [.underline]#imported the key/secret, caused the key/secret to be generated]# to use the key/secret. Exceptions may only be explicitly authorized by [_assignment: authorized subject_].
+FCS_STG_EXT.1.4:: The TSF shall have the capability to allow only the user that {empty}[selection: _imported the key/secret, caused the key/secret to be generated_] to use the key/secret. Exceptions may only be explicitly authorized by [assignment: _authorized subject_].
 
-FCS_STG_EXT.1.5:: The TSF shall allow only the user that {empty}[selection: [.underline]#imported the key/secret, caused the key/secret to be generated]# to request that the key/secret be destroyed. Exceptions may only be explicitly authorized by [_assignment: authorized subject_].
+FCS_STG_EXT.1.5:: The TSF shall allow only the user that {empty}[selection: _imported the key/secret, caused the key/secret to be generated_] to request that the key/secret be destroyed. Exceptions may only be explicitly authorized by [assignment: _authorized subject_].
 
 === Class FDP: User Data Protection
 ==== FDP_ETC_EXT Export from the TOE
@@ -3268,7 +3268,7 @@ Hierarchical to:: No other components.
 
 Dependencies:: FCS_COP.1 Cryptographic Operation
 [vertical]
-FDP_ETC_EXT.2.1:: The TSF shall propagate only SDO references, wrapped authorization data, and wrapped SDOs such that only {empty}[selection: [.underline]#the TOE, authorized users]# can access them.
+FDP_ETC_EXT.2.1:: The TSF shall propagate only SDO references, wrapped authorization data, and wrapped SDOs such that only {empty}[selection: _the TOE, authorized users_] can access them.
 
 ==== FDP_FRS_EXT Factory Reset
 
@@ -3318,7 +3318,7 @@ Hierarchical to:: No other components.
 
 Dependencies:: FDP_FRS_EXT.2 Factory Reset Behavior
 [vertical]
-FDP_FRS_EXT.1.1:: The TSF shall permit a factory reset of the TOE upon: [_assignment: conditions under which a factory reset is authorized_].
+FDP_FRS_EXT.1.1:: The TSF shall permit a factory reset of the TOE upon: [assignment: _conditions under which a factory reset is authorized_].
 
 *FDP_FRS_EXT.2 Factory Reset Behavior*
 [horizontal]
@@ -3326,7 +3326,7 @@ Hierarchical to:: No other components.
 
 Dependencies:: FDP_FRS_EXT.1 Factory Reset
 [vertical]
-FDP_FRS_EXT.2.1:: Upon initiation of a factory reset, the TSF shall destroy [_assignment: TSF data that is destroyed by factory reset_] and restore the following TSF data to their factory settings: [_assignment: TSF data that is restored by factory reset_].
+FDP_FRS_EXT.2.1:: Upon initiation of a factory reset, the TSF shall destroy [assignment: _TSF data that is destroyed by factory reset_] and restore the following TSF data to their factory settings: [assignment: _TSF data that is restored by factory reset_].
 
 ==== FDP_ITC_EXT Import from Outside of the TOE
 
@@ -3373,13 +3373,13 @@ Dependencies:: FCS_COP.1 Cryptographic Operation +
 FTP_ITE_EXT.1 Encrypted Data Communications, or +
 FTP_ITP_EXT.1 Physically Protected Channel]
 [vertical]
-FDP_ITC_EXT.1.1:: The TSF shall support importing SDEs using [_assignment: import method that maintains confidentiality and integrity of imported data_].
+FDP_ITC_EXT.1.1:: The TSF shall support importing SDEs using [assignment: _import method that maintains confidentiality and integrity of imported data_].
 
-FDP_ITC_EXT.1.2:: The TSF shall verify the integrity of the SDE using [_assignment: method of_ _integrity verification_].
+FDP_ITC_EXT.1.2:: The TSF shall verify the integrity of the SDE using [assignment: _method of integrity verification_].
 
 FDP_ITC_EXT.1.3:: The TSF shall ignore any security attributes associated with the user data when imported from outside the TOE.
 
-FDP_ITC_EXT.1.4:: The TSF shall bind SDEs to security attributes using [_assignment: list of ways the TSF generates security attributes and binds them to the SDEs_].
+FDP_ITC_EXT.1.4:: The TSF shall bind SDEs to security attributes using [assignment: _list of ways the TSF generates security attributes and binds them to the SDEs_].
 
 *FDP_ITC_EXT.2 Parsing of SDOs*
 [horizontal]
@@ -3390,9 +3390,9 @@ Dependencies:: FCS_COP.1 Cryptographic Operation +
 FTP_ITE_EXT.1 Encrypted Data Communications, or +
 FTP_ITP_EXT.1 Physically Protected Channel]
 [vertical]
-FDP_ITC_EXT.2.1:: The TSF shall support importing [.underline]#SDOs using [_assignment: import method that maintains confidentiality and integrity of imported data_]#.
+FDP_ITC_EXT.2.1:: The TSF shall support importing SDOs using [assignment: _import method that maintains confidentiality and integrity of imported data_].
 
-FDP_ITC_EXT.2.2:: The TSF shall verify the integrity of the SDO using [_assignment: method of_ _integrity verification_].
+FDP_ITC_EXT.2.2:: The TSF shall verify the integrity of the SDO using [assignment: _method of integrity verification_].
 
 FDP_ITC_EXT.2.3:: The TSF shall use the security attributes associated with the imported user data.
 
@@ -3451,11 +3451,11 @@ Hierarchical to:: No other components.
 
 Dependencies:: No dependencies.
 [vertical]
-FIA_AFL_EXT.1.1:: The TSF shall maintain {empty}[selection: [.underline]#a unique counter for [_assignment: multiple separate objects each requiring authorization_], one global counter covering [_assignment: objects requiring authorization_]]#, called the failed authorization attempt counters, that counts of the number of unsuccessful authorization attempts that occur related to authorizing access to these objects.
+FIA_AFL_EXT.1.1:: The TSF shall maintain {empty}[selection: _a unique counter for [assignment: multiple separate objects each requiring authorization], one global counter covering [assignment: objects requiring authorization]_], called the failed authorization attempt counters, that counts of the number of unsuccessful authorization attempts that occur related to authorizing access to these objects.
 
-FIA_AFL_EXT.1.2:: The TSF shall maintain a [.underline]#[selection, choose one of: static, administrator configurable variable]# threshold of the minimal acceptable number of unsuccessful authorization attempts that occur related to authorizing access to these objects.
+FIA_AFL_EXT.1.2:: The TSF shall maintain a [selection, choose one of: _static, administrator configurable variable_] threshold of the minimal acceptable number of unsuccessful authorization attempts that occur related to authorizing access to these objects.
 
-FIA_AFL_EXT.1.3:: When the failed authorization attempt counters [.underline]#[selection, choose one of: meets, surpasses]# the threshold for unsuccessful authorization attempts, the TSF shall [_assignment: perform action that temporarily or permanently prevents access to the object_] for these objects.
+FIA_AFL_EXT.1.3:: When the failed authorization attempt counters [selection, choose one of: _meets, surpasses_] the threshold for unsuccessful authorization attempts, the TSF shall [assignment: _perform action that temporarily or permanently prevents access to the object_] for these objects.
 
 FIA_AFL_EXT.1.4:: The TSF shall increment the failed authorization attempt counter before it verifies the authorization.
 
@@ -3556,7 +3556,7 @@ Hierarchical to:: No other components.
 
 Dependencies:: No dependencies.
 [vertical]
-FPT_MFW_EXT.1.1:: The TSF shall be maintained as {empty}[selection: [.underline]#immutable, mutable]# firmware.
+FPT_MFW_EXT.1.1:: The TSF shall be maintained as {empty}[selection: _immutable, mutable_] firmware.
 
 *FPT_MFW_EXT.2 Basic Firmware Integrity*
 [horizontal]
@@ -3661,7 +3661,7 @@ Dependencies:: No dependencies.
 [vertical]
 FPT_PRO_EXT.1.1:: The TSF shall contain an SDO that contains the identity of the Root of Trust.
 
-FPT_PRO_EXT.1.2:: The TSF shall maintain Root of Trust data as {empty}[selection: [.underline]#immutable, mutable if and only if its mutability is controlled by a unique identifiable owner]#.
+FPT_PRO_EXT.1.2:: The TSF shall maintain Root of Trust data as {empty}[selection: _immutable, mutable if and only if its mutability is controlled by a unique identifiable owner_].
 
 *FPT_PRO_EXT.2 Data Integrity Measurements*
 [horizontal]
@@ -3671,7 +3671,7 @@ Dependencies:: No dependencies.
 [vertical]
 FPT_PRO_EXT.2.1:: The TSF shall be able to quantify the integrity of the data protected by the TOE by generating integrity measurements and assertions.
 
-FPT_PRO_EXT.2.2:: The TSF shall accumulate platform characteristics using a consistent [_assignment: description of process for accumulating platform characteristics_] process in which verified quantifiable measurements and assertions are accumulated by the RoT for Measurement to prove the integrity of its SDOs.
+FPT_PRO_EXT.2.2:: The TSF shall accumulate platform characteristics using a consistent [assignment: _description of process for accumulating platform characteristics_] process in which verified quantifiable measurements and assertions are accumulated by the RoT for Measurement to prove the integrity of its SDOs.
 
 ==== FPT_ROT_EXT Root of Trust Services
 
@@ -3717,7 +3717,7 @@ Hierarchical to:: No other components.
 
 Dependencies:: FPT_PRO_EXT.1 Root of Trust
 [vertical]
-FPT_ROT_EXT.1.1:: The TSF shall provide a Root of Trust for Storage, a Root of Trust for Authorization, and {empty}[selection: [.underline]#Root of Trust for Measurement, Root of Trust for Reporting, no others]#.
+FPT_ROT_EXT.1.1:: The TSF shall provide a Root of Trust for Storage, a Root of Trust for Authorization, and {empty}[selection: _Root of Trust for Measurement, Root of Trust for Reporting, no others_].
 
 *FPT_ROT_EXT.2 Root of Trust for Storage*
 [horizontal]
@@ -3735,7 +3735,7 @@ Dependencies:: FCS_COP.1 Cryptographic Operation +
 FPT_PRO_EXT.1 Root of Trust +
 FPT_ROT_EXT.1 Root of Trust Services
 [vertical]
-FPT_ROT_EXT.3.1:: The TSF shall be able to attest to a state as represented by platform characteristics with a Root of Trust for Reporting mechanism that uses for its identity {empty}[selection: [.underline]#a cryptographically verifiable identity in FPT_PRO_EXT.1, an alias key bound to the cryptographically verifiable identity in FPT_PRO_EXT.1]# and using a signature algorithm as specified in FCS_COP.1.
+FPT_ROT_EXT.3.1:: The TSF shall be able to attest to a state as represented by platform characteristics with a Root of Trust for Reporting mechanism that uses for its identity {empty}[selection: _a cryptographically verifiable identity in FPT_PRO_EXT.1, an alias key bound to the cryptographically verifiable identity in FPT_PRO_EXT.1_] and using a signature algorithm as specified in FCS_COP.1.
 
 ==== FPT_STM_EXT Reliable Time Counting
 
@@ -3775,7 +3775,7 @@ Dependencies:: No dependencies.
 
 FPT_STM_EXT.1 Reliable Time Counting
 
-FPT_STM_EXT.1.1:: The TSF shall be able to provide a reliable [*selection*: internal time stamp, external time stamp, monotonically increasing counter] to measure the passage of time.
+FPT_STM_EXT.1.1:: The TSF shall be able to provide a reliable [selection: _internal time stamp, external time stamp, monotonically increasing counter_] to measure the passage of time.
 
 === Class FTP: Trusted Path/Channels
 ==== FTP_CCMP_EXT CCM Protocol
@@ -3813,7 +3813,7 @@ Hierarchical to:: No other components.
 
 Dependencies:: FCS_COP.1 Cryptographic Operation
 [vertical]
-FTP_CCMP_EXT.1.1:: The TSF shall implement CCMP using AES in CCM mode and key size [_assignment: key sizes_] as defined in [_assignment: list of standards_].
+FTP_CCMP_EXT.1.1:: The TSF shall implement CCMP using AES in CCM mode and key size [assignment: _key sizes_] as defined in [assignment: _list of standards_].
 
 FTP_CCMP_EXT.1.2:: The TSF shall discard incoming messages if authentication fails.
 
@@ -3854,7 +3854,7 @@ Hierarchical to:: No other components.
 
 Dependencies:: FCS_COP.1 Cryptographic Operation
 [vertical]
-FTP_GCMP_EXT.1.1:: The TSF shall implement GCMP using AES in GCM mode and key size [_assignment: key sizes_] as defined in [_assignment: list of standards_].
+FTP_GCMP_EXT.1.1:: The TSF shall implement GCMP using AES in GCM mode and key size [assignment: _key sizes_] as defined in [assignment: _list of standards_].
 
 FTP_GCMP_EXT.1.2:: The TSF shall discard incoming messages if authentication fails.
 
@@ -3895,7 +3895,7 @@ Hierarchical to:: No other components.
 
 Dependencies:: FCS_COP.1 Cryptographic Operation
 [vertical]
-FTP_ITC_EXT.1.1:: The TSF shall use [_assignment: cryptographic protocol_] protocol to provide a communication channel between itself and [_assignment: list of entities external to the TOE_] that protects channel data from disclosure and ensures the integrity of channel data.
+FTP_ITC_EXT.1.1:: The TSF shall use [assignment: _cryptographic protocol_] protocol to provide a communication channel between itself and [assignment: _list of entities external to the TOE_] that protects channel data from disclosure and ensures the integrity of channel data.
 
 ==== FTP_ITE_EXT Encrypted Data Communications
 
@@ -3932,7 +3932,7 @@ Hierarchical to:: No other components.
 
 Dependencies:: FCS_COP.1 Cryptographic Operation
 [vertical]
-FTP_ITE_EXT.1.1:: The TSF shall encrypt data for transfer between the TOE and [_assignment: list of entities external to the TOE_] using a cryptographic algorithm and key size as specified in FCS_COP.1, and using [_assignment: keys, identified by how they are generated by or imported into the TOE_].
+FTP_ITE_EXT.1.1:: The TSF shall encrypt data for transfer between the TOE and [assignment: _list of entities external to the TOE_] using a cryptographic algorithm and key size as specified in FCS_COP.1, and using [assignment: _keys, identified by how they are generated by or imported into the TOE_].
 
 ==== FTP_ITP_EXT Physically Protected Channel
 
@@ -3969,7 +3969,7 @@ Hierarchical to:: No other components.
 
 Dependencies:: No dependencies.
 [vertical]
-FTP_ITP_EXT.1.1:: The TSF shall provide a physically protected communication channel between itself and [_assignment: list of other IT entities within the same platform_].
+FTP_ITP_EXT.1.1:: The TSF shall provide a physically protected communication channel between itself and [assignment: _list of other IT entities within the same platform_].
 
 [appendix]
 == Entropy Documentation and Assessment


### PR DESCRIPTION
The rules for formatting in CC:2022 seem to be as follows:
- Italic is used for both assignment and selection
- The prefix "assignment: " and "selection: " are not formatted at all, nor are the surrounding brackets []
- For nested assignments / selections, the whole nested entry is in italic

Also fixes a forgotten selection option for FCS_CKM_EXT.8 (PBKDF) output length.

Closes #334