### PR TITLE
FCS_CKM_EXT.3 hidden requirement

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1317,9 +1317,7 @@ _Each algorithm and mode have varying guidance on the lengths of the salts, nonc
 
 FCS_STG_EXT.1 Protected Storage
 
-FCS_STG_EXT.1.1:: The TSF shall provide {empty}[selection: [.underline]#mutable hardware-based, immutable hardware-based, software-based]# protected storage for {empty}[selection: [.underline]#asymmetric private keys, symmetric keys]# and {empty}[selection: [.underline]#persistent secrets, no other keys]#.
-
-_Application Note {counter:remark_count}_:: _If [.underline]#software-based# is selected, the ST author is expected to select [.underline]#all software-based key storage# in FCS_CKM_EXT.3._
+FCS_STG_EXT.1.1:: The TSF shall provide {empty}[selection: [.underline]#mutable hardware-based, immutable hardware-based, software-based in accordance to FCS_CKM_EXT.3]# protected storage for {empty}[selection: [.underline]#asymmetric private keys, symmetric keys]# and {empty}[selection: [.underline]#persistent secrets, no other keys]#.
 
 FCS_STG_EXT.1.2:: The TSF shall support the capability of {empty}[selection: [.underline]#importing keys/secrets into the TOE, causing the TOE to generate keys/secrets]# upon request of {empty}[selection: [.underline]#a client application, an administrator]#.
 


### PR DESCRIPTION
This is to close #370.

The logic here is that selecting the software storage does not explicitly mandate the use of FCS_CKM_EXT.3, but that is the intent. Having this as an app note is a hidden requirement and is not allowed. By adding in the statement that protection of software-based storage has to be according to that SFR, it makes that requirement visible and explicit.

With that I don't think we actually need to have the app note anymore, since it really doesn't have any reason to be there. We do have this in some other places, but when it is explicit, I think we can drop it.