### PR TITLE
Merge FCS_COP.1/KeyedHash and FCS_COP.1/CMAC

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -1962,7 +1962,7 @@ If [.underline]#Concatenated key5# is selected for any key derivation function, 
 
 [conditional] If a KDF is used to form a KEK, the evaluator shall ensure that the TSS includes a description of the key derivation function and shall verify the key derivation uses an approved derivation mode and key expansion algorithm according to SP 800-108 Rev. 1 or SP 800-56C Rev. 2.
 
-[conditional] If [.underline]#KDF-MAC-2S# is selected, the evaluator shall ensure the TSS includes a description of the randomness extraction step, including the following:
+[conditional] If [.underline]#KDA-MAC-2S# is selected, the evaluator shall ensure the TSS includes a description of the randomness extraction step, including the following:
 
 * The description must include how an approved untruncated MAC function is being used for the randomness extraction step and the evaluator must verify the TSS describes that the output length (in bits) of the MAC function is at least as large as the targeted security strength (in bits) of the parameter set employed by the key establishment scheme (see Tables 1-3 of SP 800-56C Rev. 2).
 * The description must include how the MAC function being used for the randomness extraction step is related to the PRF used in the key expansion and verify the TSS description includes the correct MAC function:
@@ -1982,13 +1982,13 @@ The algorithm tests might require access to a development version of the TOE or 
 
 The developer shall provide sufficient information to the evaluator to properly define the implementation of the algorithm. The evaluator shall define at least one test group (a configuration of algorithm properties and associated test cases) for each combination of the following parameters, according to the implementation of the algorithm:
 
-* PRF (KDF-CTR, KDF-FB, KDF-DPI)
+* PRF (KDF-CTR, KDF-FB, KDF-DPI, KDF-KMAC)
 * Encryption algorithm (KDF-ENC)
-* Hash algorithm (KDF-HASH)
-* MAC algorithm (KDF-MAC-1S, KDF-MAC-2S, KDF-KMAC)
+* Hash algorithm (KDA-HASH-1S)
+* MAC algorithm (KDA-MAC-1S, KDA-MAC-2S)
 * Counter size (KDF-CTR, KDF-FB, KDF-DPI)
 * Counter location (KDF-CTR, KDF-FB, KDF-DPI)
-* Salt length (KDF-MAC-1S, KDF-MAC-2S)
+* Salt length (KDA-MAC-1S, KDA-MAC-2S)
 * Derived key size
 
 If the algorithm implementation supports a range of derived key sizes, it is sufficient to define test groups for the start and end of the range.
@@ -1996,7 +1996,7 @@ If the algorithm implementation supports a range of derived key sizes, it is suf
 Each test group shall consist of at least 5 test cases meeting the following requirements:
 
 * Test cases shall be generated according to the parameter configuration of the test group.
-* Each test case shall consist of at least one arbitrary key derivation key or shared secret, an arbitrary salt (KDF-MAC-1S, KDF-MAC-2S), an arbitrary fixed info (KDF-MAC-1S, KDF-MAC-2S), and the corresponding derived key.
+* Each test case shall consist of at least one arbitrary key derivation key or shared secret, an arbitrary salt (KDA-MAC-1S, KDA-MAC-2S), an arbitrary fixed info (KDA-MAC-1S, KDA-MAC-2S), and the corresponding derived key.
 * A representative sample of the domain of supported key derivation key sizes shall be tested.
 * A representative sample of the domain of supported shared secret sizes shall be tested.
 * A representative sample of the domain of supported salt sizes shall be tested.

--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -565,7 +565,7 @@ Note that where selections include 'destruction of reference to the key directly
 
 ====== TSS
 
