### PR TITLE
Align FCS_COP.1/Hash with CWG

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -607,7 +607,7 @@ There are no KMD evaluation activities for this component.
 
 ==== Cryptographic Operation (FCS_COP)
 
-===== FCS_COP.1/Hash Cryptographic Operation (Hashing) 
+===== FCS_COP.1/Hash Cryptographic Operation - Hashing
 
 ====== TSS
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -766,13 +766,15 @@ _There are no standards that specify how to derive a key from two keys using KEK
 +
 _For ST authors, please consider the assumptions that opposite parties in the operational environment contribute keying material that meets the same requirements._
 
-==== FCS_COP.1/Hash Cryptographic Operation (Hashing)
+==== FCS_COP.1/Hash Cryptographic Operation - Hashing
 
-FCS_COP.1/Hash Cryptographic Operation (Hashing)
+FCS_COP.1/Hash Cryptographic Operation - Hashing
 
-FCS_COP.1.1/Hash:: The TSF shall perform [_cryptographic hashing_] in accordance with a specified cryptographic algorithm [*selection*: _SHA-1, SHA-224, SHA-256, SHA-384, SHA-512, SHA-512/224, SHA-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512_] that meets the following: [*selection*: _ISO/IEC 10118-3:2018, FIPS PUB 180-4, FIPS PUB 202_].
+FCS_COP.1.1/Hash:: The TSF shall perform [_cryptographic hashing_] in accordance with a specified cryptographic algorithm [*selection*: _SHA-1, SHA-224, SHA-256, SHA-384, SHA-512, SHA-512/224, SHA-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512_] that meets the following: [*selection*: _ISO/IEC 10118-3:2018 [SHA, SHA3], FIPS PUB 180-4 [SHA], FIPS PUB 202 [SHA3]_].
 
-_Application Note {counter:remark_count}_:: _The hash selection should be consistent with the overall strength of the algorithm used for signature generation. For example, the TOE should choose SHA-256 for 2048-bit RSA or ECC with P-256; SHA-384 for 3072-bit RSA, 4096-bit RSA, or ECC with P-384; and SHA-512 for ECC with P-521. The ST author selects the standard based on the algorithms selected. SHA-1 may be used as a general hash function and for the following applications: generating and verifying hash-based message authentication codes (HMACs), key derivation functions (KDFs), and random bit/number generation. SHA-1 may also be used for verifying old digital signatures and time stamps, if this is explicitly allowed by the application domain. SHA-1 should not be used in applications in which collision resistance is needed._
+_Application Note {counter:remark_count}_:: _The hash selection shall be consistent with the overall strength of the algorithm used for signature generation. For example, the TOE should choose SHA-256 for 2048-bit RSA or ECC with P-256; SHA-384 for 3072-bit RSA, 4096-bit RSA, or ECC with P-384; and SHA-512 for ECC with P-521. The ST author selects the standard based on the algorithms selected._
++
+_SHA-1 may be used as a general hash function and for the following applications: generating and verifying hash-based message authentication codes (HMACs), key derivation functions (KDFs), and random bit/number generation. SHA-1 may also be used for verifying old digital signatures and time stamps, if this is explicitly allowed by the application domain. SHA-1 shall not be used in applications in which collision resistance is needed._
 
 ==== FCS_COP.1/KeyedHash Cryptographic Operation (Keyed Hash)
 
@@ -4572,7 +4574,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/AEAD !Cryptographic Operation (Authenticated Encryption with Associated Data)
 
-!FCS_COP.1/Hash !Cryptographic Operation (Hashing)
+!FCS_COP.1/Hash !Cryptographic Operation - Hashing
 
 !FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
 
@@ -4612,7 +4614,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/AEAD !Cryptographic Operation (Authenticated Encryption with Associated Data)
 
-!FCS_COP.1/Hash !Cryptographic Operation (Hashing)
+!FCS_COP.1/Hash !Cryptographic Operation - Hashing
 
 !FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
 
@@ -4650,7 +4652,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/AEAD !Cryptographic Operation (Authenticated Encryption with Associated Data)
 
-!FCS_COP.1/Hash !Cryptographic Operation (Hashing)
+!FCS_COP.1/Hash !Cryptographic Operation - Hashing
 
 !FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
 
@@ -4692,7 +4694,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/AEAD !Cryptographic Operation (Authenticated Encryption with Associated Data)
 
-!FCS_COP.1/Hash !Cryptographic Operation (Hashing)
+!FCS_COP.1/Hash !Cryptographic Operation - Hashing
 
 !FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
 
@@ -4742,7 +4744,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 !===
 
-!FCS_COP.1/Hash !Cryptographic Operation (Hashing)
+!FCS_COP.1/Hash !Cryptographic Operation - Hashing
 
 !FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
 
@@ -4786,7 +4788,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/AEAD !Cryptographic Operation (Authenticated Encryption with Associated Data)
 
-!FCS_COP.1/Hash !Cryptographic Operation (Hashing)
+!FCS_COP.1/Hash !Cryptographic Operation - Hashing
 
 !FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
 


### PR DESCRIPTION
The Crypto Working Group did not make any technical changes to this SFR.

I diverged from the Crypto Catalog in the following areas:
- In the application note, "The hash selection should be consistent" was changed to "The hash selection shall be consistent"
- In the application note, "SHA-1 should not be used in applications in which collision resistance is needed" was changed to "SHA-1 shall not be used in applications in which collision resistance is needed"
- editorial/formatting

This is potentially relevant to #377 and #381