### PR TITLE
Align FCS_COP.1/KeyWrap with CWG

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -2190,7 +2190,7 @@ The evaluator shall be able to provide a rationale as to the sufficiency of the 
 
 There are no KMD evaluation activities for this component.
 
-===== FCS_COP.1/KeyWrap Cryptographic Operation (Key Wrap)
+===== FCS_COP.1/KeyWrap Cryptographic Operation - Key Wrapping
 
 ====== TSS
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -2722,9 +2722,10 @@ FCS_COP.1.1/KeyEncap:: The TSF shall perform [_key encapsulation_] in accordance
 
 |===
 
-==== FCS_COP.1/KeyWrap Cryptographic Operation (Key Wrap)
 
-FCS_COP.1/KeyWrap Cryptographic Operation (Key Wrap)
+==== FCS_COP.1/KeyWrap Cryptographic Operation - Key Wrapping
+
+FCS_COP.1/KeyWrap Cryptographic Operation - Key Wrapping
 
 FCS_COP.1.1/KeyWrap:: The TSF shall perform [_key wrapping_] in accordance with a specified cryptographic algorithm [*selection*: _cryptographic algorithm_] and cryptographic key sizes [*selection*: _cryptographic algorithm parameters_] that meet the following: [*selection*: _list of standards_].
 
@@ -2734,37 +2735,35 @@ FCS_COP.1.1/KeyWrap:: The TSF shall perform [_key wrapping_] in accordance with 
 |===
 
 |Identifier
-|Cryptographic Algorithm 
-|Cryptographic Algorithm Parameters
+|Cryptographic Algorithm
+|Cryptographic Key Sizes
 |List of Standards
 
 |KW 
-|[selection: AES, CAM, SEED, LEA] in KW mode 
+|[selection: AES, CAM, SEED, LEA] in KW mode
 |[selection: (AES, CAM, SEED, LEA) 128, (AES, CAM, LEA) 192, (AES, CAM, LEA) 256] bits
-|[selection: ISO/IEC 19772:2020 (clause 6) [Key Wrap], NIST SP 800-38F (Section 6.2) [KW]]
+|[selection: ISO/IEC 19772:2020 (Clause 6), NIST SP 800-38F (Section 6.2)] [KW mode]
 
-ISO/IEC 18033-3 (Sub Clause 5.2) [AES]
-
-ISO/IEC 18033-3:2010 (Sub Clause 5.3) [Camellia] 
-
-ISO/IEC 18033-3:2010 (Sub Clause 5.4) [SEED]
-
-ISO/IEC 29192-2:2019 (Sub Clause 6.3) [LEA]
-
-|KWP 
-|[selection: AES, CAM, SEED, LEA]  in KWP mode 
+|KWP
+|[selection: AES, CAM, SEED, LEA] in KWP mode
 |[selection: (AES, CAM, SEED, LEA) 128, (AES, CAM, LEA) 192, (AES, CAM, LEA) 256] bits
-|NIST SP 800-38F (Section 6.3) [KWP]
+|NIST SP 800-38F (Section 6.3) [KWP mode]
 
-ISO/IEC 18033-3 (Sub Clause 5.2) [AES]
+|CCM
+|[selection: AES, CAM, LEA, SEED] in CCM mode with non-repeating nonce, minimum size of 64 bits
+|[selection: (AES, CAM, SEED, LEA) 128, (AES, CAM, LEA) 192, (AES, CAM, LEA) 256] bits
+|[selection: ISO/IEC 19772:2020 (Clause 7), NIST SP 800-38C] [CCM mode]
 
-ISO/IEC 18033-3:2010 (Sub Clause 5.3) [Camellia] 
+|GCM
+|[selection: AES, CAM, LEA, SEED] in GCM mode with non-repeating IVs
 
-ISO/IEC 18033-3:2010 (Sub Clause 5.4) [SEED]
-
-ISO/IEC 29192-2:2019 (Sub Clause 6.3) [LEA]
+IV length must be equal to 96 bits; the deterministic IV construction method [SP800-38D, Section 8.2.1] must be used; the MAC length t must be one of the values 96, 104, 112, 120, and 128 bits.
+|[selection: (AES, CAM, SEED, LEA) 128, (AES, CAM, LEA) 192, (AES, CAM, LEA) 256] bits
+|[selection: ISO/IEC 19772:2020 (Clause 10), NIST SP 800-38C] [CCM mode]
 
 |===
+
+_Application Note {counter:remark_count}_:: _NIST SP 800-57 Part 1 Revision 5 Section 5.6.2 specifies that the size of key used to protect the key being wrapped should be at least the security strength of the key it is protecting._
 
 === User Data Protection
 ==== FDP_DAU.1/Prove Basic Data Authentication (for Use with the Prove Service)
@@ -3028,7 +3027,7 @@ FCS_CKM.5 Cryptographic key derivation, or +
 FCS_CKM_EXT.8 Password-based key derivation] +
 FCS_CKM.6 Timing and event of cryptographic key destruction, +
 [FCS_COP.1/KeyEncap Cryptographic Operation (Key Encapsulation), or +
-FCS_COP.1/KeyWrap Cryptographic Operation (Key Wrap), or +
+FCS_COP.1/KeyWrap Cryptographic Operation - Key Wrapping, or +
 FCS_COP.1/SKC Cryptographic Operation (Symmetric-Key Cryptography), or +
 FCS_COP.1/AEAD Authenticated Encryption with Associated Data]
 
@@ -4578,7 +4577,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/KeyEncap !Cryptographic Operation (Key Encapsulation)
 
-!FCS_COP.1/KeyWrap !Cryptographic Operation (Key Wrap)
+!FCS_COP.1/KeyWrap !Cryptographic Operation - Key Wrapping
 
 !FCS_COP.1/SKC !Cryptographic Operation (Symmetric-Key Cryptography)
 


### PR DESCRIPTION
The Crypto Working Group made technical changes to this SFR, specifically:
- Added CCM
- Added GCM

I agree with the addition of CCM and GCM, it will reduce the number of references in our cPP (previously we referred to both /KeyWrap and /AEAD when keys were encrypted, now the reference to /AEAD can be removed). However, I don't understand the restriction that the deterministic IV construction method must be used. 

Additionally, I diverged from the Crypto Catalog in the following areas:
- "recommended choices" was changed to "allowed choices"
- Made the application note consistent with FCS_COP.1/KeyEncap
- editorial/formatting