-The evaluator shall ensure that the selected RSA, DH, and ECDH key agreement schemes correspond to the key generation schemes selected in FCS_CKM.1/AKG. If the ST selects DH, the TSS shall describe how the implementation meets the relevant sections of RFC 3526 (Section 3-7) or RFC 7919 (Appendices A.1-A.5). If the ST selects ECIES, the TSS shall describe the key sizes and algorithms (e.g. elliptic curve point multiplication, ECDH with either NIST or Brainpool curves, a symmetric cipher permitted by FCS_COP.1/SKC, a hash algorithm permitted by FCS_COP.1/Hash, and a MAC algorithm permitted by FCS_COP.1/KeyedHash or FCS_COP.1/CMAC) that are supported for the ECIES implementation.
+The evaluator shall ensure that the selected RSA, DH, and ECDH key agreement schemes correspond to the key generation schemes selected in FCS_CKM.1/AKG. If the ST selects DH, the TSS shall describe how the implementation meets the relevant sections of RFC 3526 (Section 3-7) or RFC 7919 (Appendices A.1-A.5). If the ST selects ECIES, the TSS shall describe the key sizes and algorithms (e.g. elliptic curve point multiplication, ECDH with either NIST or Brainpool curves, a symmetric cipher permitted by FCS_COP.1/SKC, a hash algorithm permitted by FCS_COP.1/Hash, and a MAC algorithm permitted by FCS_COP.1/MAC) that are supported for the ECIES implementation.
 
 The evaluator shall ensure that, for each key agreement scheme, the size of the derived keying material is at least the same as the intended strength of the key agreement scheme, and where feasible this should be twice the intended security strength of the key agreement scheme.
 
@@ -652,11 +652,11 @@ The evaluator shall be able to provide a rationale as to the sufficiency of the 
 
 There are no KMD evaluation activities for this component.
 
-===== FCS_COP.1/KeyedHash Cryptographic Operation (Keyed Hash)
+===== FCS_COP.1/MAC Cryptographic Operation (Message Authentication)
 
 ====== TSS
 
-The evaluator shall examine the TSS to ensure that it specifies the following values used by the HMAC and KMAC functions: output MAC length used.
+The evaluator shall examine the TSS to ensure that it specifies the following values used by the MAC functions: output MAC length used.
 
 ====== AGD
 
@@ -668,9 +668,11 @@ The algorithm tests might require access to a development version of the TOE or 
 
 The developer shall provide sufficient information to the evaluator to properly define the implementation of the algorithm. The evaluator shall define at least one test group (a configuration of algorithm properties and associated test cases) for each combination of the following parameters, according to the implementation of the algorithm:
 
-* Hash algorithm
+* Hash algorithm (HMAC)
+* MAC algorithm (KMAC)
+* AES key size (CMAC)
 
-Each test group shall consist of at least 75 test cases meeting the following requirements:
+Each test group shall consist of at least 8 test cases meeting the following requirements:
 
 * Test cases shall be generated according to the parameter configuration of the test group.
 * Each test case shall consist of an arbitrary key, an arbitrary input message, and its corresponding MAC tag.
@@ -1167,7 +1169,7 @@ There are no KMD evaluation activities for this component.
 
 ====== TSS
 
-The evaluator shall confirm that the ST author describes the methods for protecting the integrity of SDOs stored with the TOE, and shall identify the iteration of FCS_COP.1/Hash, FCS_COP.1/KeyedHash, FCS_COP.1/SigVer or FCS_COP.1/KeyWrap that covers any cryptographic algorithm used. The evaluator shall also confirm that the TSS describes the response upon the detection of an integrity error.
+The evaluator shall confirm that the ST author describes the methods for protecting the integrity of SDOs stored with the TOE, and shall identify the iteration of FCS_COP.1/Hash, FCS_COP.1/MAC, FCS_COP.1/SigVer or FCS_COP.1/KeyWrap that covers any cryptographic algorithm used. The evaluator shall also confirm that the TSS describes the response upon the detection of an integrity error.
 
 The evaluator shall confirm that the TSS describes the actions the TSF takes when the integrity verification fails for an SDO, including the circumstances that cause a notification to be sent when this occurs.
 
@@ -2115,39 +2117,6 @@ Assessment of the complete data path for authenticated encryption with associate
 
 The evaluator shall examine the KMD to ensure that it describes how the IV is generated and that the same initialization vector is never reused to encrypt different plaintext pairs under the same key. Moreover in the case of GCM, the evaluator must ensure that, at each invocation of GCM, the length of the plaintext is at most (2^32)-2 blocks.
 
