### PR TITLE
Clarify key agreement key derivation algorithms

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -1962,7 +1962,7 @@ If [.underline]#Concatenated key5# is selected for any key derivation function, 
 
 [conditional] If a KDF is used to form a KEK, the evaluator shall ensure that the TSS includes a description of the key derivation function and shall verify the key derivation uses an approved derivation mode and key expansion algorithm according to SP 800-108 Rev. 1 or SP 800-56C Rev. 2.
 
-[conditional] If [.underline]#KDF-MAC-2S# is selected, the evaluator shall ensure the TSS includes a description of the randomness extraction step, including the following:
+[conditional] If [.underline]#KDA-MAC-2S# is selected, the evaluator shall ensure the TSS includes a description of the randomness extraction step, including the following:
 
 * The description must include how an approved untruncated MAC function is being used for the randomness extraction step and the evaluator must verify the TSS describes that the output length (in bits) of the MAC function is at least as large as the targeted security strength (in bits) of the parameter set employed by the key establishment scheme (see Tables 1-3 of SP 800-56C Rev. 2).
 * The description must include how the MAC function being used for the randomness extraction step is related to the PRF used in the key expansion and verify the TSS description includes the correct MAC function:
@@ -1982,13 +1982,13 @@ The algorithm tests might require access to a development version of the TOE or 
 
 The developer shall provide sufficient information to the evaluator to properly define the implementation of the algorithm. The evaluator shall define at least one test group (a configuration of algorithm properties and associated test cases) for each combination of the following parameters, according to the implementation of the algorithm:
 
-* PRF (KDF-CTR, KDF-FB, KDF-DPI)
+* PRF (KDF-CTR, KDF-FB, KDF-DPI, KDF-KMAC)
 * Encryption algorithm (KDF-ENC)
-* Hash algorithm (KDF-HASH)
-* MAC algorithm (KDF-MAC-1S, KDF-MAC-2S, KDF-KMAC)
+* Hash algorithm (KDA-HASH-1S)
+* MAC algorithm (KDA-MAC-1S, KDA-MAC-2S)
 * Counter size (KDF-CTR, KDF-FB, KDF-DPI)
 * Counter location (KDF-CTR, KDF-FB, KDF-DPI)
-* Salt length (KDF-MAC-1S, KDF-MAC-2S)
+* Salt length (KDA-MAC-1S, KDA-MAC-2S)
 * Derived key size
 
 If the algorithm implementation supports a range of derived key sizes, it is sufficient to define test groups for the start and end of the range.
@@ -1996,7 +1996,7 @@ If the algorithm implementation supports a range of derived key sizes, it is suf
 Each test group shall consist of at least 5 test cases meeting the following requirements:
 
 * Test cases shall be generated according to the parameter configuration of the test group.
-* Each test case shall consist of at least one arbitrary key derivation key or shared secret, an arbitrary salt (KDF-MAC-1S, KDF-MAC-2S), an arbitrary fixed info (KDF-MAC-1S, KDF-MAC-2S), and the corresponding derived key.
+* Each test case shall consist of at least one arbitrary key derivation key or shared secret, an arbitrary salt (KDA-MAC-1S, KDA-MAC-2S), an arbitrary fixed info (KDA-MAC-1S, KDA-MAC-2S), and the corresponding derived key.
 * A representative sample of the domain of supported key derivation key sizes shall be tested.
 * A representative sample of the domain of supported shared secret sizes shall be tested.
 * A representative sample of the domain of supported salt sizes shall be tested.

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -2560,19 +2560,21 @@ NIST SP 800-108 Rev. 1 (Section 4.3) [KDF in Double-Pipeline Iteration Mode] [se
 |[selection: 128, 192, 256] bits 
 |N/A
 
-|KDF-HASH 
-|Shared secret
-|Hash function from FCS_COP.1/Hash 
+|KDA-HASH-1S
+|Shared secret, output length, fixed information
+|Hash function from FCS_COP.1/Hash as H
 |[selection: 128, 192, 256] bits 
 |NIST SP 800-56C Rev. 2 (Section 4, Option 1)
 
-|KDF-MAC-1S
+|KDA-MAC-1S
 |Shared secret, salt, output length, fixed information 
-|Keyed Hash function from FCS_COP.1/KeyedHash
+|[selection: HMAC-SHA-1, HMAC-SHA-256, HMAC-SHA-512, KMAC128, KMAC256] as H
 |[selection: 128, 192, 256] bits 
 |NIST SP 800-56C Rev. 2 (Section 4, Options 2, 3)
 
-|KDF-MAC-2S 
+[selection: ISO/IEC 9797-1:2011 (CMAC), NIST SP 800-38B (CMAC), ISO/IEC 18033-3:2010 (AES), FIPS PUB 197 (AES), ISO/IEC 9797-2:2021 (HMAC), FIPS PUB 198-1 (HMAC), ISO/IEC 10118-3:2018 (SHA), FIPS PUB 180-4 (SHA)]
+
+|KDA-MAC-2S
 |Shared secret, salt, IV, output length, fixed information 
 |[MAC Step]
 
@@ -2597,15 +2599,15 @@ NIST SP 800-108 Rev. 1 (Section 4.3) [KDF in Double-Pipeline Iteration Mode] [se
 
 _Application Note {counter:remark_count}_:: _There are no standards that specify how to derive a key from two keys using XOR (KDF-XOR) or encryption (KDF-ENC). If KDF-XOR is selected, the ST Author should describe this method in the documentation. If KDF-ENC is selected, the ST Author should document the encryption algorithm used from FCS_COP.1/AEAD or FCS_COP.1/SKC, and which of the inputs is the plaintext and which is the key._
 +
-_In KDF-MAC-2S, if a CMAC is selected in the MAC step, then select AES-128-CMAC in the KDF step and select 128 as the output key size. If HMAC is selected in the MAC step, then select the same HMAC in the KDF._
+_In KDA-MAC-2S, if a CMAC is selected in the MAC step, then select AES-128-CMAC in the KDF step and select 128 as the output key size. If HMAC is selected in the MAC step, then select the same HMAC in the KDF._
 +
 _Under input parameters, if concatenated keys or intermediary keys is selected, the ST Author should describe the sources of the keys, and the order in which they are concatenated, along with any other values that are concatenated with them. This option may be chosen in instances when input keying material for the KDF comes from two independent sources, for example, a client and a server._
 +
 _If deriving a symmetric key, select any of the above rows._
 +
-_If deriving an initialization vector, an authentication secret, HMAC key, or KMAC key, select KDF-CTR, KDF-FB, KDF-DPI, KDF-HASH, KDF-XOR, or KDF-ENC._
+_If deriving an initialization vector, an authentication secret, HMAC key, or KMAC key, select KDF-CTR, KDF-FB, KDF-DPI, KDA-HASH-1S, KDF-XOR, or KDF-ENC._
 +
-_If deriving a secret IV or seed, select KDF-HASH, KDF-MAC-1S, or KDF-MAC-2S._
+_If deriving a secret IV or seed, select KDA-HASH-1S, KDA-MAC-1S, or KDA-MAC-2S._
 
 ==== FCS_CKM_EXT.8 Password-Based Key Derivation
 


### PR DESCRIPTION
NIST prefers the term KDA for the algorithms specified in SP 800-56Cr2, so it doesn't hurt to follow them to avoid confusion. (https://github.com/usnistgov/ACVP-Server/issues/160)

Additionally, add the "-1S" prefix to KDA-HASH to clarify that this is really still a OneStep KDA. Finally, some input information was missing (e.g., output length, fixed information also apply to hash-based OneStep KDA).