### PR TITLE
updates to the dependency table

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -4008,7 +4008,7 @@ More specifically, all entropy source health tests and their rationale will be d
 [appendix]
 == SFR Dependencies Analysis
 
-The dependencies between SFRs implemented by the TOE are addressed as follows.
+The dependencies between SFRs implemented by the TOE are addressed as follows. Dependencies listed in _italics_ are DSC-specific dependencies.
 
 .SFR Dependencies Rationale for Mandatory SFRs
 [cols=".^1,.^2,.^3",options="header"]
@@ -4019,36 +4019,44 @@ The dependencies between SFRs implemented by the TOE are addressed as follows.
 |Rationale Statement
 
 |FCS_CKM.1 
-|[FCS_CKM.2, FCS_CKM.5, FCS_CKM_EXT.7 or FCS_COP.1] 
+|[_FCS_CKM.1/AKG, FCS_CKM.1/SKG_, FCS_CKM.2, FCS_CKM.5, FCS_CKM_EXT.7, _FCS_CKM_EXT.8_ or FCS_COP.1] 
 
 [FCS_RBG.1 or FCS_RNG.1]
 
-FCS_CKM.6 
-|FCS_CKM.2, FCS_CKM.6, FCS_CKM_EXT.7, FCS_COP.1 and FCS_RBG.1 are required by the PP.
+FCS_CKM.6
+|FCS_CKM.2, FCS_CKM.6, FCS_CKM_EXT.7, FCS_COP.1 and FCS_RBG.1 are required by the PP. 
+
+FCS_CKM.1/AKG, FCS_CKM.1/SKG and FCS_CKM_EXT.8 are selection-based requirements to support how keys are generated.
 
 |FCS_CKM.2
-|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1 or FCS_CKM.5] 
+|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5 or _FCS_COP.1_] 
 
 |FCS_CKM.1 is required by the PP. FDP_ITC_EXT.1 and FDP_ITC_EXT.2 are also required by the PP and equivalent to FDP_ITC.1 in this case because they all relate to a mechanism by which key data can be imported into the TSF.
 
-|FCS_CKM_EXT.7 
-|[FDP_ITC.1, FDP_ITC.2, or FCS_CKM.1] 
-
-FCS_CKM.6 
-|FCS_CKM.1 and FCS_CKM.6 are required by the PP. FDP_ITC_EXT.1 and FDP_ITC_EXT.2 are also required by the PP and equivalent to FDP_ITC.1 in this case because they all relate to a mechanism by which key data can be imported into the TSF.
+FCS_COP.1 can be used as an alternative for encapsulating or wrapping keys for cases when transport itself may not be included in the TSF.
 
 |FCS_CKM.6 
-|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, or FCS_CKM.5] 
-|FCS_CKM.1 is required by the PP. FDP_ITC_EXT.1 and FDP_ITC_EXT.2 are also required by the PP and equivalent to FDP_ITC.1 in this case because they all relate to a mechanism by which key data can be imported into the TSF.
+|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM_EXT.3, FCS_CKM.5, FCS_CKM_EXT.7, FCS_CKM_EXT.8 or FCS_CKM_EXT.9] 
+|FCS_CKM.1 and FCS_CKM_EXT.7 are required by the PP. FDP_ITC_EXT.1 and FDP_ITC_EXT.2 are also required by the PP and equivalent to FDP_ITC.1 in this case because they all relate to a mechanism by which key data can be imported into the TSF.
 
-|FCS_COP.1/Hash 
-|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, or FCS_CKM.5] 
+FCS_CKM_EXT.3, FCS_CKM.5 and FCS_CKM_EXT.8 are selection-based requirements that can be included if supported by the TSF.
+
+|FCS_CKM_EXT.7 
+|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.8]
+
+[FCS_CKM.2 or FCS_COP.1]
 
 FCS_CKM.6 
-|FCS_CKM.1 and FCS_CKM.6 are required by the PP. FDP_ITC_EXT.1 and FDP_ITC_EXT.2 are also required by the PP and equivalent to FDP_ITC.1 in this case because they all relate to a mechanism by which key data can be imported into the TSF.
+|FCS_CKM.1, FCS_CKM.2 and FCS_CKM.6 are required by the PP. FDP_ITC_EXT.1 and FDP_ITC_EXT.2 are also required by the PP and equivalent to FDP_ITC.1 in this case because they all relate to a mechanism by which key data can be imported into the TSF.
+
+Some FCS_COP.1 iterations are required by the PP while additional iterations can be included when supported by the TSF.
+
+|FCS_COP.1/Hash 
+|No dependencies.
+|N/A
 
 |FCS_COP.1/KeyedHash 
-|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, or FCS_CKM.5] 
+|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5] 
 
 FCS_CKM.6 
 |FCS_CKM.1 and FCS_CKM.6 are required by the PP. FDP_ITC_EXT.1 and FDP_ITC_EXT.2 are also required by the PP and equivalent to FDP_ITC.1 in this case because they all relate to a mechanism by which key data can be imported into the TSF.
@@ -4072,10 +4080,12 @@ FCS_CKM.6
 |FCS_CKM.1 and FCS_CKM.6 are required by the PP. FDP_ITC_EXT.1 and FDP_ITC_EXT.2 are also required by the PP and equivalent to FDP_ITC.1 in this case because they all relate to a mechanism by which key data can be imported into the TSF.
 
 |FCS_COP.1/SKC 
-|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, or FCS_CKM.5] 
+|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7 or FCS_CKM_EXT.8] 
 
 FCS_CKM.6 
-|FCS_CKM.1 and FCS_CKM.6 are required by the PP. FDP_ITC_EXT.1 and FDP_ITC_EXT.2 are also required by the PP and equivalent to FDP_ITC.1 in this case because they all relate to a mechanism by which key data can be imported into the TSF.
+
+FCS_OTV_EXT.1
+|FCS_CKM.1, FCS_CKM.6, FCS_CKM_EXT.7 and FCS_OTV_EXT.1 are required by the PP. FDP_ITC_EXT.1 and FDP_ITC_EXT.2 are also required by the PP and equivalent to FDP_ITC.1 in this case because they all relate to a mechanism by which key data can be imported into the TSF. FCS_CKM.5 and FCS_CKM_EXT.8 can be included based on support in the TSF.
 
 |FCS_RBG.1 
 |FCS_COP.1 
@@ -4299,14 +4309,12 @@ FDP_SDC.2
 |All of FCS_CKM.1, FCS_COP.1, and FDP_SDC.2 are required by the PP.
 
 |FCS_CKM_EXT.8 
-|[FDP_ITC.1, FDP_ITC.2] 
-
-[FCS_CKM.2 or FCS_COP.1 or FCS_CKM_EXT.7]
+|[FCS_CKM.2 or FCS_COP.1 or FCS_CKM_EXT.7]
 
 FCS_COP.1/KeyedHash
 
 FCS_CKM.6 
-|FCS_CKM.1/KeyedHash and FCS_CKM.6 are required by the PP. FDP_ITC_EXT.1 and FDP_ITC_EXT.2 are also required by the PP and equivalent to FDP_ITC.1 in this case because they all relate to a mechanism by which key data can be imported into the TSF.
+|FCS_CKM.1/KeyedHash and FCS_CKM.6 are required by the PP.
 
 |FCS_COP.1/AEAD
 |[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7, FCS_CKM_EXT.8]

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -4004,8 +4004,6 @@ More specifically, all entropy source health tests and their rationale will be d
 [appendix]
 == SFR Dependencies Analysis
 