-===== FCS_COP.1/CMAC Cryptographic Operation (CMAC)
-
-====== TSS
-
-The evaluator shall examine the TSS to ensure that it specifies the following values used by the CMAC functions: output MAC length used.
-
-====== AGD
-
-There are no guidance evaluation activities for this component.
-
-====== Test
-
-The algorithm tests might require access to a development version of the TOE or a test platform that provides tools not typically found on factory products.
-
-The developer shall provide sufficient information to the evaluator to properly define the implementation of the algorithm. The evaluator shall define at least three test groups (a configuration of algorithm properties and associated test cases) for each combination of the following parameters, according to the implementation of the algorithm:
-
-* AES key size
-
-Each test group shall consist of at least 8 test cases meeting the following requirements:
-
-* Test cases shall be generated according to the parameter configuration of the test group.
-* Each test case shall consist of an arbitrary key, an arbitrary input message, and its corresponding MAC tag.
-* A representative sample of the domain of supported key sizes shall be tested.
-* A representative sample of the domain of supported input message sizes shall be tested.
-
-For each test case in each test group, the evaluator shall verify that the TSF generates the correct MAC tag.
-
-The evaluator shall be able to provide a rationale as to the sufficiency of the test groups and test cases in exercising the algorithm. Test cases shall be generated using a known-good implementation to ensure the correct result is produced by the TSF. The evaluator shall determine the proper known-good implementation and provide a rationale for its use for testing. Internal or external implementations are acceptable with a sufficient rationale.
-
-====== KMD
-
-There are no KMD evaluation activities for this component.
-
 ===== FCS_COP.1/KeyEncap Cryptographic Operation (Key Encapsulation)
 
 ====== TSS
@@ -2673,17 +2642,11 @@ However, if the evaluator is unable to perform some other required EA because th
 |Password-Based Key Derivation
 |[FCS_CKM_EXT.8]
 
-|CMAC
-|[FCS_COP.1/CMAC]
-
 |Cryptographic Hashing
 |FCS_COP.1/Hash
 
-|Cryptographic Keyed Hash
-|FCS_COP.1/KeyedHash
-
-|Cryptographic Key Encapsulation
-|[FCS_COP.1/KeyEncap]
+|Cryptographic Message Authentication
+|[FCS_COP.1/MAC]
 
 |Cryptographic Key Wrapping
 |[FCS_COP.1/KeyWrap]

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -774,18 +774,18 @@ FCS_COP.1.1/Hash:: The TSF shall perform [_cryptographic hashing_] in accordance
 
 _Application Note {counter:remark_count}_:: _The hash selection should be consistent with the overall strength of the algorithm used for signature generation. For example, the TOE should choose SHA-256 for 2048-bit RSA or ECC with P-256; SHA-384 for 3072-bit RSA, 4096-bit RSA, or ECC with P-384; and SHA-512 for ECC with P-521. The ST author selects the standard based on the algorithms selected. SHA-1 may be used as a general hash function and for the following applications: generating and verifying hash-based message authentication codes (HMACs), key derivation functions (KDFs), and random bit/number generation. SHA-1 may also be used for verifying old digital signatures and time stamps, if this is explicitly allowed by the application domain. SHA-1 should not be used in applications in which collision resistance is needed._
 
-==== FCS_COP.1/KeyedHash Cryptographic Operation (Keyed Hash)
+==== FCS_COP.1/MAC Cryptographic Operation (Message Authentication)
 
-FCS_COP.1/KeyedHash Cryptographic Operation (Keyed Hash)
+FCS_COP.1/MAC Cryptographic Operation (Message Authentication)
 
-FCS_COP.1.1/KeyedHash:: The TSF shall perform [_keyed hash message authentication_] in accordance with a specified cryptographic algorithm [*selection*: _keyed hash algorithm_] and cryptographic *algorithm parameters* [*selection*: _cryptographic algorithm parameters_] that meet the following: [*selection*: _list of standards_].
+FCS_COP.1.1/MAC:: The TSF shall perform [_message authentication_] in accordance with a specified cryptographic algorithm [*selection*: _MAC algorithm_] and cryptographic *algorithm parameters* [*selection*: _cryptographic algorithm parameters_] that meet the following: [*selection*: _list of standards_].
 
-.Keyed Hash
-[[KeyedHashAlgorithms]]
+.MAC
+[[MACAlgorithms]]
 [cols=".^1,.^1,.^3",options=header]
 |===
 
-|Keyed Hash Algorithm 
+|MAC Algorithm
 |Cryptographic Algorithm Parameters 
 |List of Standards
 
