### PR TITLE
FCS_CKM.2 changes

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -456,22 +456,18 @@ The evaluator shall iterate through each of the methods selected by the ST and p
 The evaluator shall iterate through each of the methods selected by the ST and confirm that the KMD describes the applicable selected methods.
 
 ===== FCS_CKM.2 Cryptographic Key Distribution
-[IMPORTANT]
-====
-This has been changed from establishment to distribution
-====
 
 ====== TSS
 
-The evaluator shall examine the TSS to ensure that ST supports at least one key establishment scheme. The evaluator also ensures that for each key establishment scheme selected by the ST in FCS_CKM.2.1 it also supports one or more corresponding methods selected in FCS_COP.1/KAT. If the ST selects RSA in FCS_CKM.2.1, then the TOE must support one or more of "KAS1," or "KAS2," "KTS-OAEP," from FCS_COP.1/KAT. If the ST selects elliptic curve-based, then the TOE must support one or more of "ECDH-NIST" or "ECDH-BPC" from FCS_COP.1/KAT. If the ST selects Diffie-Hellman-based key establishment, then the TOE must support "DH" from FCS_COP.1/KAT.
+The evaluator shall examine the TSS to determine whether it describes the supported methods for key distribution functionality consistent with the claim(s) made in FCS_CKM.2.1. The evaluator shall confirm that the matching SFRs are included in the ST based on the claim(s) made in FCS_CKM.2.1.
 
 ====== AGD
 
-The evaluator shall verify that the guidance instructs the administrator how to configure the TOE to use the selected key establishment scheme .
+The evaluator shall verify that the guidance instructs the administrator how to configure the TOE to use the selected key distribution scheme.
 
 ====== Test
 
-Testing for this SFR is performed under the corresponding functions in FCS_COP.1/KAT.
+Testing for this SFR is performed under the corresponding functions based on the selection(s) made in the ST.
 
 ====== KMD
 

--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -459,11 +459,11 @@ The evaluator shall iterate through each of the methods selected by the ST and c
 
 ====== TSS
 
-The evaluator shall examine the TSS to determine whether it describes the supported methods for key distribution functionality consistent with the claim(s) made in FCS_CKM.2.1. The evaluator shall confirm that the matching SFRs are included in the ST based on the claim(s) made in FCS_CKM.2.1.
+The evaluator shall examine the TSS to determine whether it describes the supported methods for key distribution functionality consistent with the selection(s) made in FCS_CKM.2.1. The evaluator shall confirm that the matching SFRs are included in the ST based on the selection(s) made in FCS_CKM.2.1.
 
 ====== AGD
 
-The evaluator shall verify that the guidance instructs the administrator how to configure the TOE to use the selected key distribution scheme.
+The evaluator shall verify that the guidance instructs the administrator how to configure the TOE to use the selected key distribution method.
 
 ====== Test
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -676,7 +676,7 @@ _If [.underline]#Derived keys generated in accordance with FCS_CKM_EXT.8# is sel
 
 FCS_CKM.2 Cryptographic Key Distribution
 
-FCS_CKM.2.1:: The TSF shall distribute cryptographic keys in accordance with a specified cryptographic key distribution method [*selection*: _key encapsulation as specified in FCS_COP.1/KeyEncap, key wrapping as specified in FCS_COP.1/KeyWrap or FCS_COP.1/AEAD, physically protected channels as specified in FTP_ITP_EXT.1, encrypted data buffers as specified in FTP_ITE_EXT.1, cryptographically protected data channels as specified in FTP_ITC_EXT.1_] that meets the following: [_none_].
+FCS_CKM.2.1:: The TSF shall distribute cryptographic keys in accordance with a specified cryptographic key distribution method [*selection*: _key encapsulation as specified in FCS_COP.1/KeyEncap, key wrapping as specified in FCS_COP.1/KeyWrap, key wrapping as specified in FCS_COP.1/AEAD, physically protected channels as specified in FTP_ITP_EXT.1, encrypted data buffers as specified in FTP_ITE_EXT.1, cryptographically protected data channels as specified in FTP_ITC_EXT.1_] that meets the following: [_none_].
 
 _Application Note {counter:remark_count}_:: _This SFR assumes there is no pre-shared key between the parties._
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -676,9 +676,9 @@ _If [.underline]#Derived keys generated in accordance with FCS_CKM_EXT.8# is sel
 
 FCS_CKM.2 Cryptographic Key Distribution
 
-FCS_CKM.2.1:: The TSF shall distribute cryptographic keys in accordance with a specified cryptographic key distribution method [*selection*: _key encapsulation, key wrapping, physically protected channels as specified in FTP_ITP_EXT.1, encrypted data buffers as specified in FTP_ITE_EXT.1, cryptographically protected data channels as specified in FTP_ITC_EXT.1_] that meets the following: [_none_].
+FCS_CKM.2.1:: The TSF shall distribute cryptographic keys in accordance with a specified cryptographic key distribution method [*selection*: _key encapsulation as specified in FCS_COP.1/KeyEncap, key wrapping as specified in FCS_COP.1/KeyWrap or FCS_COP.1/AEAD, physically protected channels as specified in FTP_ITP_EXT.1, encrypted data buffers as specified in FTP_ITE_EXT.1, cryptographically protected data channels as specified in FTP_ITC_EXT.1_] that meets the following: [_none_].
 
-_Application Note {counter:remark_count}_:: _This SFR assumes there is no pre-shared key between the parties. If key encapsulation is chosen, then FCS_COP.1/KeyEncap SHALL be included which specifies the relevant list of standards. If key wrapping is chosen, then FCS_COP.1/KeyWrap or FCS_COP.1/AEAD SHALL be included which specifies the relevant list of standards._
+_Application Note {counter:remark_count}_:: _This SFR assumes there is no pre-shared key between the parties._
 
 ==== FCS_CKM.6 Timing and event of cryptographic key destruction
 


### PR DESCRIPTION
This is to clear out a note that FCS_CKM.2 had been left from the old requirement EA and needed to be updated.

At the same time the cPP requirement was changed to explicitly note the SFRs that need to be specified for encapsulation and wrapping.