### PR TITLE
Generalize FCS_OTV_EXT.1

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -919,7 +919,7 @@ There are no KMD evaluation activities for this component.
 
 ====== TSS
 
-The evaluator shall ensure the TSS describes how salts are generated using the RBG.
+The evaluator shall ensure the TSS describes how salts, nonces, and other one-time values are generated using the RBG.
 
 ====== AGD
 
@@ -927,7 +927,7 @@ There are no AGD evaluation activities for this component.
 
 ====== Test
 
-The evaluator shall confirm by testing that the salts obtained in the cryptographic operations that use the salts are of the length specified in FCS_SLT_EXT.1, are obtained from the RBG, and are fresh on each invocation.
+The evaluator shall confirm by testing that the one-time values used by cryptographic operations are of the length specified in FCS_OTV_EXT.1, are obtained from the RBG, and are fresh on each invocation.
 
 Note: in general these tests may be carried out as part of the tests of the relevant cryptographic operations. 
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -2157,7 +2157,7 @@ The following rationale provides justification for each security problem definit
 |This requirement ensures the use of strong random bit generation mechanisms.
 
 |FCS_OTV_EXT.1
-|This requirement ensures that salts and nonces used by the TOE do not negatively impact key strength.
+|This requirement ensures that one-time values used by the TOE do not negatively impact key strength.
 
 .10+|T.WEAK_CRYPTO
 |FPT_STM_EXT.1 
@@ -3150,7 +3150,7 @@ FCS_CKM_EXT.8.1:: The TSF shall perform password-based key derivation functions 
 
 *Family Behavior*
 
-This family defines requirements for salt and nonce usage.
+This family defines requirements for salt, nonce, and other one-time value usage.
 
 *Component Leveling*
 
@@ -3165,7 +3165,7 @@ This family defines requirements for salt and nonce usage.
     +--------------------------------------------+ 
 ....
 
-FCS_OTV_EXT.1 One-Time Value, requires the TSF to use salts and nonces that are created by the TOE's deterministic random bit generator.
+FCS_OTV_EXT.1 One-Time Value, requires the TSF to use salts, nonces, and other one-time values that are created by the TOE's deterministic random bit generator.
 
 *Management: FCS_OTV_EXT.1*
 


### PR DESCRIPTION
FCS_OTV_EXT.1 replaced FCS_SLT_EXT.1 and is now more general. Its references in the SD as well as in some other places in the DSC should be updated.