-The dependencies between SFRs implemented by the TOE are addressed as follows. Dependencies listed in _italics_ are DSC-specific dependencies.
-
 .SFR Dependencies Rationale for Mandatory SFRs
 [cols=".^1,.^2,.^3",options="header"]
 |===
@@ -4016,8 +4014,6 @@ The dependencies between SFRs implemented by the TOE are addressed as follows. D
 
 |FCS_CKM.1 
 |[FCS_CKM.1/AKG, FCS_CKM.1/SKG, FCS_CKM.2, FCS_CKM.5, FCS_CKM_EXT.7, FCS_CKM_EXT.8 or FCS_COP.1] 
-
-FCS_CKM.3
 
 [FCS_RBG.1 or FCS_RNG.1]
 
@@ -4061,12 +4057,14 @@ FCS_COP.1/KeyWrap - (selection-based SFR) included
 FCS_COP.1/AEAD - (selection-based SFR) included
 
 |FCS_CKM.6 
-|[FDP_ITC.1, FDP_ITC.2 or FCS_CKM.1] 
+|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1 or FCS_CKM.5] 
 |FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
 
 FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
 
 FCS_CKM.1 - included
+
+FCS_CKM.5 - (selection-based SFR) included
 
 |FCS_CKM_EXT.7 
 |[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.8]
@@ -4097,10 +4095,6 @@ FCS_CKM.6 - included
 |FCS_COP.1/KeyedHash 
 |[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7 or FCS_CKM_EXT.8] 
 
-FCS_COP.1/Hash
-
-FCS_CKM.3
-
 FCS_CKM.6 
 |FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
 
@@ -4110,64 +4104,14 @@ FCS_CKM.1 - included
 
 FCS_CKM.5 - (selection-based SFR) included
 
-FCS_CKM_EXT.7 - (selection-based SFR) included
+FCS_CKM_EXT.7 - included
 
 FCS_CKM_EXT.8 - (selection-based SFR) included
-
-FCS_COP.1/Hash - included
-
-FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
-
-FCS_CKM.6 - included
-
-|FCS_COP.1/KeyEncap
-|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7, or FCS_CKM_EXT.8]
-
-FCS_CKM.3
-
-FCS_CKM.6 
-|FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
-
-FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
-
-FCS_CKM.1 - included
-
-FCS_CKM.5 - (selection-based SFR) included
-
-FCS_CKM_EXT.7 - (selection-based SFR) included
-
-FCS_CKM_EXT.8 - (selection-based SFR) included
-
-FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
-
-FCS_CKM.6 - included
-
-|FCS_COP.1/KeyWrap
-|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7, or FCS_CKM_EXT.8]
-
-FCS_CKM.3
-
-FCS_CKM.6 
-|FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
-
-FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
-
-FCS_CKM.1 - included
-
-FCS_CKM.5 - (selection-based SFR) included
-
-FCS_CKM_EXT.7 - (selection-based SFR) included
-
-FCS_CKM_EXT.8 - (selection-based SFR) included
-
-FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
 
 FCS_CKM.6 - included
 
 |FCS_COP.1/SigGen 
 |[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1/AKG, or FCS_CKM.5] 
-
-FCS_CKM.3
 
 FCS_CKM.6 
 |FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
@@ -4177,8 +4121,6 @@ FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data
 FCS_CKM.1/AKG - (selection-based SFR) included
 
 FCS_CKM.5 - (selection-based SFR) included
-
-FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
 
 FCS_CKM.6 - included
 
@@ -4196,12 +4138,8 @@ FCS_CKM.5 - (selection-based SFR) included
 
 FCS_CKM.6 - included
 
-FCS_CKM.3 is not necessary as this is only verifying a signature, not generating or storing keys
-
 |FCS_COP.1/SKC 
 |[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7 or FCS_CKM_EXT.8] 
-
-FCS_CKM.3
 
 FCS_CKM.6 
 
@@ -4214,11 +4152,9 @@ FCS_CKM.1 - included
 
 FCS_CKM.5 - (selection-based SFR) included
 
-FCS_CKM_EXT.7 - (selection-based SFR) included
+FCS_CKM_EXT.7 - included
 
 FCS_CKM_EXT.8 - (selection-based SFR) included
-
-FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
 
 FCS_CKM.6 - included
 
@@ -4231,9 +4167,9 @@ FPT_FLS.1
 
 FPT_TST.1
 
-|FCS_RBG.2 - (selection-based SFR) included
+|FCS_RBG.2 - (optional SFR) included
 
-FCS_RBG.3 - (selection-based SFR) included
+FCS_RBG.3 - (optional SFR) included
 
 FPT_FLS.1 - included
 
@@ -4265,7 +4201,7 @@ FMT_MSA.3 - included
 
 |FDP_FRS_EXT.1 
 |FDP_FRS_EXT.2 
-|FDP_FRS_EXT.2 - (optional-based SFR) included
+|FDP_FRS_EXT.2 - (optional SFR) included
 
 |FDP_ITC_EXT.1 
 |FCS_COP.1 
@@ -4419,7 +4355,7 @@ FMT_SMR.1 - included
 FCS_RBG.5 
 |FCS_RBG.1 - included
 
-FCS_RBG.5 - (selection-based SFR) included
+FCS_RBG.5 - (optional SFR) included
 
 |FCS_RBG.5
 |FCS_RBG.1
@@ -4427,11 +4363,11 @@ FCS_RBG.5 - (selection-based SFR) included
 [FCS_RBG.2 or FCS_RBG.3 or RCS_RBG.4]
 |FCS_RBG.1 - included
 
-FCS_RBG.2 - (selection-based SFR) included
+FCS_RBG.2 - (optional SFR) included
 
-FCS_RBG.3 - (selection-based SFR) included
+FCS_RBG.3 - (optional SFR) included
 
-FCS_RBG.4 - (selection-based SFR) included
+FCS_RBG.4 - (optional SFR) included
 
 |FCS_RBG.6 
 |FCS_RBG.1 
@@ -4453,9 +4389,9 @@ FPT_PRO_EXT.1
 FPT_ROT_EXT.1 
 |FCS_COP.1- included
 
-FPT_PRO_EXT.1- included
+FPT_PRO_EXT.1 - included
 
-FPT_ROT_EXT.1- included
+FPT_ROT_EXT.1 - included
 
 |===
 
@@ -4473,14 +4409,10 @@ FPT_ROT_EXT.1- included
 
 [FCS_RBG.1 or FCS_RNG.1]
 
-FCS_CKM.3
-
 FCS_CKM.6 
 |FCS_CKM.2 - included
 
-FCS_CKM.5 - included
-
-FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
+FCS_CKM.5 - (selection-based SFR) included
 
 FCS_COP.1 - included
 
@@ -4495,16 +4427,12 @@ FCS_CKM.6 - included
 
 [FCS_RBG.1 or FCS_RNG.1]
 
-FCS_CKM.3
-
 FCS_CKM.6 
 |FCS_CKM.2 - included
 
-FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
+FCS_CKM.5 - (selection-based SFR) included
 
-FCS_CKM.5 - included
-
-FCS_CKM_EXT.7 - (selection-based SFR) included
+FCS_CKM_EXT.7 - included
 
 FCS_COP.1 - included
 
@@ -4522,7 +4450,7 @@ FCS_CKM.6 - included
 FCS_CKM.6 
 |FCS_CKM.1 - included
 
-FCS_CKM.5 - included
+FCS_CKM.5 - (selection-based SFR) included
 
 FCS_CKM_EXT.8 - (selection-based SFR) included
 
