### PR TITLE
Fix definition of FCS_STG_EXT.1.3

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -3220,7 +3220,7 @@ FCS_STG_EXT.1.1:: The TSF shall provide [assignment: _protection method_] protec
 
 FCS_STG_EXT.1.2:: The TSF shall support the capability of [selection: _importing keys/secrets into the TOE, causing the TOE to generate keys/secrets_] upon request of [assignment: _authorized subject_].
 
-FCS_STG_EXT.1.3:: The TSF shall have the capability to allow only the user that [selection: _imported the key/secret, caused the key/secret to be generated_] to use the key/secret. Exceptions may only be explicitly authorized by [assignment: _authorized subject_].
+FCS_STG_EXT.1.3:: The TSF shall be capable of destroying keys/secrets in the protected storage upon request of [assignment: _authorized subject_].
 
 FCS_STG_EXT.1.4:: The TSF shall have the capability to allow only the user that [selection: _imported the key/secret, caused the key/secret to be generated_] to use the key/secret. Exceptions may only be explicitly authorized by [assignment: _authorized subject_].
 


### PR DESCRIPTION
In #332 it was pointed out that there were two FCS_STG_EXT.1.4 definitions in the ECD. I just assumed the numbering was wrong, but in fact the entire element definition was duplicated. I restored it based on the instantiation of this element in the main cPP body.