@@ -834,6 +834,10 @@ FCS_COP.1.1/KeyedHash:: The TSF shall perform [_keyed hash message authenticatio
 |KMACXOF256
 |256 bits
 |[selection: ISO/IEC 9797-2:2021 (Section 9 "MAC Algorithm 4"), NIST SP 800-185 (Section 4 "KMAC")]
+
+|AES-CMAC
+|[selection: 128 bits, 192 bits, 256 bits]
+|[selection: ISO/IEC 9797-1:2011 sub clause 7.6 (CMAC) and ISO/IEC 18033-3:2010 sub clause 5.2 (AES), NIST SP 800-38B (CMAC) and NIST FIPS 197 (AES)]
 
 |===
 
@@ -1393,7 +1397,7 @@ FDP_ITC_EXT.1 Parsing of SDEs
 
 FDP_ITC_EXT.1.1:: The TSF shall support importing SDEs using [*selection*: _physically protected channels as specified in FTP_ITP_EXT.1, encrypted data buffers as specified in FTP_ITE_EXT.1, cryptographically protected data channels as specified in FTP_ITC_EXT.1_].
 
-FDP_ITC_EXT.1.2:: The TSF shall verify the integrity of the SDE using [*selection*: _message authentication code as specified in FCS_COP.1/CMAC, cryptographic hash as specified in FCS_COP.1/Hash, keyed hash as specified in FCS_COP.1/KeyedHash, key wrap encryption algorithm as specified in FCS_COP.1/KeyWrap, authenticated encryption algorithm as specified in FCS_COP.1/AEAD, digital signature as specified in FCS_COP.1/SigVer, integrity verification supported by FDP_ITC_EXT.1.1_].
+FDP_ITC_EXT.1.2:: The TSF shall verify the integrity of the SDE using [*selection*: _cryptographic hash as specified in FCS_COP.1/Hash, message authentication code as specified in FCS_COP.1/MAC, key wrap encryption algorithm as specified in FCS_COP.1/KeyWrap, authenticated encryption algorithm as specified in FCS_COP.1/AEAD, digital signature as specified in FCS_COP.1/SigVer, integrity verification supported by FDP_ITC_EXT.1.1_].
 
 FDP_ITC_EXT.1.3:: The TSF shall ignore any security attributes associated with the user data when imported from outside the TOE.
 
@@ -1409,7 +1413,7 @@ FDP_ITC_EXT.2 Parsing of SDOs
 
 FDP_ITC_EXT.2.1:: The TSF shall support importing SDOs using [*selection*: _physically protected channels as specified in FTP_ITP_EXT.1, encrypted data buffers as specified in FTP_ITE_EXT.1, cryptographically protected data channels as specified in FTP_ITC_EXT.1_].
 
-FDP_ITC_EXT.2.2:: The TSF shall verify the integrity of the SDO using [*selection*: _message authentication code as specified in FCS_COP.1/CMAC, cryptographic hash as specified in FCS_COP.1/Hash, keyed hash as specified in FCS_COP.1/KeyedHash, key wrap encryption algorithm as specified in FCS_COP.1/KeyWrap, authenticated encryption algorithm as specified in FCS_COP.1/AEAD, digital signature as specified in FCS_COP.1/SigVer, integrity verification supported by FDP_ITC_EXT.2.1_].
+FDP_ITC_EXT.2.2:: The TSF shall verify the integrity of the SDO using [*selection*: _cryptographic hash as specified in FCS_COP.1/Hash, message authentication code as specified in FCS_COP.1/MAC, key wrap encryption algorithm as specified in FCS_COP.1/KeyWrap, authenticated encryption algorithm as specified in FCS_COP.1/AEAD, digital signature as specified in FCS_COP.1/SigVer, integrity verification supported by FDP_ITC_EXT.2.1_].
 
 FDP_ITC_EXT.2.3:: The TSF shall use the security attributes associated with the imported user data.
 
@@ -1446,7 +1450,7 @@ _Application Note {counter:remark_count}_:: _This SFR applies to SDOs with the c
 
 FDP_SDI.2 Stored Data Integrity Monitoring and Action
 
-FDP_SDI.2.1:: The TSF shall monitor *SDOs and SDEs* controlled by the TSF for [_integrity errors_] on all objects, based on the following attributes: [*selection*: _[assignment: attribute associated with presence in protected storage], message authentication code as specified in FCS_COP.1/CMAC, cryptographic hash as specified in FCS_COP.1/Hash, keyed hash as specified in FCS_COP.1/KeyedHash, digital signature as specified in FCS_COP.1/SigVer, key wrap encryption algorithm as specified in FCS_COP.1/KeyWrap, authenticated encryption algorithm as specified in FCS_COP.1/AEAD_].
+FDP_SDI.2.1:: The TSF shall monitor *SDOs and SDEs* controlled by the TSF for [_integrity errors_] on all objects, based on the following attributes: [*selection*: _[assignment: attribute associated with presence in protected storage], cryptographic hash as specified in FCS_COP.1/Hash, message authentication code as specified in FCS_COP.1/MAC, digital signature as specified in FCS_COP.1/SigVer, key wrap encryption algorithm as specified in FCS_COP.1/KeyWrap, authenticated encryption algorithm as specified in FCS_COP.1/AEAD_].
 
 FDP_SDI.2.2:: Upon detection of a data integrity error, the TSF shall [
 +
@@ -1457,7 +1461,7 @@ _Application Note {counter:remark_count}_:: _This SFR deals with the mechanism t
 +
 _The cryptographic requirements for cryptographic hashes and digital signatures apply here._
 +
-_No specific requirement is placed here on the nature of the integrity protection data, but the Security Target shall describe this protection measure, and shall identify the iteration of FCS_COP.1/CMAC, FCS_COP.1/Hash, FCS_COP.1/KeyedHash, FCS_COP.1/KeyVer, FCS_COP.1/KeyWrap or FCS_COP.1/AEAD that covers any cryptographic algorithm used._
+_No specific requirement is placed here on the nature of the integrity protection data, but the Security Target shall describe this protection measure, and shall identify the iteration of FCS_COP.1/Hash, FCS_COP.1/MAC, FCS_COP.1/SigVer, FCS_COP.1/KeyWrap or FCS_COP.1/AEAD that covers any cryptographic algorithm used._
 +
 _The integrity protection data in FDP_SDI.2.1 is included in the list of attributes identified in FMT_MSA.1, and protects the value of the SDEs and of the SDO security attributes._
 +
@@ -1994,11 +1998,11 @@ The following rationale provides justification for each security problem definit
 |FTP_ITP_EXT.1 (selection-based)
 |This requirement defines a physically protected channel that the TSF can use to securely parse data being imported into it.
 
-.9+|T.WEAK_ELEMENT_BINDING
+.8+|T.WEAK_ELEMENT_BINDING
 |FCS_COP.1/Hash
 |This requirement provides a cryptographic operation for asserting the integrity of SDOs.
 
-|FCS_COP.1/KeyedHash
+|FCS_COP.1/MAC
 |This requirement provides a cryptographic operation for asserting the authenticity of SDOs.
 
 |FCS_COP.1/SigGen
@@ -2015,9 +2019,6 @@ The following rationale provides justification for each security problem definit
 
 |FPT_PRO_EXT.2 (optional)
 |This requirement ensures that the TSF can measure the integrity of its stored data.
-
-|FCS_COP.1/CMAC (selection-based)
-|This requirement provides a cryptographic operation for asserting the authenticity of SDOs.
 
 |FPT_FLS.1/FW (selection-based)
 |This requirement requires the TSF to take action to preserve its secure operation if any violations to its firmware integrity are detected.
@@ -2076,8 +2077,8 @@ The following rationale provides justification for each security problem definit
 |FCS_COP.1/Hash 
 |This requirement ensures the use of strong hash mechanisms.
 
-|FCS_COP.1/KeyedHash 
-|This requirement ensures the use of strong HMAC mechanisms.
+|FCS_COP.1/MAC
+|This requirement ensures the use of strong MAC mechanisms.
 
 |FCS_COP.1/SigGen 
 |This requirement ensures the use of strong digital signature services.
@@ -2125,10 +2126,7 @@ The following rationale provides justification for each security problem definit
 |FCS_CKM.5 (selection-based)
 |This requirement ensures the use of strong mechanisms to perform key derivation.
 
-.6+|T.WEAK_CRYPTO
-|FCS_COP.1/CMAC (selection-based)
-|This requirement ensures the use of strong methods to perform CMAC.
-
+.5+|T.WEAK_CRYPTO
 |FCS_COP.1/KeyEncap (selection-based)
 |This requirement ensures the use of strong methods to perform key encapsulation.
 
@@ -2693,12 +2691,6 @@ FCS_COP.1.1/AEAD:: The TSF shall perform [_authenticated encryption with associa
 
 |===
 
-==== FCS_COP.1/CMAC Cryptographic Operation (CMAC)
-
-FCS_COP.1/CMAC Cryptographic Operation (CMAC)
-
-FCS_COP.1.1/CMAC:: The TSF shall perform [_CMAC_] in accordance with a specified cryptographic algorithm [_AES-CMAC_] and cryptographic key sizes [*selection*: _128 bits, 192 bits, 256 bits_] that meet the following: [*selection*: _ISO/IEC 9797-1:2011 sub clause 7.6 (CMAC) and ISO/IEC 18033-3:2010 sub clause 5.2 (AES), NIST SP 800-38B (CMAC) and NIST FIPS 197 (AES)_].
-
 ==== FCS_COP.1/KeyEncap Cryptographic Operation (Key Encapsulation)
 
 FCS_COP.1/KeyEncap Cryptographic Operation (Key Encapsulation)
@@ -2829,7 +2821,7 @@ _Verifying the integrity of the firmware could be accomplished by guaranteeing t
 +
 _This requirement covers the case of ensuring the firmware is trustworthy in immutable form or mutable through any firmware updates, since the integrity and authenticity are checked prior to execution._
 +
-_FCS_COP.1/SigVer applies if the TOE provides the capability to update the TOE firmware and uses digital signatures for update verification. FCS_COP.1/CMAC or FCS_COP.1/KeyedHash applies if the TOE provides the capability to update the TOE firmware and uses MAC verification for update verification. The ST author should choose the algorithm implemented to perform digital signatures or MAC verification. For the algorithms chosen, the ST author should make the appropriate assignments/selections to specify the parameters that are implemented for that algorithm._
+_FCS_COP.1/SigVer applies if the TOE provides the capability to update the TOE firmware and uses digital signatures for update verification. FCS_COP.1/MAC applies if the TOE provides the capability to update the TOE firmware and uses MAC verification for update verification. The ST author should choose the algorithm implemented to perform digital signatures or MAC verification. For the algorithms chosen, the ST author should make the appropriate assignments/selections to specify the parameters that are implemented for that algorithm._
 
 ==== FPT_MFW_EXT.3 Firmware Authentication with Identity of Guarantor
 
@@ -3059,8 +3051,7 @@ Hierarchical to:: No other components.
 
 Dependencies:: [FCS_CKM.2 Cryptographic key distribution, or +
 FCS_CKM_EXT.7 Cryptographic Key Agreement] +
-FCS_COP.1/KeyedHash Cryptographic Operation (Keyed Hash) +
-FCS_CKM.6 Timing and event of cryptographic key destruction 
+FCS_CKM.6 Timing and event of cryptographic key destruction
 
 [vertical]
 FCS_CKM_EXT.8.1:: The TSF shall perform password-based key derivation functions in accordance with a specified cryptographic algorithm HMAC-[selection: _SHA-256, SHA-384, SHA-512_], with iteration count of [assignment: _number of iterations_] using a randomly generated salt of length {empty}[selection: _128, [assignment: greater than 128]_] and output cryptographic key sizes {empty}[selection: _128, 192, 256 [assignment: greater than 128]_] bits that meet the following: [assignment: _list of standards_].
@@ -4008,7 +3999,7 @@ FCS_CKM.6 - included
 |No dependencies.
 |There are no keys involved with hashing, so no cryptograhpic key-based dependencies are necessary.
 
-|FCS_COP.1/KeyedHash 
+|FCS_COP.1/MAC
 |[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7 or FCS_CKM_EXT.8] 
 
 FCS_CKM.6 
@@ -4395,14 +4386,10 @@ FCS_CKM.6 - included
 |FCS_CKM_EXT.8 
 |[FCS_CKM.2 or FCS_CKM_EXT.7]
 
-FCS_COP.1/KeyedHash
-
 FCS_CKM.6 
 |FCS_CKM.2 - included
 
 FCS_CKM_EXT.7 - included
-
-FCS_COP.1/KeyedHash - included
 
 FCS_CKM.6 - included
 
@@ -4427,25 +4414,6 @@ FCS_CKM_EXT.8 - (selection-based SFR) included
 FCS_CKM.6 - included
 
 FCS_OTV_EXT.1 - included
-
-|FCS_COP.1/CMAC
-|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7 or FCS_CKM_EXT.8]
-
-FCS_CKM.6
-
-|FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
-
-FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
-
-FCS_CKM.1 - included
-
-FCS_CKM.5 - (selection-based SFR) included
-
-FCS_CKM_EXT.7 - included
-
-FCS_CKM_EXT.8 - (selection-based SFR) included
-
-FCS_CKM.6 - included
 
 |FCS_COP.1/KeyEncap
 |[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7, or FCS_CKM_EXT.8]
@@ -4576,7 +4544,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/Hash !Cryptographic Operation (Hashing)
 
-!FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
+!FCS_COP.1/MAC !Cryptographic Operation (Message Authentication)
 
 !FCS_COP.1/KeyEncap !Cryptographic Operation (Key Encapsulation)
 
@@ -4616,7 +4584,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/Hash !Cryptographic Operation (Hashing)
 
-!FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
+!FCS_COP.1/MAC !Cryptographic Operation (Message Authentication)
 
 !FCS_COP.1/SKC !Cryptographic Operation (Symmetric-Key Cryptography)
 
@@ -4654,7 +4622,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/Hash !Cryptographic Operation (Hashing)
 
-!FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
+!FCS_COP.1/MAC !Cryptographic Operation (Message Authentication)
 
 !FCS_COP.1/SKC !Cryptographic Operation (Symmetric-Key Cryptography)
 
@@ -4696,7 +4664,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/Hash !Cryptographic Operation (Hashing)
 
-!FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
+!FCS_COP.1/MAC !Cryptographic Operation (Message Authentication)
 
 !FCS_COP.1/KeyEnc !Cryptographic Operation (Key Encryption)
 
@@ -4746,7 +4714,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/Hash !Cryptographic Operation (Hashing)
 
-!FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
+!FCS_COP.1/MAC !Cryptographic Operation (Message Authentication)
 
 !FCS_RBG.1 !Random Bit Generation (RBG)
 
@@ -4790,7 +4758,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/Hash !Cryptographic Operation (Hashing)
 
-!FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
+!FCS_COP.1/MAC !Cryptographic Operation (Message Authentication)
 
 !FCS_COP.1/KeyEnc !Cryptographic Operation (Key Encryption)
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -2560,19 +2560,21 @@ NIST SP 800-108 Rev. 1 (Section 4.3) [KDF in Double-Pipeline Iteration Mode] [se
 |[selection: 128, 192, 256] bits 
 |N/A
 
-|KDF-HASH 
-|Shared secret
-|Hash function from FCS_COP.1/Hash 
+|KDA-HASH-1S
+|Shared secret, output length, fixed information
+|Hash function from FCS_COP.1/Hash as H
 |[selection: 128, 192, 256] bits 
 |NIST SP 800-56C Rev. 2 (Section 4, Option 1)
 
-|KDF-MAC-1S
+|KDA-MAC-1S
 |Shared secret, salt, output length, fixed information 
-|Keyed Hash function from FCS_COP.1/KeyedHash
+|[selection: HMAC-SHA-1, HMAC-SHA-256, HMAC-SHA-512, KMAC128, KMAC256] as H
 |[selection: 128, 192, 256] bits 
 |NIST SP 800-56C Rev. 2 (Section 4, Options 2, 3)
 
-|KDF-MAC-2S 
+[selection: ISO/IEC 9797-1:2011 (CMAC), NIST SP 800-38B (CMAC), ISO/IEC 18033-3:2010 (AES), FIPS PUB 197 (AES), ISO/IEC 9797-2:2021 (HMAC), FIPS PUB 198-1 (HMAC), ISO/IEC 10118-3:2018 (SHA), FIPS PUB 180-4 (SHA)]
+
+|KDA-MAC-2S
 |Shared secret, salt, IV, output length, fixed information 
 |[MAC Step]
 
@@ -2597,15 +2599,15 @@ NIST SP 800-108 Rev. 1 (Section 4.3) [KDF in Double-Pipeline Iteration Mode] [se
 
 _Application Note {counter:remark_count}_:: _There are no standards that specify how to derive a key from two keys using XOR (KDF-XOR) or encryption (KDF-ENC). If KDF-XOR is selected, the ST Author should describe this method in the documentation. If KDF-ENC is selected, the ST Author should document the encryption algorithm used from FCS_COP.1/AEAD or FCS_COP.1/SKC, and which of the inputs is the plaintext and which is the key._
 +
-_In KDF-MAC-2S, if a CMAC is selected in the MAC step, then select AES-128-CMAC in the KDF step and select 128 as the output key size. If HMAC is selected in the MAC step, then select the same HMAC in the KDF._
+_In KDA-MAC-2S, if a CMAC is selected in the MAC step, then select AES-128-CMAC in the KDF step and select 128 as the output key size. If HMAC is selected in the MAC step, then select the same HMAC in the KDF._
 +
 _Under input parameters, if concatenated keys or intermediary keys is selected, the ST Author should describe the sources of the keys, and the order in which they are concatenated, along with any other values that are concatenated with them. This option may be chosen in instances when input keying material for the KDF comes from two independent sources, for example, a client and a server._
 +
 _If deriving a symmetric key, select any of the above rows._
 +
-_If deriving an initialization vector, an authentication secret, HMAC key, or KMAC key, select KDF-CTR, KDF-FB, KDF-DPI, KDF-HASH, KDF-XOR, or KDF-ENC._
+_If deriving an initialization vector, an authentication secret, HMAC key, or KMAC key, select KDF-CTR, KDF-FB, KDF-DPI, KDA-HASH-1S, KDF-XOR, or KDF-ENC._
 +
-_If deriving a secret IV or seed, select KDF-HASH, KDF-MAC-1S, or KDF-MAC-2S._
+_If deriving a secret IV or seed, select KDA-HASH-1S, KDA-MAC-1S, or KDA-MAC-2S._
 
 ==== FCS_CKM_EXT.8 Password-Based Key Derivation
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -828,12 +828,12 @@ FCS_COP.1.1/KeyedHash:: The TSF shall perform [_keyed hash message authenticatio
 |[selection: ISO/IEC 9797-2:2021 (Section 9 "MAC Algorithm 4"), NIST SP 800-185 (Section 4 "KMAC")]
 
 |KMACXOF128
-|128 bits	
-|[selection: ISO/IEC 9797-2:2021, (Section 9 "MAC Algorithm 4"), NIST SP 800-185, (Section 4 "KMAC")]
+|128 bits
+|[selection: ISO/IEC 9797-2:2021 (Section 9 "MAC Algorithm 4"), NIST SP 800-185 (Section 4 "KMAC")]
 
 |KMACXOF256
 |256 bits
-|[selection: ISO/IEC 9797-2:2021, (Section 9 "MAC Algorithm 4"), NIST SP 800-185, (Section 4 "KMAC")]
+|[selection: ISO/IEC 9797-2:2021 (Section 9 "MAC Algorithm 4"), NIST SP 800-185 (Section 4 "KMAC")]
 
 |===
 


### PR DESCRIPTION
HMAC and CMAC serve the same security goals, so it would make sense to have only one Security Functional Requirement. This simplifies our cPP and allows more flexibility in the future (e.g. if we wanted to add other MACs such as GMAC).

There are some tricky areas though:
- FCS_CKM_EXT.8 depended on FCS_COP.1/KeyedHash. However since that's our SFR, we can just remove the dependency. This doesn't really change the security properties, since by definition you'll need to implement HMAC in order to have a properly functioning PBKDF2 implementation.
- The KDF-MAC-2S referred to FCS_COP.1/KeyedHash, this has now been changed to an explicit list of allowed MACs.
- In the SD, the number of test groups and test cases was different for HMAC and CMAC (remember this is based on ACVP, which does not consistently provide the same number of test groups and test cases). Right now the new minimum for FCS_COP.1/MAC is the minimum of both SFRs (1 test group of 8 test cases).


Note this includes some commits from #396 so this cannot be merged until that PR is merged.