### PR TITLE
FDP_DSC.2 EA

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -1159,9 +1159,7 @@ There are no KMD evaluation activities for this component.
 
 The evaluator shall examine the TSS to determine that it describes the protection for SDEs and authorization data and the methods of protection (e.g. protected storage, symmetric encryption, key wrapping, etc.).
 
-The evaluator shall also examine the TSS to determine whether the TSF stores this data inside the TOE boundary or in its operational environment. If the TSF stores this data inside the TOE boundary, the evaluator shall ensure that TSF uses one of the listed methods to provide confidentiality. If the data is stored in the TOE's operational environment, the evaluator shall ensure that the TSF uses key wrapping to provide confidentiality.
-
-The evaluator shall examine the TSS to confirm it sufficiently describes each method used to provide confidentiality for SDEs. The evaluator shall also confirm that the TOE supports all encryption methods selected.
+The evaluator shall also examine the TSS to determine whether the TSF stores this data inside the TOE boundary or in its operational environment. The evaluator shall examine that the methods of protection used for the various SDEs and authorization data are specified based on where the data resides (inside or outside the TOE boundary), and that the protection method is appropariate to provide confidentiality.
 
 ====== AGD
 
@@ -1169,11 +1167,7 @@ There are no AGD evaluation activities for this component.
 
 ====== Test
 
-If the TOE stores SDEs and authorization data inside the TSF, the evaluator shall ensure that external interfaces cannot extract this data in plaintext. 
-
-In this case, use the evaluation activities of the FPT_PHP.3 if [.underline]#protected storage# is selected, FCS_COP.1/SKC if [.underline]#symmetric encryption using…# is selected, and FCS_COP.1/KeyWrap if [.underline]#key wrapping using…# is selected.
-
-If the TOE stores authentication data inside the operational environment, the evaluator shall ensure that plaintext data is not visible on the interface between the TOE and the operational environment.
+The tests for FCS_COP.1 (as applicable), FPT_PHP.3 and FCS_STG_EXT.1 shall suffice for this component.
 
 ====== KMD
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1494,8 +1494,6 @@ FDP_SDC.2.1:: The TSF shall ensure the confidentiality of the [.underline]#[auth
 FDP_SDC.2.2:: The TSF shall ensure the confidentiality of the user data specified in FDP_SDC.2.1 without user intervention.
 
 _Application Note {counter:remark_count}_:: _This SFR applies to SDOs with the confidential-SDE attribute set to require confidentiality, especially secret and private keys, Allowed Random Number Generators' state data, and vendor verification reference data. If SDEs do not require confidentiality, then its omission from this list indicates that confidentiality is not required. This SFR also applies to all authorization data appearing in the attribute list under SDO.AuthData as well as any administrator authorization data which may be stored implicitly._
-+
-_If the TOE stores these parameters outside of its boundary, it must encrypt them according to the cryptographic requirements for key encryption, as required by FDP_ETC_EXT.2._
 
 ==== FDP_SDI.2 Stored Data Integrity Monitoring and Action
 


### PR DESCRIPTION
This is to close #372.

The point of this change is to be minimally invasive and to point to other tests that would actually verify the underlying activities to support this SFR. The only dependency listed in FCS_COP.1, but based on how the cPP is designed FPT_PHP.3 is needed as well (and FCS_STG_EXT.1.1 ties what is needed where, sort of, but the closest we have).