### PR TITLE
FMT_MSA.3 SD consistency

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -1383,7 +1383,7 @@ The evaluator shall confirm that the TSS describes the allowed values for each o
 
 ====== AGD
 
-The evaluator shall confirm that the user guidance describes all attributes assigned by the TOE to any parsed SDOs.
+When applicable, the evaluator shall confirm that the user guidance describes all attributes assigned by the TOE to any parsed SDOs.
 
 ====== Test
 

--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -1377,13 +1377,13 @@ There are no KMD evaluation activities for this component.
 
 ====== TSS
 
-The evaluator shall confirm that the TSS describes the initialization process for importing and generating SDOs. The TSS shall describe each type of SDO.Type and any additional attributes that are beyond the ones listed. Additionally, list any further restrictions of the allowed values for the minimum list of attributes.
+The evaluator shall confirm that the TSS describes the initialization process for importing and generating SDOs. The TSS shall describe each type of SDO.Type and any additional attributes that are beyond the ones listed. In particular, it shall describe all attributes assigned to the SDO during parsing. Additionally, list any further restrictions of the allowed values for the minimum list of attributes.
 
 The evaluator shall confirm that the TSS describes the allowed values for each of the attributes.
 
 ====== AGD
 
-There are no AGD evaluation activities for this component.
+The evaluator shall confirm that the user guidance describes all attributes assigned by the TOE to any parsed SDOs.
 
 ====== Test
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1762,7 +1762,7 @@ _The SDO.Conf attribute indicates which SDEs, if any, the TOE should encrypt whe
 +
 _The SDO.Integrity attribute includes evidence that the TSF can use to protect and verify the integrity of the SDO._
 +
-_Attributes assigned by the TOE to any parsed SDOs must be described in the Security Target and in operational user guidance._
+_Attributes assigned by the TOE to any parsed SDOs must be described in the Security Target. Where attributes may be assigned by authorized roles, the information should also be described in operational user guidance._
 +
 _The TOE uses the Binding Data for an SDO to strongly link the SDO to the TOE, a parent SDO in a hierarchy, or to nothing at all. SDOs bound to nothing may freely travel from one TOE to another without restrictions. If bound to another SDO as a child to a parent in a hierarchy, it may travel only where the parent SDO travels. If bound to the TOE, it may travel to any other TOE for any reason, even if the TOE moves its parent to another TOE. Note that vendors will initialize attributes of pre-installed SDOs with default values. However, authorization values to change the attributes of pre-installed SDOs may differ from the authorization value required to use the pre-installed SDO._
 +


### PR DESCRIPTION
Original comment:

> Application Note 29 states:
> Attributes assigned by the TOE to any parsed SDOs must be described in the Security Target and in operational user guidance.
> However, there is no corresponding guidance EA for FMT_MSA.3 in section 2.4.2.2.
> Either remove the requirement for the operational user guidance from Application Note 29 or include guidance EA.

I added it to the guidance EA, and also made it more explicit in the TSS EA.