@@ -4530,7 +4458,7 @@ FCS_COP.1/KeyEncap - (selection-based SFR) included
 
 FCS_COP.1/KeyWrap - (selection-based SFR) included
 
-FCS_COP.1/SKC - (selection-based SFR) included
+FCS_COP.1/SKC - included
 
 FCS_COP.1/AEAD - (selection-based SFR) included
 
@@ -4542,7 +4470,7 @@ FCS_CKM.6 - included
 FCS_COP.1 
 
 FCS_CKM.6
-|FCS_CKM.1 - included
+|FCS_CKM.2 - included
 
 FCS_COP.1 - included
 
@@ -4556,18 +4484,14 @@ FCS_COP.1/KeyedHash
 FCS_CKM.6 
 |FCS_CKM.2 - included
 
-FCS_COP.1 - included
+FCS_CKM_EXT.7 - included
 
-FCS_CKM_EXT.7 - (selection-based SFR) included
-
-FCS_CKM.1/KeyedHash - included
+FCS_COP.1/KeyedHash - included
 
 FCS_CKM.6 - included
 
 |FCS_COP.1/AEAD
 |[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7 or FCS_CKM_EXT.8]
-
-FCS_CKM.3
 
 FCS_CKM.6
 
@@ -4580,11 +4504,9 @@ FCS_CKM.1 - included
 
 FCS_CKM.5 - (selection-based SFR) included
 
-FCS_CKM_EXT.7 - (selection-based SFR) included
+FCS_CKM_EXT.7 - included
 
 FCS_CKM_EXT.8 - (selection-based SFR) included
-
-FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
 
 FCS_CKM.6 - included
 
@@ -4593,9 +4515,26 @@ FCS_OTV_EXT.1 - included
 |FCS_COP.1/CMAC
 |[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7 or FCS_CKM_EXT.8]
 
-FCS_CKM.3
-
 FCS_CKM.6
+
+|FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
+
+FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
+
+FCS_CKM.1 - included
+
+FCS_CKM.5 - (selection-based SFR) included
+
+FCS_CKM_EXT.7 - included
+
+FCS_CKM_EXT.8 - (selection-based SFR) included
+
+FCS_CKM.6 - included
+
+|FCS_COP.1/KeyEncap
+|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7, or FCS_CKM_EXT.8]
+
+FCS_CKM.6 
 
 FCS_OTV_EXT.1
 |FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
@@ -4606,15 +4545,31 @@ FCS_CKM.1 - included
 
 FCS_CKM.5 - (selection-based SFR) included
 
-FCS_CKM_EXT.7 - (selection-based SFR) included
+FCS_CKM_EXT.7 - included
 
 FCS_CKM_EXT.8 - (selection-based SFR) included
-
-FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
 
 FCS_CKM.6 - included
 
 FCS_OTV_EXT.1 - included
+
+|FCS_COP.1/KeyWrap
+|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7, or FCS_CKM_EXT.8]
+
+FCS_CKM.6 
+|FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
+
+FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
+
+FCS_CKM.1 - included
+
+FCS_CKM.5 - (selection-based SFR) included
+
+FCS_CKM_EXT.7 - included
+
+FCS_CKM_EXT.8 - (selection-based SFR) included
+
+FCS_CKM.6 - included
 
 |FDP_DAU.1/Prove 
 |No dependencies
@@ -4636,7 +4591,7 @@ FCS_OTV_EXT.1 - included
 |FPT_MFW_EXT.1 
 
 FCS_COP.1
-|FPT_MFW_EXT.1- included
+|FPT_MFW_EXT.1 - included
 
 FCS_COP.1 - included
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -4024,8 +4024,6 @@ FCS_CKM.1/SKG - (selection-based SFR) included
 
 FCS_CKM.2 - included
 
-FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
-
 FCS_CKM.5 - (selection-based SFR) included
 
 FCS_CKM_EXT.7 - included
@@ -4201,7 +4199,7 @@ FMT_MSA.3 - included
 
 |FDP_FRS_EXT.1 
 |FDP_FRS_EXT.2 
-|FDP_FRS_EXT.2 - (optional SFR) included
+|FDP_FRS_EXT.2 - (selection-based SFR) included
 
 |FDP_ITC_EXT.1 
 |FCS_COP.1 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -4030,6 +4030,8 @@ FCS_CKM.2 - included
 
 FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
 
+FCS_CKM.5 - (selection-based) included
+
 FCS_CKM_EXT.7 - included
 
 FCS_CKM_EXT.8 - (selection-based) included

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -4015,26 +4015,26 @@ The dependencies between SFRs implemented by the TOE are addressed as follows. D
 |Rationale Statement
 
 |FCS_CKM.1 
-|[_FCS_CKM.1/AKG_, _FCS_CKM.1/SKG_, FCS_CKM.2, FCS_CKM.5, FCS_CKM_EXT.7, _FCS_CKM_EXT.8_ or FCS_COP.1] 
+|[FCS_CKM.1/AKG, FCS_CKM.1/SKG, FCS_CKM.2, FCS_CKM.5, FCS_CKM_EXT.7, FCS_CKM_EXT.8 or FCS_COP.1] 
 
 FCS_CKM.3
 
 [FCS_RBG.1 or FCS_RNG.1]
 
 FCS_CKM.6
-|FCS_CKM.1/AKG - (selection-based) included
+|FCS_CKM.1/AKG - (selection-based SFR) included
 
-FCS_CKM.1/SKG - (selection-based) included
+FCS_CKM.1/SKG - (selection-based SFR) included
 
 FCS_CKM.2 - included
 
 FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
 
-FCS_CKM.5 - (selection-based) included
+FCS_CKM.5 - (selection-based SFR) included
 
 FCS_CKM_EXT.7 - included
 
-FCS_CKM_EXT.8 - (selection-based) included
+FCS_CKM_EXT.8 - (selection-based SFR) included
 
 FCS_COP.1 - included
 
@@ -4045,36 +4045,28 @@ FCS_RNG.1 is satisfied by FCS_RBG.1 - included
 FCS_CKM.6 - included
 
 |FCS_CKM.2
-|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5 or _FCS_COP.1_] 
+|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5 or FCS_COP.1] 
 |FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
 
 FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
 
 FCS_CKM.1 - included
 
-FCS_CKM.5 - (selection-based) included
+FCS_CKM.5 - (selection-based SFR) included
 
-FCS_COP.1/KeyEncap - (selection-based) included
+FCS_COP.1/KeyEncap - (selection-based SFR) included
 
-FCS_COP.1/KeyWrap - (selection-based) included
+FCS_COP.1/KeyWrap - (selection-based SFR) included
 
-FCS_COP.1/AEAD - (selection-based) included
+FCS_COP.1/AEAD - (selection-based SFR) included
 
 |FCS_CKM.6 
-|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM_EXT.3, FCS_CKM.5, FCS_CKM_EXT.7 or FCS_CKM_EXT.8] 
+|[FDP_ITC.1, FDP_ITC.2 or FCS_CKM.1] 
 |FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
 
 FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
 
 FCS_CKM.1 - included
-
-FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
-
-FCS_CKM.5 - (selection-based) included
-
-FCS_CKM_EXT.7 - included
-
-FCS_CKM_EXT.8 - (selection-based) included
 
 |FCS_CKM_EXT.7 
 |[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.8]
@@ -4088,9 +4080,9 @@ FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data
 
 FCS_CKM.1 - included
 
-FCS_CKM.5 - (selection-based) included
+FCS_CKM.5 - (selection-based SFR) included
 
