### PR TITLE
Align FCS_COP.1/SigVer with CWG

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -722,7 +722,7 @@ The evaluator shall be able to provide a rationale as to the sufficiency of the 
 
 There are no KMD evaluation activities for this component.
 
-===== FCS_COP.1/SigVer Cryptographic Operation (Signature Verification)
+===== FCS_COP.1/SigVer Cryptographic Operation - Signature Verification
 
 ====== TSS
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -923,16 +923,20 @@ _FIPS 186-5 specifies that the same key generation algorithm applies to both ECD
 +
 _For LMS and XMSS, the key sizes do not represent the expected security strength. All key sizes given here correspond to an expected security strength of 128 bits, per NIST SP 800-208._
 
-==== FCS_COP.1/SigVer Cryptographic Operation (Signature Verification)
+==== FCS_COP.1/SigVer Cryptographic Operation - Signature Verification
 
-FCS_COP.1/SigVer Cryptographic Operation (Signature Verification)
+FCS_COP.1/SigVer Cryptographic Operation - Signature Verification
 
 FCS_COP.1.1/SigVer:: The TSF shall perform [_digital signature verification_] in accordance with a specified cryptographic algorithm [*selection*: _cryptographic algorithm_] and cryptographic *algorithm parameters* [*selection*: _cryptographic algorithm parameters_] that meet the following: [*selection*: _list of standards_].
 
-.Signature Verification
+
+The following table provides the allowed choices for completion of the selection operations of FCS_COP.1/SigVer.
+
+.Allowed choices for FCS_COP.1/SigVer
 [[SigVerOps]]
 [cols=".^1,.^2,.^2,.^2",options=header]
 |===
+
 |Identifier
 |Cryptographic Algorithm
 |Cryptographic Algorithm Parameters
@@ -940,72 +944,90 @@ FCS_COP.1.1/SigVer:: The TSF shall perform [_digital signature verification_] in
 
 |RSA-PKCS
 |RSASSA-PKCS1-v1_5
