### PR TITLE
Remove Apple from list

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -22,8 +22,6 @@ This collaborative Protection Profile (cPP) was developed by the {iTC-longame} i
 [.text-center]
 *Industry*
 [.text-center]
-Apple Inc.
-[.text-center]
 Google, LLC.
 [.text-center]
 Samsung Electronics Co., Ltd.


### PR DESCRIPTION
Per request from Apple legal counsel, remove Apple from the list of acknowledgements for the document.

--------

Brian,

Thank you very much for this offer, Brian.  We would prefer to be removed given our current status.  Thank you for doing this before publishing the next draft.

Jonathan

On Aug 8, 2024, at 11:09 AM, Brian Wood <> wrote:

Sure, we can do that, but given your heavy initial participation, it is still valid that you can be listed as such going forward (the v2.0 we are working on is still based on that work and has a lot of original content from it).

There isn't a problem with doing it, but contributions can be for the past, not just the current.

Please confirm that you do still want to remove it (based on this), and I will do so before the next draft is published.

Thank you

Brian Wood (chair of the iTC)

On Thu, Aug 8, 2024 at 2:00 PM Jonathan Brown <> wrote:
Dear iTC-DSC,

I write to notify you that Shawn Geddis is no longer with Apple.  Shawn’s earlier involvement while he was at Apple presumably led to Apple’s name being listed as a contributor to Protection Profile Version 2.0-PRD-1, published October 31, 2023, https://dsc-itc.github.io//v2/2.0PRD-2/cPP-DSC-v2.0PRD-2.pdf.  Can you please confirm that Apple will not be listed as a contributor going forward (unless Apple participates in the future)?  Thank you.