-FCS_CKM_EXT.8 - (selection-based) included
+FCS_CKM_EXT.8 - (selection-based SFR) included
 
 FCS_CKM.2 - included
 
@@ -4116,11 +4108,11 @@ FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data
 
 FCS_CKM.1 - included
 
-FCS_CKM.5 - (selection-based) included
+FCS_CKM.5 - (selection-based SFR) included
 
-FCS_CKM_EXT.7 - (selection-based) included
+FCS_CKM_EXT.7 - (selection-based SFR) included
 
-FCS_CKM_EXT.8 - (selection-based) included
+FCS_CKM_EXT.8 - (selection-based SFR) included
 
 FCS_COP.1/Hash - included
 
@@ -4140,11 +4132,11 @@ FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data
 
 FCS_CKM.1 - included
 
-FCS_CKM.5 - (selection-based) included
+FCS_CKM.5 - (selection-based SFR) included
 
-FCS_CKM_EXT.7 - (selection-based) included
+FCS_CKM_EXT.7 - (selection-based SFR) included
 
-FCS_CKM_EXT.8 - (selection-based) included
+FCS_CKM_EXT.8 - (selection-based SFR) included
 
 FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
 
@@ -4162,11 +4154,11 @@ FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data
 
 FCS_CKM.1 - included
 
-FCS_CKM.5 - (selection-based) included
+FCS_CKM.5 - (selection-based SFR) included
 
-FCS_CKM_EXT.7 - (selection-based) included
+FCS_CKM_EXT.7 - (selection-based SFR) included
 
-FCS_CKM_EXT.8 - (selection-based) included
+FCS_CKM_EXT.8 - (selection-based SFR) included
 
 FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
 
@@ -4182,9 +4174,9 @@ FCS_CKM.6
 
 FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
 
-FCS_CKM.1/AKG - (selection-based) included
+FCS_CKM.1/AKG - (selection-based SFR) included
 
-FCS_CKM.5 - (selection-based) included
+FCS_CKM.5 - (selection-based SFR) included
 
 FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
 
@@ -4200,7 +4192,7 @@ FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data
 
 FCS_CKM.1 - included
 
-FCS_CKM.5 - (selection-based) included
+FCS_CKM.5 - (selection-based SFR) included
 
 FCS_CKM.6 - included
 
@@ -4220,11 +4212,11 @@ FDP_ITC_EXT.2 satisfies FDP_ITC.2 related to a mechanism by which key data can b
 
 FCS_CKM.1 - included
 
-FCS_CKM.5 - (selection-based) included
+FCS_CKM.5 - (selection-based SFR) included
 
-FCS_CKM_EXT.7 - (selection-based) included
+FCS_CKM_EXT.7 - (selection-based SFR) included
 
-FCS_CKM_EXT.8 - (selection-based) included
+FCS_CKM_EXT.8 - (selection-based SFR) included
 
 FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
 
@@ -4239,9 +4231,9 @@ FPT_FLS.1
 
 FPT_TST.1
 
-|FCS_RBG.2 - (selection-based) included
+|FCS_RBG.2 - (selection-based SFR) included
 
-FCS_RBG.3 - (selection-based) included
+FCS_RBG.3 - (selection-based SFR) included
 
 FPT_FLS.1 - included
 
@@ -4273,7 +4265,7 @@ FMT_MSA.3 - included
 
 |FDP_FRS_EXT.1 
 |FDP_FRS_EXT.2 
-|FDP_FRS_EXT.2 - (optional-based) included
+|FDP_FRS_EXT.2 - (optional-based SFR) included
 
 |FDP_ITC_EXT.1 
 |FCS_COP.1 
@@ -4281,11 +4273,11 @@ FMT_MSA.3 - included
 [FTP_ITC_EXT.1, FTP_ITE_EXT.1, or FTP_ITP_EXT.1] 
 |FCS_COP.1 - included
 
-FTP_ITC_EXT.1 - (selection-based) included
+FTP_ITC_EXT.1 - (selection-based SFR) included
 
-FTP_ITE_EXT.1 - (selection-based) included
+FTP_ITE_EXT.1 - (selection-based SFR) included
 
-FTP_ITP_EXT.1 - (selection-based) included
+FTP_ITP_EXT.1 - (selection-based SFR) included
 
 |FDP_ITC_EXT.2 
 |FCS_COP.1 
@@ -4293,11 +4285,11 @@ FTP_ITP_EXT.1 - (selection-based) included
 [FTP_ITC_EXT.1, FTP_ITE_EXT.1, or FTP_ITP_EXT.1] 
 |FCS_COP.1 - included
 
-FTP_ITC_EXT.1 - (selection-based) included
+FTP_ITC_EXT.1 - (selection-based SFR) included
 
-FTP_ITE_EXT.1 - (selection-based) included
+FTP_ITE_EXT.1 - (selection-based SFR) included
 
-FTP_ITP_EXT.1 - (selection-based) included
+FTP_ITP_EXT.1 - (selection-based SFR) included
 
 |FDP_RIP.1 
 |No dependencies
@@ -4427,7 +4419,7 @@ FMT_SMR.1 - included
 FCS_RBG.5 
 |FCS_RBG.1 - included
 
-FCS_RBG.5 - (selection-based) included
+FCS_RBG.5 - (selection-based SFR) included
 
 |FCS_RBG.5
 |FCS_RBG.1
@@ -4435,11 +4427,11 @@ FCS_RBG.5 - (selection-based) included
 [FCS_RBG.2 or FCS_RBG.3 or RCS_RBG.4]
 |FCS_RBG.1 - included
 
-FCS_RBG.2 - (selection-based) included
+FCS_RBG.2 - (selection-based SFR) included
 
-FCS_RBG.3 - (selection-based) included
+FCS_RBG.3 - (selection-based SFR) included
 
-FCS_RBG.4 - (selection-based) included
+FCS_RBG.4 - (selection-based SFR) included
 
 |FCS_RBG.6 
 |FCS_RBG.1 
@@ -4512,7 +4504,7 @@ FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
 
 FCS_CKM.5 - included
 
-FCS_CKM_EXT.7 - (selection-based) included
+FCS_CKM_EXT.7 - (selection-based SFR) included
 
 FCS_COP.1 - included
 
@@ -4532,15 +4524,15 @@ FCS_CKM.6
 
 FCS_CKM.5 - included
 
-FCS_CKM_EXT.8 - (selection-based) included
+FCS_CKM_EXT.8 - (selection-based SFR) included
 
-FCS_COP.1/KeyEncap - (selection-based) included
+FCS_COP.1/KeyEncap - (selection-based SFR) included
 
-FCS_COP.1/KeyWrap - (selection-based) included
+FCS_COP.1/KeyWrap - (selection-based SFR) included
 
-FCS_COP.1/SKC - (selection-based) included
+FCS_COP.1/SKC - (selection-based SFR) included
 
-FCS_COP.1/AEAD - (selection-based) included
+FCS_COP.1/AEAD - (selection-based SFR) included
 
 FCS_CKM.6 - included
 
@@ -4566,7 +4558,7 @@ FCS_CKM.6
 
 FCS_COP.1 - included
 
-FCS_CKM_EXT.7 - (selection-based) included
+FCS_CKM_EXT.7 - (selection-based SFR) included
 
 FCS_CKM.1/KeyedHash - included
 
@@ -4586,11 +4578,11 @@ FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data
 
 FCS_CKM.1 - included
 
-FCS_CKM.5 - (selection-based) included
+FCS_CKM.5 - (selection-based SFR) included
 
