### PR TITLE
Align FCS_COP.1/CMAC with CWG

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -2115,7 +2115,7 @@ Assessment of the complete data path for authenticated encryption with associate
 
 The evaluator shall examine the KMD to ensure that it describes how the IV is generated and that the same initialization vector is never reused to encrypt different plaintext pairs under the same key. Moreover in the case of GCM, the evaluator must ensure that, at each invocation of GCM, the length of the plaintext is at most (2^32)-2 blocks.
 
-===== FCS_COP.1/CMAC Cryptographic Operation (CMAC)
+===== FCS_COP.1/CMAC Cryptographic Operation - CMAC
 
 ====== TSS
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -2691,11 +2691,39 @@ FCS_COP.1.1/AEAD:: The TSF shall perform [_authenticated encryption with associa
 
 |===
 
-==== FCS_COP.1/CMAC Cryptographic Operation (CMAC)
+==== FCS_COP.1/CMAC Cryptographic Operation - CMAC
 
-FCS_COP.1/CMAC Cryptographic Operation (CMAC)
+FCS_COP.1/CMAC Cryptographic Operation - CMAC
 
-FCS_COP.1.1/CMAC:: The TSF shall perform [_CMAC_] in accordance with a specified cryptographic algorithm [_AES-CMAC_] and cryptographic key sizes [*selection*: _128 bits, 192 bits, 256 bits_] that meet the following: [*selection*: _ISO/IEC 9797-1:2011 sub clause 7.6 (CMAC) and ISO/IEC 18033-3:2010 sub clause 5.2 (AES), NIST SP 800-38B (CMAC) and NIST FIPS 197 (AES)_].
+FCS_COP.1.1/CMAC:: The TSF shall perform [_CMAC_] in accordance with a specified cryptographic algorithm [*selection*: _cryptographic algorithm_] and cryptographic key sizes [*selection*: _cryptographic key sizes_] that meet the following: [*selection*: _list of standards_].
+
+The following table provides the allowed choices for completion of the selection operations of FCS_COP.1/CMAC.
+
+.Allowed choices for FCS_COP.1/CMAC
+[[CMACAlgorithms]]
+[cols=".^1,.^2,.^2,.^2",options=header]
+|===
+
+|Identifier
+|Cryptographic Algorithm
+|Cryptographic Key Sizes
+|List of Standards
+
+|AES-CMAC
+|AES using CMAC mode
+|[selection: 128, 192, 256] bits
+|[selection: ISO/IEC 18033-3:2010 (Subclause 5.2), FIPS PUB 197] [AES]
+
+[selection: ISO/IEC 9797-1:2011 Subclause 7.6, NIST SP 800-38B] [CMAC]
+
+|CAM-CMAC
+|Camellia using CMAC mode
+|[selection: 128, 192, 256] bits
+|ISO/IEC 18033-3:2010 Subclause 5.3 [Camellia]
+
+[selection: ISO/IEC 9797-1:2011 Subclause 7.6, NIST SP 800-38B] [CMAC]
+
+|===
 
 ==== FCS_COP.1/KeyEncap Cryptographic Operation (Key Encapsulation)
 
@@ -4576,6 +4604,8 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
 
+!FCS_COP.1/CMAC !Cryptographic Operation - CMAC
+
 !FCS_COP.1/KeyEncap !Cryptographic Operation (Key Encapsulation)
 
 !FCS_COP.1/KeyWrap !Cryptographic Operation (Key Wrap)
@@ -4616,6 +4646,8 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
 
+!FCS_COP.1/CMAC !Cryptographic Operation - CMAC
+
 !FCS_COP.1/SKC !Cryptographic Operation (Symmetric-Key Cryptography)
 
 !FCS_RBG.1 !Random Bit Generation (RBG)
@@ -4653,6 +4685,8 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 !FCS_COP.1/Hash !Cryptographic Operation (Hashing)
 
 !FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
+
+!FCS_COP.1/CMAC !Cryptographic Operation - CMAC
 
 !FCS_COP.1/SKC !Cryptographic Operation (Symmetric-Key Cryptography)
 
@@ -4695,6 +4729,8 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 !FCS_COP.1/Hash !Cryptographic Operation (Hashing)
 
 !FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
+
+!FCS_COP.1/CMAC !Cryptographic Operation - CMAC
 
 !FCS_COP.1/KeyEnc !Cryptographic Operation (Key Encryption)
 
@@ -4746,6 +4782,8 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
 
+!FCS_COP.1/CMAC !Cryptographic Operation - CMAC
+
 !FCS_RBG.1 !Random Bit Generation (RBG)
 
 !FCS_OTV_EXT.1 !One-Time Value
@@ -4789,6 +4827,8 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 !FCS_COP.1/Hash !Cryptographic Operation (Hashing)
 
 !FCS_COP.1/KeyedHash !Cryptographic Operation (Keyed Hash)
+
+!FCS_COP.1/CMAC !Cryptographic Operation - CMAC
 
 !FCS_COP.1/KeyEnc !Cryptographic Operation (Key Encryption)
 


### PR DESCRIPTION
The Crypto Working Group made technical changes to this SFR, specifically:
- Add CAM-CMAC

I don't have any opinion on these technical changes made by the CWG.

Additionally, I diverged from the Crypto Catalog in the following areas:
- "recommended choices" was changed to "allowed choices"
- editorial/formatting/typo fixes

I also added some references to FCS_COP.1/CMAC throughout the cPP where KeyedHash is used.