-|Modulus of size [selection: 2048, 3072, 4096] bits, hash or XOF [selection: SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512, SHAKE128, SHAKE256]
-|[selection: RFC 8017, PKCS #1 v2.2 (Section 8.2), FIPS PUB 186-5 (Section 5.4)] [RSASSA-PKCS1-v1_5]
+|Modulus of size [selection: 2048, 3072, 4096] bits, hash or XOF [selection: SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512]
+|RFC 8017 (Section 8.2) [PKCS #1 v2.2]
 
-[selection: ISO/IEC 10118-3:2018, FIPS 180-4 [SHA2], FIPS PUB 202 [SHA3]]
+FIPS PUB 186-5 (Section 5.4) [RSASSA-PKCS1-v1_5]
 
 |RSA-PSS
 |RSASSA-PSS
 |Modulus of size [selection: 2048, 3072, 4096] bits, hash or XOF [selection: SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512, SHAKE128, SHAKE256]
-|[selection: RFC 8017, PKCS#1 v2.2 (Section 8.1), FIPS PUB 186-5 (Section 5.4)] [RSASSA-PSS]
+|RFC 8017 (Section 8.1) [PKCS #1 v2.2]
 
-[selection: ISO/IEC 10118-3:2018, FIPS 180-4 [SHA2], FIPS PUB 202 [SHA3]]
+FIPS PUB 186-5 (Section 5.4) [RSASSA-PSS]
 
 |DSA
 |DSA
 |Domain parameters for (L, N) = [selection: (2048, 224), (2048, 256), (3072, 256)] bits
-|FIPS PUB 186-4 (Section 4.7)
+|FIPS PUB 186-4 (Section 4.7) [DSA Signature Verification]
 
 |ECDSA
 |ECDSA
-|Elliptic Curve [selection: brainpoolP256r1, brainpoolP384r1, brainpoolP512r1, NIST P-256, NIST P-384, NIST P-521] using hash or XOF [selection: SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512, SHAKE128, SHAKE256]
-|[selection: ISO/IEC 14888-3:2018 (Sub Clause 6.6), FIPS PUB 186-5 (Section 6.4.2)] [ECDSA]
+|Elliptic Curve [selection: P-256, brainpoolP256r1, P-384, brainpoolP384r1, P-521, brainpoolP512r1] using hash or XOF function using [selection: SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512, SHAKE128, SHAKE256]
+|[selection: ISO/IEC 14888-3:2018 (Subclause 6.6), FIPS PUB 186-5 (Section 6.4.2)] [ECDSA]
 
-[selection: RFC 5639 (Section 3) [Brainpool Curves], NIST SP 800-186 (Section 3) [NIST Curves]]
-
-[selection: ISO/IEC 10118-3:2018, FIPS 180-4 [SHA2], FIPS PUB 202 [SHA3, SHAKE]]
+[selection: RFC 5639 (Section 3) [Brainpool Curves], NIST SP-800 186 (Section 4) [NIST Curves]]
 
 |KCDSA
 |KCDSA
-|hash or XOF function using [selection: SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512, SHAKE128, SHAKE256]
-|ISO/IEC 14888-3:2018 (Sub Clause 6.3) [KCDSA]
-
-[selection: ISO/IEC 10118-3:2018 (Clause 10, 14), FIPS 180-4 [SHA2], FIPS PUB 202 [SHA3, SHAKE]]
+|hash function using [selection: SHA-224, SHA-256, SHA-384, SHA-512]
+|ISO/IEC 14888-3:2018 (Subclause 6.3) [KCDSA]
 
 |EC-KCDSA
-|EC-KCDSA 
-|Elliptic Curve [selection: NIST P-224, NIST P-256, NIST B-233, NIST B-283, NIST K-233, NIST K-283] using hash or XOF [selection: SHA-224, SHA-256 SHA3-256, SHA3-384, SHA3-512, SHAKE128, SHAKE256]
-|ISO/IEC 14888-3:2018 (Sub Clause 6.7) [EC-KCDSA]
+|EC-KCDSA
+|Elliptic Curve [selection: P-224, P-256, B-233, B-283, K-233, K-283] using hash [selection: SHA-224, SHA-256, SHA-384, SHA-512]
+|ISO/IEC 14888-3:2018 (Subclause 6.7) [EC-KCDSA]
 
 NIST SP 800-186 (Section 3) [NIST Curves]
-
-[selection: ISO/IEC 10118-3:2018 (Clause 10, 14), FIPS 180-4 [SHA2], FIPS PUB 202 [SHA3, SHAKE]]
 
 |EdDSA
 |Edwards-Curve Digital Signature Algorithm
 |Domain parameters approved for elliptic curves [selection: Edwards25519, Edwards448]
-|[selection: NIST FIPS 186-5 (section 7.7), RFC 8032]
+|NIST FIPS PUB 186-5 (Section 7.7) [EdDSA]
 
-[selection: ISO/IEC 10118-3:2018 (Clause 10, 14), FIPS 180-4 [SHA2], FIPS PUB 202 [SHAKE]]
+RFC 8032 [Edwards Curves]
 
 |LMS
-|LMS, HSS
-|Hash/XOF [selection: SHA256/192, SHAKE256/192]
-|NIST SP 800-208, RFC 8554
+|LMS
+|Private key size = [selection: 192 bits with [selection: SHA-256/192, SHAKE256/192], 256 bits with [selection: SHA-256, SHAKE256]], Winternitz parameter = [selection: 1, 2, 4, 8], and tree height = [selection: 5, 10, 15, 20, 25]
+|RFC 8554 [LMS]
+
+NIST SP 800-208 [parameters]
+
+|HSS
+|Multitree version of LMS
+|Private key size = [selection: 192 bits with [selection: SHA-256/192, SHAKE256/192], 256 bits with [selection: SHA-256, SHAKE256]], Winternitz parameter = [selection: 1, 2, 4, 8], tree height = [selection: 5, 10, 15, 20, 25], and number of levels = [selection: 1, 2, 3, 4, 5, 6, 7, 8]
+|RFC 8554 [HSS]
+
+NIST SP 800-208 [parameters]
 
 |XMSS
-|XMSS, XMSS^MT^
-|Hash/XOF [selection: SHA256/192, SHAKE256/192]
-|NIST SP 800-208, RFC 8391
+|XMSS
+|Private key size = [selection: 192 bits with [selection: SHA-256/192, SHAKE256/192], 256 bits with [selection: SHA-256, SHAKE256]], tree height = [selection: 10, 16, 20]
+|RFC 8391 [XMSS]
+
+NIST SP 800-208 [parameters]
+
+|XMSS^MT^
+|Multitree version of XMSS
+|Private key size = [selection: 192 bits with [selection: SHA-256/192, SHAKE256/192], 256 bits with [selection: SHA-256, SHAKE256]], (total tree height, number of levels) = [selection: (20, 2), (20, 4), (40, 2), (40, 4), (40, 8), (60, 3), (60, 6), (60, 12)]
+|RFC 8391 [XMSS^MT^]
+
+NIST SP 800-208 [parameters]
 
 |===
 
-_Application Note {counter:remark_count}_:: _DSA is no longer approved for digital signature generation. DSA may be used to verify signatures generated prior to the implementation date of FIPS 186-5. The specifications and algorithms for DSA are no longer included in FIPS 186-5. They may be found in FIPS 186-4._
+_Application Note {counter:remark_count}_:: _FIPS 186-5 allows the use of SHAKE128 and SHAKE256. Implementations shall use the correct number of bits of output as specified in FIPS 186-5._
 +
-_FIPS 186-5 allows the use of SHAKE128 and SHAKE256. Implementations must use the correct number of bits of output as specified in FIPS 186-5._
+_DSA may only be used to verify signatures generated prior to the implementation date of FIPS 186-5._
 +
-_The TOE may contain a public key which is integrity protected (e.g., in hardware), in which case the FDP_ITC.1 and FDP_ITC.2 dependencies do not apply. In this case, no dependencies may be chosen. For signature verifications, private keys are not necessary, so there are no dependencies required for generating or destroying cryptographic keys._
+_The TOE may contain a public key which is integrity protected (e.g., in hardware), in which case the FDP_ITC.1 and FDP_ITC.2 dependencies do not apply. In this case, no dependencies may be chosen._
++
+_For signature verifications, private keys are not necessary, so there are no dependencies required for generating or destroying cryptographic keys._
++
+_For LMS, HSS, XMSS, and XMSS^MT^, the key sizes do not represent the expected security strength. All key sizes given here correspond to an expected security strength of 128 bits, per NIST SP 800-208._
++
+_For HSS and XMSS^MT^ the same hash or XOF function shall be used at each level. Within each level, the same Winternitz parameter shall be used but can be different for each level. For HSS, within each level, the same tree height shall be used but can be different for each level._
 
 ==== FCS_COP.1/SKC Cryptographic Operation (Symmetric-Key Cryptography)
 
@@ -4700,7 +4722,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/SigGen !Cryptographic Operation (Signature Generation)
 
-!FCS_COP.1/SigVer !Cryptographic Operation (Signature Verification)
+!FCS_COP.1/SigVer !Cryptographic Operation - Signature Verification
 
 !FCS_COP.1/SKC !Cryptographic Operation (Symmetric-Key Cryptography)
 


### PR DESCRIPTION
The Crypto Working Group made technical changes to this SFR, specifically:
- Hash functions for KCDSA and EC-KCDSA were updated
- LMS and HSS were separated in two separate rows
- Additional selections were defined for LMS and HSS 
- XMSS and XMSS^MT^ were separated in two separate rows
- Additional selections were defined for XMSS and XMSS^MT^

I don't have any opinion on the KCDSA and EC-KCDSA changes; I agree with the LMS, HSS, XMSS, and XMSS^MT^ changes made by the CWG.

Additionally, I diverged from the Crypto Catalog in the following areas:
- "recommended choices" was changed to "allowed choices"
- Consistency with FCS_COP.1/SigGen
- The application note "FIPS 186-5 allows the use of SHAKE128 and SHAKE256. Implementations must use the correct number of bits of output as specified in FIPS 186-5." seems to be a note we added ourselves or was removed from the Crypto Catalog. I believe it is still useful so I kept it but changed "must" to "shall" per #381.
- editorial/formatting