-FCS_CKM_EXT.7 - (selection-based) included
+FCS_CKM_EXT.7 - (selection-based SFR) included
 
-FCS_CKM_EXT.8 - (selection-based) included
+FCS_CKM_EXT.8 - (selection-based SFR) included
 
 FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
 
@@ -4612,11 +4604,11 @@ FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data
 
 FCS_CKM.1 - included
 
-FCS_CKM.5 - (selection-based) included
+FCS_CKM.5 - (selection-based SFR) included
 
-FCS_CKM_EXT.7 - (selection-based) included
+FCS_CKM_EXT.7 - (selection-based SFR) included
 
-FCS_CKM_EXT.8 - (selection-based) included
+FCS_CKM_EXT.8 - (selection-based SFR) included
 
 FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -3107,15 +3107,14 @@ There are no auditable events foreseen.
 [horizontal]
 Hierarchical to:: No other components.
 
-Dependencies:: [FDP_ITC.1 Import of user data without security attributes, or +
-FDP_ITC.2 Import of user data with security attributes, or +
-FCS_CKM.1 Cryptographic key generation, or +
+Dependencies:: [FCS_CKM.1 Cryptographic key generation, or +
 FCS_CKM.5 Cryptographic key derivation, or +
 FCS_CKM_EXT.8 Password-based key derivation] +
 FCS_CKM.6 Timing and event of cryptographic key destruction, +
 [FCS_COP.1/KeyEncap Cryptographic Operation (Key Encapsulation), or +
 FCS_COP.1/KeyWrap Cryptographic Operation (Key Wrap), or +
-FCS_COP.1/SKC Cryptographic Operation (Symmetric-Key Cryptography)]
+FCS_COP.1/SKC Cryptographic Operation (Symmetric-Key Cryptography), or +
+FCS_COP.1/AEAD Authenticated Encryption with Associated Data]
 
 [vertical]
 FCS_CKM_EXT.3.1:: The TSF shall use specified cryptographic key access methods [selection: _key encapsulation, key wrapping, key encryption_] to access keys when performing [selection: _cryptographic key usage in cryptographic operations, cryptographic key storage, cryptographic key recovery, modifications to attributes of cryptographic keys, cryptographic key destruction_].
@@ -3140,10 +3139,7 @@ FCS_CKM_EXT.7.1:: The TSF shall derive shared cryptographic keys with input from
 [horizontal]
 Hierarchical to:: No other components.
 
-Dependencies:: [FDP_ITC.1 Import of user data without security attributes, or +
-FDP_ITC.2 Import of user data with security attributes] +
-[FCS_CKM.2 Cryptographic key distribution, or +
-FCS_COP.1 Cryptographic operation, or +
+Dependencies:: [FCS_CKM.2 Cryptographic key distribution, or +
 FCS_CKM_EXT.7 Cryptographic Key Agreement] +
 FCS_COP.1/KeyedHash Cryptographic Operation (Keyed Hash) +
 FCS_CKM.6 Timing and event of cryptographic key destruction 
@@ -4019,27 +4015,64 @@ The dependencies between SFRs implemented by the TOE are addressed as follows. D
 |Rationale Statement
 
 |FCS_CKM.1 
-|[_FCS_CKM.1/AKG, FCS_CKM.1/SKG_, FCS_CKM.2, FCS_CKM.5, FCS_CKM_EXT.7, _FCS_CKM_EXT.8_ or FCS_COP.1] 
+|[_FCS_CKM.1/AKG_, _FCS_CKM.1/SKG_, FCS_CKM.2, FCS_CKM.5, FCS_CKM_EXT.7, _FCS_CKM_EXT.8_ or FCS_COP.1] 
+
+FCS_CKM.3
 
 [FCS_RBG.1 or FCS_RNG.1]
 
 FCS_CKM.6
-|FCS_CKM.2, FCS_CKM.6, FCS_CKM_EXT.7, FCS_COP.1 and FCS_RBG.1 are required by the PP. 
+|FCS_CKM.1/AKG - (selection-based) included
 
-FCS_CKM.1/AKG, FCS_CKM.1/SKG and FCS_CKM_EXT.8 are selection-based requirements to support how keys are generated.
+FCS_CKM.1/SKG - (selection-based) included
+
+FCS_CKM.2 - included
+
+FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
+
+FCS_CKM_EXT.7 - included
+
+FCS_CKM_EXT.8 - (selection-based) included
+
+FCS_COP.1 - included
+
+FCS_RBG.1 - included
+
+FCS_RNG.1 is satisfied by FCS_RBG.1 - included
+
+FCS_CKM.6 - included
 
 |FCS_CKM.2
 |[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5 or _FCS_COP.1_] 
+|FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
 
-|FCS_CKM.1 is required by the PP. FDP_ITC_EXT.1 and FDP_ITC_EXT.2 are also required by the PP and equivalent to FDP_ITC.1 in this case because they all relate to a mechanism by which key data can be imported into the TSF.
+FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
 
-FCS_COP.1 can be used as an alternative for encapsulating or wrapping keys for cases when transport itself may not be included in the TSF.
+FCS_CKM.1 - included
+
+FCS_CKM.5 - (selection-based) included
+
+FCS_COP.1/KeyEncap - (selection-based) included
+
+FCS_COP.1/KeyWrap - (selection-based) included
+
+FCS_COP.1/AEAD - (selection-based) included
 
 |FCS_CKM.6 
-|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM_EXT.3, FCS_CKM.5, FCS_CKM_EXT.7, FCS_CKM_EXT.8 or FCS_CKM_EXT.9] 
-|FCS_CKM.1 and FCS_CKM_EXT.7 are required by the PP. FDP_ITC_EXT.1 and FDP_ITC_EXT.2 are also required by the PP and equivalent to FDP_ITC.1 in this case because they all relate to a mechanism by which key data can be imported into the TSF.
+|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM_EXT.3, FCS_CKM.5, FCS_CKM_EXT.7 or FCS_CKM_EXT.8] 
+|FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
 
-FCS_CKM_EXT.3, FCS_CKM.5 and FCS_CKM_EXT.8 are selection-based requirements that can be included if supported by the TSF.
+FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
+
+FCS_CKM.1 - included
+
+FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
+
+FCS_CKM.5 - (selection-based) included
+
+FCS_CKM_EXT.7 - included
+
+FCS_CKM_EXT.8 - (selection-based) included
 
 |FCS_CKM_EXT.7 
 |[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.8]
@@ -4047,123 +4080,258 @@ FCS_CKM_EXT.3, FCS_CKM.5 and FCS_CKM_EXT.8 are selection-based requirements that
 [FCS_CKM.2 or FCS_COP.1]
 
 FCS_CKM.6 
-|FCS_CKM.1, FCS_CKM.2 and FCS_CKM.6 are required by the PP. FDP_ITC_EXT.1 and FDP_ITC_EXT.2 are also required by the PP and equivalent to FDP_ITC.1 in this case because they all relate to a mechanism by which key data can be imported into the TSF.
+|FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
 
-Some FCS_COP.1 iterations are required by the PP while additional iterations can be included when supported by the TSF.
+FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
+
+FCS_CKM.1 - included
+
+FCS_CKM.5 - (selection-based) included
+
+FCS_CKM_EXT.8 - (selection-based) included
+
+FCS_CKM.2 - included
+
+FCS_COP.1 - included
+
+FCS_CKM.6 - included
 
 |FCS_COP.1/Hash 
 |No dependencies.
