### PR TITLE
Align FCS_CKM.1/SKG with CWG

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -1928,7 +1928,7 @@ If the TOE uses the generated key in a key chain/hierarchy then the evaluator sh
 * If [.underline]#AK1# is selected, then the KMD describes which methods for generating p and q are used
 * How the key is used as part of the key chain/hierarchy. 
 
-===== FCS_CKM.1/SKG Cryptographic key generation (Symmetric Key)
+===== FCS_CKM.1/SKG Cryptographic Key Generation - Symmetric Key
 
 ====== TSS
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -2462,24 +2462,28 @@ _When generating EdDSA key pairs for digital signatures, choose NIST FIPS PUB 18
 _For hash-based signatures, the choice of the hash or XOF determines the security of the system. For 192 bits of security strength, choose SHA256/192 or SHAKE256/192. For 256 bits of security strength, choose SHA256 or SHAKE256._
 
 
-==== FCS_CKM.1/SKG Cryptographic Key Generation (Symmetric Key)
+==== FCS_CKM.1/SKG Cryptographic Key Generation - Symmetric Key
 
-FCS_CKM.1/SKG Cryptographic Key Generation (Symmetric Key)
+FCS_CKM.1/SKG Cryptographic Key Generation - Symmetric Key
 
 FCS_CKM.1.1/SKG:: The TSF shall generate *symmetric* cryptographic keys in accordance with a specified cryptographic key generation algorithm [*selection*: _cryptographic key generation algorithm_] and specified cryptographic key sizes [*selection*: _cryptographic key sizes_] that meet the following: [*selection*: _list of standards_].
 
-.Symmetric Cryptographic Key Generation
+The following table provides the allowed choices for completion of the selection operations of FCS_CKM.1/SKG:
+
+.Allowed choices for FCS_CKM.1/SKG
 [[SymKeyGen]]
-[cols=".^1,.^2,.^2",options=header]
+[cols=".^1,.^2,.^2,.^2",options=header]
 |===
 
+|Identifier
 |Cryptographic Key Generation Algorithm
 |Cryptographic Key Sizes
 |List of Standards
 
-|Direct Generation from a Random Bit Generator as specified in FCS_RBG.1 
-|[selection: 128, 192, 256, 512] bits 
-|NIST SP 800-133 Rev. 2 (Section 6.1).
+|RSK
+|Direct Generation from a Random Bit Generator as specified in FCS_RBG.1
+|[selection: 128, 192, 256, 512] bits
+|NIST SP 800-133 Revision 2 (Section 6.1). [Direct generation of symmetric keys]
 
 |===
 
@@ -4640,7 +4644,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_RBG.5 !Random Bit Generation (Combining Entropy Sources)
 
-!FCS_CKM.1/SKG !Cryptographic key generation - Symmetric Key
+!FCS_CKM.1/SKG !Cryptographic Key Generation - Symmetric Key
 
 !===
 


### PR DESCRIPTION
The Crypto Working Group did not make any technical changes to this SFR.

I diverged from the Crypto Catalog in the following areas:
- "recommended choices" was changed to "allowed choices"
- editorial/formatting