### PR TITLE
Align FCS_COP.1/KeyedHash with CWG

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -652,7 +652,7 @@ The evaluator shall be able to provide a rationale as to the sufficiency of the 
 
 There are no KMD evaluation activities for this component.
 
-===== FCS_COP.1/KeyedHash Cryptographic Operation (Keyed Hash)
+===== FCS_COP.1/KeyedHash Cryptographic Operation - Keyed Hash
 
 ====== TSS
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -774,72 +774,62 @@ FCS_COP.1.1/Hash:: The TSF shall perform [_cryptographic hashing_] in accordance
 
 _Application Note {counter:remark_count}_:: _The hash selection should be consistent with the overall strength of the algorithm used for signature generation. For example, the TOE should choose SHA-256 for 2048-bit RSA or ECC with P-256; SHA-384 for 3072-bit RSA, 4096-bit RSA, or ECC with P-384; and SHA-512 for ECC with P-521. The ST author selects the standard based on the algorithms selected. SHA-1 may be used as a general hash function and for the following applications: generating and verifying hash-based message authentication codes (HMACs), key derivation functions (KDFs), and random bit/number generation. SHA-1 may also be used for verifying old digital signatures and time stamps, if this is explicitly allowed by the application domain. SHA-1 should not be used in applications in which collision resistance is needed._
 
-==== FCS_COP.1/KeyedHash Cryptographic Operation (Keyed Hash)
+==== FCS_COP.1/KeyedHash Cryptographic Operation - Keyed Hash
 
-FCS_COP.1/KeyedHash Cryptographic Operation (Keyed Hash)
+FCS_COP.1/KeyedHash Cryptographic Operation - Keyed Hash
 
-FCS_COP.1.1/KeyedHash:: The TSF shall perform [_keyed hash message authentication_] in accordance with a specified cryptographic algorithm [*selection*: _keyed hash algorithm_] and cryptographic *algorithm parameters* [*selection*: _cryptographic algorithm parameters_] that meet the following: [*selection*: _list of standards_].
+FCS_COP.1.1/KeyedHash:: The TSF shall perform [_keyed hash message authentication_] in accordance with a specified cryptographic algorithm [*selection*: _keyed hash algorithm_] and cryptographic key sizes [*selection*: _cryptographic key size_] that meet the following: [*selection*: _list of standards_].
 
-.Keyed Hash
+The following table provides the allowed choices for completion of the selection operations of FCS_COP.1/KeyedHash.
+
+.Allowed choices for FCS_COP.1/KeyedHash
 [[KeyedHashAlgorithms]]
 [cols=".^1,.^1,.^3",options=header]
 |===
 
-|Keyed Hash Algorithm 
-|Cryptographic Algorithm Parameters 
+|Keyed Hash Algorithm
+|Cryptographic Key Sizes
 |List of Standards
 
 |HMAC-SHA-1
 |[selection: (ISO, FIPS) 160, (FIPS) 128] bits
-|[selection: ISO/IEC 9797-2:2021 (Section 7 "MAC Algorithm 2"), FIPS PUB 198-1] [HMAC] 
-
-[selection: ISO/IEC 10118-3:2018, FIPS PUB 180-4] [SHA] 
+|[selection: ISO/IEC 9797-2:2021 (Section 7 "MAC Algorithm 2"); FIPS PUB 198-1]
 
 |HMAC-SHA-224
-|[selection: (ISO, FIPS) 224, (FIPS)  192, 128] bits
-|[selection: ISO/IEC 9797-2:2021 (Section 7 "MAC Algorithm 2"), FIPS PUB 198-1] [HMAC] 
-
-[selection: ISO/IEC 10118-3:2018, FIPS PUB 180-4] [SHA] 
+|[selection: (ISO, FIPS) 224, (FIPS) 192, 128] bits
+|[selection: ISO/IEC 9797-2:2021 (Section 7 "MAC Algorithm 2"); FIPS PUB 198-1]
 
 |HMAC-SHA-256
 |[selection: (ISO, FIPS) 256, (FIPS) 192, 128] bits
-|[selection: ISO/IEC 9797-2:2021 (Section 7 "MAC Algorithm 2"), FIPS PUB 198-1] [HMAC] 
-
-[selection: ISO/IEC 10118-3:2018, FIPS PUB 180-4] [SHA] 
+|[selection: ISO/IEC 9797-2:2021 (Section 7 "MAC Algorithm 2"); FIPS PUB 198-1]
 
 |HMAC-SHA-384
 |[selection: (ISO, FIPS) 384, (FIPS) 256, 192, 128] bits
-|[selection: ISO/IEC 9797-2:2021 (Section 7 "MAC Algorithm 2"), FIPS PUB 198-1] [HMAC] 
-
-[selection: ISO/IEC 10118-3:2018, FIPS PUB 180-4] [SHA] 
+|[selection: ISO/IEC 9797-2:2021 (Section 7 "MAC Algorithm 2"); FIPS PUB 198-1]
 
 |HMAC-SHA-512
 |[selection: (ISO, FIPS) 512, (FIPS) 384, 256, 192, 128] bits
-|[selection: ISO/IEC 9797-2:2021 (Section 7 "MAC Algorithm 2"), FIPS PUB 198-1] [HMAC] 
-
-[selection: ISO/IEC 10118-3:2018, FIPS PUB 180-4] [SHA] 
+|[selection: ISO/IEC 9797-2:2021 (Section 7 "MAC Algorithm 2"); FIPS PUB 198-1]
 
 |KMAC128
 |128 bits