-|N/A
+|There are no keys involved with hashing, so no cryptograhpic key-based dependencies are necessary.
 
 |FCS_COP.1/KeyedHash 
-|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5] 
+|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7 or FCS_CKM_EXT.8] 
+
+FCS_COP.1/Hash
+
+FCS_CKM.3
 
 FCS_CKM.6 
-|FCS_CKM.1 and FCS_CKM.6 are required by the PP. FDP_ITC_EXT.1 and FDP_ITC_EXT.2 are also required by the PP and equivalent to FDP_ITC.1 in this case because they all relate to a mechanism by which key data can be imported into the TSF.
+|FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
+
+FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
+
+FCS_CKM.1 - included
+
+FCS_CKM.5 - (selection-based) included
+
+FCS_CKM_EXT.7 - (selection-based) included
+
+FCS_CKM_EXT.8 - (selection-based) included
+
+FCS_COP.1/Hash - included
+
+FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
+
+FCS_CKM.6 - included
+
+|FCS_COP.1/KeyEncap
+|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7, or FCS_CKM_EXT.8]
+
+FCS_CKM.3
+
+FCS_CKM.6 
+|FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
+
+FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
+
+FCS_CKM.1 - included
+
+FCS_CKM.5 - (selection-based) included
+
+FCS_CKM_EXT.7 - (selection-based) included
+
+FCS_CKM_EXT.8 - (selection-based) included
+
+FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
+
+FCS_CKM.6 - included
 
 |FCS_COP.1/KeyWrap
 |[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7, or FCS_CKM_EXT.8]
 
+FCS_CKM.3
+
 FCS_CKM.6 
-|FCS_CKM.1 and FCS_CKM.6 are required by the PP. FDP_ITC_EXT.1 and FDP_ITC_EXT.2 are also required by the PP and equivalent to FDP_ITC.1 in this case because they all relate to a mechanism by which key data can be imported into the TSF.
+|FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
+
+FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
+
+FCS_CKM.1 - included
+
+FCS_CKM.5 - (selection-based) included
+
+FCS_CKM_EXT.7 - (selection-based) included
+
+FCS_CKM_EXT.8 - (selection-based) included
+
+FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
+
+FCS_CKM.6 - included
 
 |FCS_COP.1/SigGen 
-|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, or FCS_CKM.5] 
+|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1/AKG, or FCS_CKM.5] 
+
+FCS_CKM.3
 
 FCS_CKM.6 
-|FCS_CKM.1 and FCS_CKM.6 are required by the PP. FDP_ITC_EXT.1 and FDP_ITC_EXT.2 are also required by the PP and equivalent to FDP_ITC.1 in this case because they all relate to a mechanism by which key data can be imported into the TSF.
+|FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
+
+FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
+
+FCS_CKM.1/AKG - (selection-based) included
+
+FCS_CKM.5 - (selection-based) included
+
+FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
+
+FCS_CKM.6 - included
 
 |FCS_COP.1/SigVer 
 |[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, or FCS_CKM.5] 
 
 FCS_CKM.6 
-|FCS_CKM.1 and FCS_CKM.6 are required by the PP. FDP_ITC_EXT.1 and FDP_ITC_EXT.2 are also required by the PP and equivalent to FDP_ITC.1 in this case because they all relate to a mechanism by which key data can be imported into the TSF.
+|FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
+
+FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
+
+FCS_CKM.1 - included
+
+FCS_CKM.5 - (selection-based) included
+
+FCS_CKM.6 - included
+
+FCS_CKM.3 is not necessary as this is only verifying a signature, not generating or storing keys
 
 |FCS_COP.1/SKC 
 |[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7 or FCS_CKM_EXT.8] 
 
+FCS_CKM.3
+
 FCS_CKM.6 
 
 FCS_OTV_EXT.1
-|FCS_CKM.1, FCS_CKM.6, FCS_CKM_EXT.7 and FCS_OTV_EXT.1 are required by the PP. FDP_ITC_EXT.1 and FDP_ITC_EXT.2 are also required by the PP and equivalent to FDP_ITC.1 in this case because they all relate to a mechanism by which key data can be imported into the TSF. FCS_CKM.5 and FCS_CKM_EXT.8 can be included based on support in the TSF.
+|FDP_ITC_EXT.1 satisfies FDP_ITC.1 related to a mechanism by which key data can be imported into the TSF - included
+
+FDP_ITC_EXT.2 satisfies FDP_ITC.2 related to a mechanism by which key data can be imported into the TSF - included
+
+FCS_CKM.1 - included
+
+FCS_CKM.5 - (selection-based) included
+
+FCS_CKM_EXT.7 - (selection-based) included
+
+FCS_CKM_EXT.8 - (selection-based) included
+
+FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
+
+FCS_CKM.6 - included
+
+FCS_OTV_EXT.1 - included
 
 |FCS_RBG.1 
-|FCS_COP.1 
-|FCS_COP.1 is required by the PP.
+|[FCS_RBG.2 or FCS_RBG.3]
+
+FPT_FLS.1
+
+FPT_TST.1
+
+|FCS_RBG.2 - (selection-based) included
+
+FCS_RBG.3 - (selection-based) included
+
+FPT_FLS.1 - included
+
+FPT_TST.1 - included
 
 |FCS_OTV_EXT.1 
 |FCS_RBG.1 
-|FCS_RBG.1 is required by the PP.
+|FCS_RBG.1 - included
 
 |FCS_STG_EXT.1 
-|No dependencies. 
+|No dependencies
 |N/A
 
 |FDP_ACC.1 
 |FDP_ACF.1 
-|FDP_ACF.1 is required by the PP.
+|FDP_ACF.1 - included
 
 |FDP_ACF.1 
 |FDP_ACC.1 
 
 FMT_MSA.3
-|FDP_ACC.1 and FMT_MSA.3 are required by the PP.
+|FDP_ACC.1 - included
+
+FMT_MSA.3 - included
 
 |FDP_ETC_EXT.2 
 |FCS_COP.1 
-|FCS_COP.1 is required by the PP.
+|FCS_COP.1 - included
 
 |FDP_FRS_EXT.1 
 |FDP_FRS_EXT.2 
-|FDP_FRS_EXT.2 is an optional SFR in the PP. It does not need to be required because the PP's definition of FDP_FRS_EXT.1 allows the ST author to specify that no factory reset is possible, in which case the behavior described by FDP_FRS_EXT.2 is not triggered.
+|FDP_FRS_EXT.2 - (optional-based) included
 
 |FDP_ITC_EXT.1 
 |FCS_COP.1 
 
 [FTP_ITC_EXT.1, FTP_ITE_EXT.1, or FTP_ITP_EXT.1] 
-|FCS_COP.1 is required by the PP. FTP_ITC_EXT.1, FTP_ITE_EXT.1, and FTP_ITP_EXT.1 are each selection-based SFRs in the PP but the PP's definition of FDP_ITC_EXT.1 requires at least one of them to be selected so the dependency is always addressed.
+|FCS_COP.1 - included
+
+FTP_ITC_EXT.1 - (selection-based) included
+
+FTP_ITE_EXT.1 - (selection-based) included
+
+FTP_ITP_EXT.1 - (selection-based) included
 
 |FDP_ITC_EXT.2 
 |FCS_COP.1 
 
 [FTP_ITC_EXT.1, FTP_ITE_EXT.1, or FTP_ITP_EXT.1] 
-|FCS_COP.1 is required by the PP. FTP_ITC_EXT.1, FTP_ITE_EXT.1, and FTP_ITP_EXT.1 are each selection-based SFRs in the PP but the PP's definition of FDP_ITC_EXT.1 requires at least one of them to be selected so the dependency is always addressed.
+|FCS_COP.1 - included
+
+FTP_ITC_EXT.1 - (selection-based) included
+
+FTP_ITE_EXT.1 - (selection-based) included
+
+FTP_ITP_EXT.1 - (selection-based) included
 
 |FDP_RIP.1 
-|No dependencies. 
+|No dependencies
 |N/A
 
 |FDP_SDC.2 
 |FCS_COP.1
-|FCS_COP.1 is required by this PP.
+|FCS_COP.1 - included
 
 |FDP_SDI.2 
-|No dependencies. 
+|No dependencies
 |N/A
 
 |FIA_AFL_EXT.1 
-|No dependencies. 
+|No dependencies
 |N/A
 
 |FIA_SOS.2 
-|No dependencies. 
+|No dependencies
 |N/A
 
 |FIA_UAU.2 
 |FIA_UID.1 
-|This dependency is not present in the PP because all of the methods used to access the TSF (physically protected channels, encrypted data buffers, or cryptographically protected data channels) all implicitly identify the subject that is attempting to authenticate to the TOE. Therefore, it is not necessary to include a separate SFR that requires subjects to be identified.
+|This dependency is not present in the PP because all of the methods used to access the TSF (physically protected channels, encrypted data buffers, or cryptographically protected data channels) all implicitly identify the subject that is attempting to authenticate to the TOE.
 
 |FIA_UAU.5 
-|No dependencies. 
+|No dependencies
 |N/A
 
 |FIA_UAU.6 
-|No dependencies. 
+|No dependencies
 |N/A
 
 |FMT_MOF_EXT.1 
 |FMT_SMF.1 
-|FMT_SMF.1 is required by this PP.
+|FMT_SMF.1 - included
 
 |FMT_MSA.1 
 |[FDP_ACC.1 or FDP_IFC.1] 
@@ -4171,24 +4339,30 @@ FMT_MSA.3
 FMT_SMR.1 
 
 FMT_SMF.1 
-|FDP_ACC.1, FMT_SMF.1 and FMT_SMR.1 are required by the PP.
+|FDP_ACC.1 - included
+
+FMT_SMF.1 - included
+
+FMT_SMR.1 - included
 
 |FMT_MSA.3 
 |FMT_MSA.1 
 
 FMT_SMR.1 
-|FMT_MSA.1 and FMT_SMR.1 are required by the PP.
+|FMT_MSA.1 - included
+
+FMT_SMR.1 - included
 
 |FMT_SMF.1 
-|No dependencies. 
+|No dependencies
 |N/A
 
 |FMT_SMR.1 
 |FIA_UID.1 
-|This dependency is not present in the PP because all of the methods used to access the TSF (physically protected channels, encrypted data buffers, or cryptographically protected data channels) all implicitly identify the subject that is attempting to authenticate to the TOE. Therefore, it is not necessary to include a separate SFR that requires subjects to be identified.
+|This dependency is not present in the PP because all of the methods used to access the TSF (physically protected channels, encrypted data buffers, or cryptographically protected data channels) all implicitly identify the subject that is attempting to authenticate to the TOE.
 
 |FPT_FLS.1/FI 
-|No dependencies. 
+|No dependencies
 |N/A
 
 |FPT_MFW_EXT.1
@@ -4196,36 +4370,36 @@ FMT_SMR.1
 |N/A
 
 |FPT_MOD_EXT.1 
-|No dependencies. 
+|No dependencies
 |N/A
 
 |FPT_PHP.3 
-|No dependencies. 
+|No dependencies
 |N/A
 
 |FPT_PRO_EXT.1 
-|No dependencies. 
+|No dependencies
 |N/A
 
 |FPT_ROT_EXT.1 
 |FPT_PRO_EXT.1 
-|FPT_PRO_EXT.1 is required by this PP.
+|FPT_PRO_EXT.1 - included
 
 |FPT_ROT_EXT.2 
 |FPT_PRO_EXT.1 
-|FPT_PRO_EXT.1 is required by this PP.
+|FPT_PRO_EXT.1 - included
 
 |FPT_RPL.1/Authorization
-|No dependencies. 
+|No dependencies
 |N/A
 
 |FPT_TST.1 
-|No dependencies. 
+|No dependencies
 |N/A
 
 |FRU_FLT.1 
 |FPT_FLS.1 
-|FPT_FLS.1 (as FPT_FLS.1/FI) is required by the PP.
+|FPT_FLS.1/FI - included
 
 |===
 
@@ -4239,34 +4413,42 @@ FMT_SMR.1
 
 |FCS_RBG.2 
 |FCS_RBG.1 
-|FCS_RBG.1 is required by this PP.
+|FCS_RBG.1 - included
 
 |FCS_RBG.3 
 |FCS_RBG.1 
-|FCS_RBG.1 is required by this PP.
+|FCS_RBG.1 - included
 
 |FCS_RBG.4 
 |FCS_RBG.1
 
 FCS_RBG.5 
-|FCS_RBG.1 is required by this PP. FCS_RBG.5 is required when combining multiple entropy sources.
+|FCS_RBG.1 - included
+
+FCS_RBG.5 - (selection-based) included
 
 |FCS_RBG.5
 |FCS_RBG.1
 
 [FCS_RBG.2 or FCS_RBG.3 or RCS_RBG.4]
-|FCS_RBG.1 is required by this PP. A second source is required for combining sources of entropy.
+|FCS_RBG.1 - included
+
+FCS_RBG.2 - (selection-based) included
+
+FCS_RBG.3 - (selection-based) included
+
+FCS_RBG.4 - (selection-based) included
 
 |FCS_RBG.6 
 |FCS_RBG.1 
-|FCS_RBG.1 is required by this PP.
+|FCS_RBG.1 - included
 
 |FPT_ITT.1 
-|No dependencies. 
+|No dependencies
 |N/A
 
 |FPT_PRO_EXT.2 
-|No dependencies. 
+|No dependencies
 |N/A
 
 |FPT_ROT_EXT.3 
@@ -4275,7 +4457,11 @@ FCS_RBG.5
 FPT_PRO_EXT.1 
 
 FPT_ROT_EXT.1 
-|All of FCS_COP.1, FPT_PRO_EXT.1, and FPT_ROT_EXT.1 are required by this PP.
+|FCS_COP.1- included
+
+FPT_PRO_EXT.1- included
+
+FPT_ROT_EXT.1- included
 
 |===
 
@@ -4289,95 +4475,211 @@ FPT_ROT_EXT.1
 |Rationale Statement
 
 |FCS_CKM.1/AKG 
-|[FCS_CKM_EXT.7 or FCS_COP.1] 
+|[FCS_CKM.2, FCS_CKM.5 or FCS_COP.1]
+
+[FCS_RBG.1 or FCS_RNG.1]
+
+FCS_CKM.3
 
 FCS_CKM.6 
-|All of FCS_CKM_EXT.7, FCS_CKM.6, and FCS_COP.1 are required by the PP.
+|FCS_CKM.2 - included
+
+FCS_CKM.5 - included
+
+FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
+
+FCS_COP.1 - included
+
+FCS_RBG.1 - included
+
+FCS_RNG.1 is satisfied by FCS_RBG.1 - included
+
+FCS_CKM.6 - included
 
 |FCS_CKM.1/SKG 