-|[selection: ISO/IEC 9797-2:2021 (Section 9 "MAC Algorithm 4"), NIST SP 800-185 (Section 4 "KMAC")]
+|[selection: ISO/IEC 9797-2:2021 (Section 9 "MAC Algorithm 4"); NIST SP 800-185 (Section 4 "KMAC")]
 
 |KMAC256
 |256 bits
-|[selection: ISO/IEC 9797-2:2021 (Section 9 "MAC Algorithm 4"), NIST SP 800-185 (Section 4 "KMAC")]
+|[selection: ISO/IEC 9797-2:2021 (Section 9 "MAC Algorithm 4"); NIST SP 800-185 (Section 4 "KMAC")]
 
 |KMACXOF128
-|128 bits	
-|[selection: ISO/IEC 9797-2:2021, (Section 9 "MAC Algorithm 4"), NIST SP 800-185, (Section 4 "KMAC")]
+|[assignment: integer 256 <= Lk < 2^2040^]
+|[selection: ISO/IEC 9797-2:2021 (Section 9 "MAC Algorithm 4"); NIST SP 800-185 (Section 4 "KMAC")]
 
 |KMACXOF256
-|256 bits
-|[selection: ISO/IEC 9797-2:2021, (Section 9 "MAC Algorithm 4"), NIST SP 800-185, (Section 4 "KMAC")]
+|[assignment: integer 256 <= Lk < 2^2040^]
+|[selection: ISO/IEC 9797-2:2021 (Section 9 "MAC Algorithm 4"); NIST SP 800-185 (Section 4 "KMAC")]
 
 |===
 
-_Application Note {counter:remark_count}_:: _The HMAC minimum key sizes in the table are specified in the ISO 9797-2:2021 standard, which requires that the minimum key size be equal to the digest size. The FIPS PUB 198-1 standard specifies no minimum or maximum key sizes, so if FIPS PUB 198-1 is selected, larger or smaller key sizes may be used._
-
-:xrefstyle: full
+_Application Note {counter:remark_count}_:: _The HMAC minimum key sizes in the table are specified in ISO/IEC 9797-2:2021, which requires that the minimum key size be equal to the digest size. The FIPS standard specifies no minimum or maximum key sizes, so if FIPS PUB 198-1 is selected, larger or smaller key sizes may be used. This is indicted by the parenthesized annotations in the Cryptographic Key Sizes column._
 
 ==== FCS_COP.1/SigGen Cryptographic Operation (Signature Generation)
 
@@ -3057,7 +3047,7 @@ Hierarchical to:: No other components.
 
 Dependencies:: [FCS_CKM.2 Cryptographic key distribution, or +
 FCS_CKM_EXT.7 Cryptographic Key Agreement] +
-FCS_COP.1/KeyedHash Cryptographic Operation (Keyed Hash) +
+FCS_COP.1/KeyedHash Cryptographic Operation - Keyed Hash +
 FCS_CKM.6 Timing and event of cryptographic key destruction 
 
 [vertical]
@@ -4574,7 +4564,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/Hash !Cryptographic Operation (Hashing)
 
-!FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
+!FCS_COP.1/KeyedHash !Cryptographic Operation - Keyed Hash
 
 !FCS_COP.1/KeyEncap !Cryptographic Operation (Key Encapsulation)
 
@@ -4614,7 +4604,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/Hash !Cryptographic Operation (Hashing)
 
-!FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
+!FCS_COP.1/KeyedHash !Cryptographic Operation - Keyed Hash
 
 !FCS_COP.1/SKC !Cryptographic Operation (Symmetric-Key Cryptography)
 
@@ -4652,7 +4642,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/Hash !Cryptographic Operation (Hashing)
 
-!FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
+!FCS_COP.1/KeyedHash !Cryptographic Operation - Keyed Hash
 
 !FCS_COP.1/SKC !Cryptographic Operation (Symmetric-Key Cryptography)
 
@@ -4694,7 +4684,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/Hash !Cryptographic Operation (Hashing)
 
-!FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
+!FCS_COP.1/KeyedHash !Cryptographic Operation - Keyed Hash
 
 !FCS_COP.1/KeyEnc !Cryptographic Operation (Key Encryption)
 
@@ -4744,7 +4734,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/Hash !Cryptographic Operation (Hashing)
 
-!FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
+!FCS_COP.1/KeyedHash !Cryptographic Operation - Keyed Hash
 
 !FCS_RBG.1 !Random Bit Generation (RBG)
 
@@ -4788,7 +4778,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/Hash !Cryptographic Operation (Hashing)
 
-!FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
+!FCS_COP.1/KeyedHash !Cryptographic Operation - Keyed Hash
 
 !FCS_COP.1/KeyEnc !Cryptographic Operation (Key Encryption)
 


### PR DESCRIPTION
The Crypto Working Group made technical changes to this SFR, specifically:
- The allowed key sizes for KMACXOF were changed

I don't have any opinion on these technical changes made by the CWG.

Additionally, I diverged from the Crypto Catalog in the following areas:
- "recommended choices" was changed to "allowed choices"
- Not including the following application note from the Crypto Catalog:
> If “KMACXOF128” or “KMACXOF256” is selected as Keyed Hash Algorithm, then FCS_COP.1/XOF must be claimed. 

The reason is twofold: firstly, we don't have FCS_COP.1/XOF in the cPP yet, secondly this kind of "hidden requirement" (#377) is not proper
- editorial/formatting