-|[FCS_CKM_EXT.7 or FCS_COP.1] 
+|[FCS_CKM.2, FCS_CKM.5, FCS_CKM_EXT.7 or FCS_COP.1]
+
+[FCS_RBG.1 or FCS_RNG.1]
+
+FCS_CKM.3
 
 FCS_CKM.6 
-|All of FCS_CKM_EXT.7, FCS_CKM.6, and FCS_COP.1 are required by the PP.
+|FCS_CKM.2 - included
+
+FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
+
+FCS_CKM.5 - included
+
+FCS_CKM_EXT.7 - (selection-based) included
+
+FCS_COP.1 - included
+
+FCS_RBG.1 - included
+
+FCS_RNG.1 is satisfied by FCS_RBG.1 - included
+
+FCS_CKM.6 - included
+
+|FCS_CKM_EXT.3 
+|[FCS_CKM.1, FCS_CKM.5 or FCS_CKM_EXT.8]
+
+[FCS_COP.1/KeyEncap, FCS_COP.1/KeyWrap, FCS_COP.1/SKC or FCS_COP.1/AEAD]
+
+FCS_CKM.6 
+|FCS_CKM.1 - included
+
+FCS_CKM.5 - included
+
+FCS_CKM_EXT.8 - (selection-based) included
+
+FCS_COP.1/KeyEncap - (selection-based) included
+
+FCS_COP.1/KeyWrap - (selection-based) included
+
+FCS_COP.1/SKC - (selection-based) included
+
+FCS_COP.1/AEAD - (selection-based) included
+
+FCS_CKM.6 - included
 
 |FCS_CKM.5 
-|FCS_CKM.1 
+|FCS_CKM.2
 
 FCS_COP.1 
 
-FDP_SDC.2 
-|All of FCS_CKM.1, FCS_COP.1, and FDP_SDC.2 are required by the PP.
+FCS_CKM.6
+|FCS_CKM.1 - included
+
+FCS_COP.1 - included
+
+FCS_CKM.6 - included
 
 |FCS_CKM_EXT.8 
-|[FCS_CKM.2 or FCS_COP.1 or FCS_CKM_EXT.7]
+|[FCS_CKM.2 or FCS_CKM_EXT.7]
 
 FCS_COP.1/KeyedHash
 
 FCS_CKM.6 
-|FCS_CKM.1/KeyedHash and FCS_CKM.6 are required by the PP.
+|FCS_CKM.2 - included
+
+FCS_COP.1 - included
+
+FCS_CKM_EXT.7 - (selection-based) included
+
+FCS_CKM.1/KeyedHash - included
+
+FCS_CKM.6 - included
 
 |FCS_COP.1/AEAD
-|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7, FCS_CKM_EXT.8]
+|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7 or FCS_CKM_EXT.8]
+
+FCS_CKM.3
 
 FCS_CKM.6
 
 FCS_OTV_EXT.1
-|FCS_CKM.1 and FCS_CKM.6 are required by the PP. FDP_ITC_EXT.1 and FDP_ITC_EXT.2 are also required by the PP and equivalent to FDP_ITC.1 in this case because they all relate to a mechanism by which key data can be imported into the TSF.
+|FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
+
+FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
+
+FCS_CKM.1 - included
+
+FCS_CKM.5 - (selection-based) included
+
+FCS_CKM_EXT.7 - (selection-based) included
+
+FCS_CKM_EXT.8 - (selection-based) included
+
+FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
+
+FCS_CKM.6 - included
+
+FCS_OTV_EXT.1 - included
+
+|FCS_COP.1/CMAC
+|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7 or FCS_CKM_EXT.8]
+
+FCS_CKM.3
+
+FCS_CKM.6
+
+FCS_OTV_EXT.1
+|FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
+
+FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
+
+FCS_CKM.1 - included
+
+FCS_CKM.5 - (selection-based) included
+
+FCS_CKM_EXT.7 - (selection-based) included
+
+FCS_CKM_EXT.8 - (selection-based) included
+
+FCS_CKM.3 is satisfied by FAU_STG_EXT.1 which controls access to keys - included
+
+FCS_CKM.6 - included
+
+FCS_OTV_EXT.1 - included
 
 |FDP_DAU.1/Prove 
-|No dependencies. 
+|No dependencies
 |N/A
 
 |FDP_FRS_EXT.2 
 |FDP_FRS_EXT.1 
-|FDP_FRS_EXT.1 is required by the PP.
+|FDP_FRS_EXT.1 - included
 
 |FIA_AFL_EXT.2
 |FIA_AFL_EXT.1
-|FIA_AFL_EXT.1 is required by the PP.
+|FIA_AFL_EXT.1 - included
 
 |FPT_FLS.1/FW
-|No dependencies.
+|No dependencies
 |N/A
 
 |FPT_MFW_EXT.2 
 |FPT_MFW_EXT.1 
 
-FCS_COP.1 
-|FPT_MFW_EXT.1 and FCS_COP.1 are required by the PP.
+FCS_COP.1
+|FPT_MFW_EXT.1- included
+
+FCS_COP.1 - included
 
 |FPT_MFW_EXT.3 
 |FPT_MFW_EXT.1 
 
 FCS_COP.1 
-|FPT_MFW_EXT.1 and FCS_COP.1 are required by the PP.
+|FPT_MFW_EXT.1 - included
+
+FCS_COP.1 - included
 
 |FPT_RPL.1/Rollback 
-|No dependencies. 
+|No dependencies
 |N/A
 
 |FPT_STM_EXT.1
-|No dependencies.
+|No dependencies
 |N/A
 
 |FTP_CCMP_EXT.1 
 |FCS_COP.1 
-|FCS_COP.1 is required by the PP.
+|FCS_COP.1 - included
 
 |FTP_GCMP_EXT.1 
 |FCS_COP.1 
-|FCS_COP.1 is required by the PP.
+|FCS_COP.1 - included
 
 |FTP_ITC_EXT.1 
 |FCS_COP.1 
-|FCS_COP.1 is required by the PP.
+|FCS_COP.1 - included
 
 |FTP_ITE_EXT.1 
 |FCS_COP.1 
-|FCS_COP.1 is required by the PP.
+|FCS_COP.1 - included
 
 |FTP_ITP_EXT.1 
-|No dependencies. 
+|No dependencies
 |N/A
 
 |===


### PR DESCRIPTION
This is to close #347

Taking a good look at this, it is a lot of text. I'm rewriting it to look more like the Network Device table where the rationale statements are simpler (things like "SFR included" or other simple statements).

I'm adding DSC-specific dependencies in italics in the lists so they are clearly different than the CC:2022 ones.

One question here is that the catalog excludes FCS_CKM.3 from the dependencies. There is FCS_CKM_EXT.3 which is similar and probably sufficient in general. I'm adding this in for some but not all, though it would seem to mean that that not having it included in any FCS_COP.1 requires an explanation.

Looking at the catalog, the following dependencies seem wrong (in the catalog, the table or both):

FCS_COP.1/KeyedHash - it would seem that FCS_COP.1/Hash is a dependency, since SHA is required for HMAC-SHA to work. Also, it lists FCS_CKM.5 as a dependency, but that seems backwards. Further, several of the other ones don't make a lot of sense.

FCS_COP.1/CMAC - shouldn't FCS_COP.1/SKC be a dependency here? Somehow though FCS_COP.1/SigGen is, but this doesn't have anything to do with signature generation. I used the same as from FCS_COP.1/AEAD, but I'm not sure some of those line up right.

FCS_COP.1 in CC:2022 has a dependency on FCS_CKM.3. I have added this to all the SFRs and point it to the FCS_CKM_EXT.3 with a note.