### PR TITLE
 Align FCS_CKM.5 with CWG

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -1967,10 +1967,10 @@ If [.underline]#Concatenated key5# is selected for any key derivation function, 
 * The description must include how an approved untruncated MAC function is being used for the randomness extraction step and the evaluator must verify the TSS describes that the output length (in bits) of the MAC function is at least as large as the targeted security strength (in bits) of the parameter set employed by the key establishment scheme (see Tables 1-3 of SP 800-56C Rev. 2).
 * The description must include how the MAC function being used for the randomness extraction step is related to the PRF used in the key expansion and verify the TSS description includes the correct MAC function:
 ** If an HMAC-hash is used in the randomness extraction step, then the same HMAC-hash (with the same hash function hash) is used as the PRF in the key expansion step.
-** If an AES-CMAC (with key length 128, 192, or 256 bits) is used in the randomness extraction step, then AES-CMAC with a 128-bit key is used as the PRF in the key expansion step.
+** If an AES-N-CMAC or Camellia-N-CMAC (with N equal to 128, 192, or 256 bits) is used in the randomness extraction step, then CMAC with the same cipher and a 128-bit key is used as the PRF in the key expansion step.
 * The description must include the lengths of the salt values being used in the randomness extraction step and the evaluator shall verify the TSS description includes correct salt lengths:
 ** If an HMAC-hash is being used as the MAC, the salt length can be any value up to the maximum bit length permitted for input to the hash function hash.
-** If an AES-CMAC is being used as the MAC, the salt length shall be the same length as the AES key (i.e. 128, 192, or 256 bits).
+** If an CMAC is being used as the MAC, the salt length shall be the same length as the CMAC cipher key (i.e. 128, 192, or 256 bits).
 
 ====== AGD
 

--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -1982,10 +1982,10 @@ The algorithm tests might require access to a development version of the TOE or 
 
 The developer shall provide sufficient information to the evaluator to properly define the implementation of the algorithm. The evaluator shall define at least one test group (a configuration of algorithm properties and associated test cases) for each combination of the following parameters, according to the implementation of the algorithm:
 
-* PRF (KDF-CTR, KDF-FB, KDF-DPI)
+* PRF (KDF-CTR, KDF-FB, KDF-DPI, KDF-KMAC)
 * Encryption algorithm (KDF-ENC)
 * Hash algorithm (KDF-HASH)
-* MAC algorithm (KDF-MAC-1S, KDF-MAC-2S, KDF-KMAC)
+* MAC algorithm (KDF-MAC-1S, KDF-MAC-2S)
 * Counter size (KDF-CTR, KDF-FB, KDF-DPI)
 * Counter location (KDF-CTR, KDF-FB, KDF-DPI)
 * Salt length (KDF-MAC-1S, KDF-MAC-2S)

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -2532,6 +2532,12 @@ The following table provides the allowed choices for completion of the selection
 |[selection: 128, 192, 256, 512] bits
 |[selection: ISO/IEC 11770-6:2016 (Subclause 7.3.4) [KPF3], NIST SP 800-108 Revision 1 Update 1 (Section 4.3) [KDF in Double-Pipeline Iteration Mode]]
 
+|KDF-KMAC
+|Input key(s), label, context, output length
+|[selection: KMAC128, KMAC256]
+|[selection: 128, 192, 256, 512] bits
+|NIST SP 800-108 Revision 1 Update 1 (Section 4.4 "KDF Using KMAC")
+
 |KDF-XOR
 |More than one intermediary keys
 |exclusive OR (XOR)
@@ -2569,12 +2575,6 @@ KDF Step
 |[selection: 128, 192, 256, 512] bits
 |NIST SP 800-56C Revision 2 (Section 5) [Two-Step Key Derivation]
 
-|KDF-KMAC
-|Input key(s), label, context, output length
-|[selection: KMAC128, KMAC256]
-|[selection: 128, 192, 256, 512] bits
-|NIST SP 800-108 Revision 1 Update 1 (Section 4.4 "KDF Using KMAC")
-
 |===
 
 _Application Note {counter:remark_count}_:: _There are no standards that specify how to derive a key from two keys using XOR (KDF-XOR) or encryption (KDF-ENC). If KDF-XOR is selected, the ST Author should describe this method in the documentation. If KDF-ENC is selected, the ST Author should document the encryption algorithm used from FCS_COP.1/AEAD or FCS_COP.1/SKC, and which of the inputs is the plaintext and which is the key._
@@ -2582,7 +2582,6 @@ _Application Note {counter:remark_count}_:: _There are no standards that specify
 _In KDF-MAC-2S, if AES-N-CMAC or Camellia-N-CMAC is selected in the MAC step, then select CMAC with the same cipher and a 128-bit key in the KDF step, and select 128 as the output key size. If HMAC is selected in the MAC step, then select the same HMAC in the KDF._
 +
 _Under input parameters, if concatenated keys or intermediary keys is selected, the ST Author should describe the sources of the keys, and the order in which they are concatenated, along with any other values that are concatenated with them. This option may be chosen in instances when input keying material for the KDF comes from two independent sources, for example, a client and a server._
-
 
 ==== FCS_CKM_EXT.8 Password-Based Key Derivation
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -2579,7 +2579,7 @@ KDF Step
 
 _Application Note {counter:remark_count}_:: _There are no standards that specify how to derive a key from two keys using XOR (KDF-XOR) or encryption (KDF-ENC). If KDF-XOR is selected, the ST Author should describe this method in the documentation. If KDF-ENC is selected, the ST Author should document the encryption algorithm used from FCS_COP.1/AEAD or FCS_COP.1/SKC, and which of the inputs is the plaintext and which is the key._
 +
-_In KDF-MAC-2S, if a CMAC is selected in the MAC step, then select AES-128-CMAC or Camellia-128-CMAC in the KDF step and select 128 as the output key size. If HMAC is selected in the MAC step, then select the same HMAC in the KDF._
+_In KDF-MAC-2S, if AES-N-CMAC or Camellia-N-CMAC is selected in the MAC step, then select CMAC with the same cipher and a 128-bit key in the KDF step, and select 128 as the output key size. If HMAC is selected in the MAC step, then select the same HMAC in the KDF._
 +
 _Under input parameters, if concatenated keys or intermediary keys is selected, the ST Author should describe the sources of the keys, and the order in which they are concatenated, along with any other values that are concatenated with them. This option may be chosen in instances when input keying material for the KDF comes from two independent sources, for example, a client and a server._
 +

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -2501,7 +2501,9 @@ FCS_CKM.5 Cryptographic Key Derivation
 
 FCS_CKM.5.1:: The TSF shall derive cryptographic keys [*selection*: _key type_] from [*selection*: _input parameters_], in accordance with a specified cryptographic key derivation algorithm [*selection*: _key derivation algorithm_] and specified cryptographic key sizes [*selection*: _key sizes_] that meet the following: [*selection*: _list of standards_].
 
-.Cryptographic Key Derivation
+The following table provides the allowed choices for completion of the selection operations of FCS_CKM.5.
+
+.Allowed choices for FCS_CKM.5
 [[KeyDerivation]]
 [cols=".^1,.^2,.^2,.^1,.^2",options=header]
 |===
@@ -2512,92 +2514,72 @@ FCS_CKM.5.1:: The TSF shall derive cryptographic keys [*selection*: _key type_] 
 |Key Sizes
 |List of Standards
 
-|KDF-CTR 
+|KDF-CTR
 |[selection: Direct Generation from a Random Bit Generator as specified in FCS_RBG.1, Concatenated keys]
-|KPF2 - KDF in Counter Mode using [selection: AES-128-CMAC, AES-192-CMAC, AES-256-CMAC, CMAC-HIGHT-128, CMAC-LEA-128, CMAC-LEA-256, CMAC-SEED-128, HMAC-SHA-1, HMAC-SHA-256, HMAC-SHA-512] as the PRF
-|[selection: 128, 192, 256] bits 
-|ISO/IEC 11770-6:2016 (subclause 7.3.2) [KPF2]
-
-NIST SP 800-108 Rev. 1 (Section 4.1) [KDF in Counter Mode] [selection: ISO/IEC 9797-1:2011 (CMAC), NIST SP 800-38B (CMAC)] [selection: ISO/IEC 18033-3:2010 (AES), FIPS PUB 197 (AES), ISO/IEC 18033-3:2010 (subclause 4.5) [HIGHT], ISO/IEC 29192-2:2019 (subclause 6.3) [LEA], ISO/IEC 18033-3:2010 (subclause 5.4) [SEED]],
-
-[selection: ISO/IEC 9797-2:2021 (HMAC), FIPS PUB 198-1 (HMAC)],
-
-[selection: ISO/IEC 10118-3:2018 (SHA), FIPS PUB 180-4 (SHA)]
+|KPF2 - KDF in Counter Mode using [selection: AES-128-CMAC, AES-192-CMAC, AES-256-CMAC, Camellia-128-CMAC, Camellia-192-CMAC, Camellia-256-CMAC, CMAC-HIGHT-128, CMAC-LEA-128, CMAC-LEA-256, CMAC-SEED-128, HMAC-SHA-1, HMAC-SHA-256, HMAC-SHA-512] as the PRF
+|[selection: 128, 192, 256, 512] bits
+|[selection: ISO/IEC 11770-6:2016 (Subclause 7.3.2) [KPF2], NIST SP 800-108 Revision 1 Update 1 (Section 4.1) [KDF in Counter Mode]]
 
 |KDF-FB
 |[selection: Direct Generation from a Random Bit Generator as specified in FCS_RBG.1, Concatenated keys]
-|KPF3 - KDF in Feedback Mode using [selection: AES-128-CMAC, AES-192-CMAC, AES-256-CMAC, CMAC-HIGHT-128, CMAC-LEA-128, CMAC-LEA-256, CMAC-SEED-128, HMAC-SHA-1, HMAC-SHA-256, HMAC-SHA-512] as the PRF
-|[selection: 128, 192, 256] bits 
-|ISO/IEC 11770-6:2016 (subclause 7.3.3) [KPF3]
+|KPF3 - KDF in Feedback Mode using [selection: AES-128-CMAC, AES-192-CMAC, AES-256-CMAC, Camellia-128-CMAC, Camellia-192-CMAC, Camellia-256-CMAC, CMAC-HIGHT-128, CMAC-LEA-128, CMAC-LEA-256, CMAC-SEED-128, HMAC-SHA-1, HMAC-SHA-256, HMAC-SHA-512] as the PRF
+|[selection: 128, 192, 256, 512] bits
+|[selection: ISO/IEC 11770-6:2016 (Subclause 7.3.3) [KPF3], NIST SP 800-108 Revision 1 Update 1 (Section 4.2) [KDF in Feedback Mode]]
 
-NIST SP 800-108 Rev. 1 (Section 4.2) [KDF in Feedback Mode] [selection: ISO/IEC 9797-1:2011 (CMAC), NIST SP 800-38B (CMAC)] [selection: ISO/IEC 18033-3:2010 (AES), FIPS PUB 197 (AES), ISO/IEC 18033-3:2010 (subclause 4.5) [HIGHT], ISO/IEC 29192-2:2019 (subclause 6.3) [LEA], ISO/IEC 18033-3:2010 (subclause 5.4) [SEED]],
-
-[selection: ISO/IEC 9797-2:2021 (HMAC), FIPS PUB 198-1 (HMAC)],
-
-[selection: ISO/IEC 10118-3:2018 (SHA), FIPS PUB 180-4 (SHA)]
-
-|KDF-DPI 
+|KDF-DPI
 |[selection: Direct Generation from a Random Bit Generator as specified in FCS_RBG.1, Concatenated keys]
-|KPF4 - KDF in Double-Pipeline Iteration Mode using [selection: AES-128-CMAC, AES-192-CMAC, AES-256-CMAC, CMAC-HIGHT-128, CMAC-LEA-128, CMAC-LEA-256, CMAC-SEED-128, HMAC-SHA-1, HMAC-SHA-256, HMAC-SHA-512] as the PRF
-|[selection: 128, 192, 256] bits 
-|ISO/IEC 11770-6:2016 (subclause 7.3.4) [KPF4]
-
-NIST SP 800-108 Rev. 1 (Section 4.3) [KDF in Double-Pipeline Iteration Mode] [selection: ISO/IEC 9797-1:2011 (CMAC), NIST SP 800-38B (CMAC)] [selection: ISO/IEC 18033-3:2010 (AES), FIPS PUB 197 (AES), ISO/IEC 18033-3:2010 (subclause 4.5) [HIGHT], ISO/IEC 29192-2:2019 (subclause 6.3) [LEA], ISO/IEC 18033-3:2010 (subclause 5.4) [SEED]],
-
-[selection: ISO/IEC 9797-2:2021 (HMAC), FIPS PUB 198-1 (HMAC)],
-
-[selection: ISO/IEC 10118-3:2018 (SHA), FIPS PUB 180-4 (SHA)]
+|KPF4 - KDF in Double-Pipeline Iteration Mode using [selection: AES-128-CMAC, AES-192-CMAC, AES-256-CMAC, Camellia-128-CMAC, Camellia-192-CMAC, Camellia-256-CMAC, CMAC-HIGHT-128, CMAC-LEA-128, CMAC-LEA-256, CMAC-SEED-128, HMAC-SHA-1, HMAC-SHA-256, HMAC-SHA-512] as the PRF
+|[selection: 128, 192, 256, 512] bits
+|[selection: ISO/IEC 11770-6:2016 (Subclause 7.3.4) [KPF3], NIST SP 800-108 Revision 1 Update 1 (Section 4.3) [KDF in Double-Pipeline Iteration Mode]]
 
 |KDF-XOR
 |More than one intermediary keys
 |exclusive OR (XOR)
-|[selection: 128, 192, 256] bits 
+|[selection: 128, 192, 256, 512] bits
 |N/A
 
 |KDF-ENC
-|Two keys 
-|Encrypting using an algorithm specified in FCS_COP.1/AEAD or FCS_COP.1/SKC
-|[selection: 128, 192, 256] bits 
+|Two keys
+|Encrypting using an algorithm specified in [selection: FCS_COP.1/AEAD, FCS_COP.1/SKC]
+|[selection: 128, 192, 256, 512] bits
 |N/A
 
-|KDF-HASH 
+|KDF-HASH
 |Shared secret
-|Hash function from FCS_COP.1/Hash 
-|[selection: 128, 192, 256] bits 
-|NIST SP 800-56C Rev. 2 (Section 4, Option 1)
+|Hash function from FCS_COP.1/Hash
+|[selection: 128, 192, 256, 512] bits
+|NIST SP 800-56C Revision 2 (Section 4.1, Option 1) [One-Step Key Derivation]
 
 |KDF-MAC-1S
-|Shared secret, salt, output length, fixed information 
+|Shared secret, salt, output length, fixed information
 |Keyed Hash function from FCS_COP.1/KeyedHash
-|[selection: 128, 192, 256] bits 
-|NIST SP 800-56C Rev. 2 (Section 4, Options 2, 3)
+|[selection: 128, 192, 256, 512] bits
+|NIST SP 800-56C Revision 2 (Section 4.1, Options 2, 3) [One-Step Key Derivation]
 
-|KDF-MAC-2S 
-|Shared secret, salt, IV, output length, fixed information 
-|[MAC Step]
+|KDF-MAC-2S
+|Shared secret, salt, IV, output length, fixed information
+|MAC Step
 
-[selection: AES-128-CMAC, AES-192-CMAC, AES-256-CMAC, HMAC-SHA-1, HMAC-SHA-256, HMAC-SHA-512] as the MAC and;
+[selection: AES-128-CMAC, AES-192-CMAC, AES-256-CMAC, Camellia-128-CMAC, Camellia-192-CMAC, Camellia-256-CMAC, HMAC-SHA-1, HMAC-SHA-256, HMAC-SHA-512] as the MAC and;
 
-[KDF Step] 
+KDF Step
 
-[selection: KDF-CTR, KDF-FB, KDF-DPI] using [selection: AES-128-CMAC, AES-192-CMAC, AES-256-CMAC, HMAC-SHA-1, HMAC-SHA-256, HMAC-SHA-512] as PRF
+[selection: KDF-CTR, KDF-FB, KDF-DPI] using [selection: AES-128-CMAC, AES-192-CMAC, AES-256-CMAC, Camellia-128-CMAC, Camellia-192-CMAC, Camellia-256-CMAC, HMAC-SHA-1, HMAC-SHA-256, HMAC-SHA-512] as PRF
 
-|[selection: 128, 192, 256] bits 
-|NIST SP 800-56C Rev. 2 (Section 5)
-
-[selection: ISO/IEC 9797-1:2011 (CMAC), NIST SP 800-38B (CMAC), ISO/IEC 18033-3:2010 (AES), FIPS PUB 197 (AES), ISO/IEC 9797-2:2021 (HMAC), FIPS PUB 198-1 (HMAC), ISO/IEC 10118-3:2018 (SHA), FIPS PUB 180-4 (SHA)] 
+|[selection: 128, 192, 256, 512] bits
+|NIST SP 800-56C Revision 2 (Section 5) [Two-Step Key Derivation]
 
 |KDF-KMAC
-|See NIST 800-108 Rev. 1, Section 4.4
+|Key, context string, output length, label
 |[selection: KMAC128, KMAC256]
-|[selection: 128, 256] bits
-|[selection: ISO/IEC 9797-2:2021 (Section 9 "MAC Algorithm 4"); NIST SP 800-185 (Section 4 "KMAC")]
+|[selection: 128, 192, 256, 512] bits
+|NIST SP 800-108 Revision 1 Update 1 (Section 4.4 "KDF Using KMAC")
 
 |===
 
 _Application Note {counter:remark_count}_:: _There are no standards that specify how to derive a key from two keys using XOR (KDF-XOR) or encryption (KDF-ENC). If KDF-XOR is selected, the ST Author should describe this method in the documentation. If KDF-ENC is selected, the ST Author should document the encryption algorithm used from FCS_COP.1/AEAD or FCS_COP.1/SKC, and which of the inputs is the plaintext and which is the key._
 +
-_In KDF-MAC-2S, if a CMAC is selected in the MAC step, then select AES-128-CMAC in the KDF step and select 128 as the output key size. If HMAC is selected in the MAC step, then select the same HMAC in the KDF._
+_In KDF-MAC-2S, if a CMAC is selected in the MAC step, then select AES-128-CMAC or Camellia-128-CMAC in the KDF step and select 128 as the output key size. If HMAC is selected in the MAC step, then select the same HMAC in the KDF._
 +
 _Under input parameters, if concatenated keys or intermediary keys is selected, the ST Author should describe the sources of the keys, and the order in which they are concatenated, along with any other values that are concatenated with them. This option may be chosen in instances when input keying material for the KDF comes from two independent sources, for example, a client and a server._
 +

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -2515,19 +2515,19 @@ The following table provides the allowed choices for completion of the selection
 |List of Standards
 
 |KDF-CTR
-|[selection: Direct Generation from a Random Bit Generator as specified in FCS_RBG.1, Concatenated keys]
+|Input key(s), label, context, output length
 |KPF2 - KDF in Counter Mode using [selection: AES-128-CMAC, AES-192-CMAC, AES-256-CMAC, Camellia-128-CMAC, Camellia-192-CMAC, Camellia-256-CMAC, CMAC-HIGHT-128, CMAC-LEA-128, CMAC-LEA-256, CMAC-SEED-128, HMAC-SHA-1, HMAC-SHA-256, HMAC-SHA-512] as the PRF
 |[selection: 128, 192, 256, 512] bits
 |[selection: ISO/IEC 11770-6:2016 (Subclause 7.3.2) [KPF2], NIST SP 800-108 Revision 1 Update 1 (Section 4.1) [KDF in Counter Mode]]
 
 |KDF-FB
-|[selection: Direct Generation from a Random Bit Generator as specified in FCS_RBG.1, Concatenated keys]
+|Input key(s), label, context, IV output length
 |KPF3 - KDF in Feedback Mode using [selection: AES-128-CMAC, AES-192-CMAC, AES-256-CMAC, Camellia-128-CMAC, Camellia-192-CMAC, Camellia-256-CMAC, CMAC-HIGHT-128, CMAC-LEA-128, CMAC-LEA-256, CMAC-SEED-128, HMAC-SHA-1, HMAC-SHA-256, HMAC-SHA-512] as the PRF
 |[selection: 128, 192, 256, 512] bits
 |[selection: ISO/IEC 11770-6:2016 (Subclause 7.3.3) [KPF3], NIST SP 800-108 Revision 1 Update 1 (Section 4.2) [KDF in Feedback Mode]]
 
 |KDF-DPI
-|[selection: Direct Generation from a Random Bit Generator as specified in FCS_RBG.1, Concatenated keys]
+|Input key(s), label, context, output length
 |KPF4 - KDF in Double-Pipeline Iteration Mode using [selection: AES-128-CMAC, AES-192-CMAC, AES-256-CMAC, Camellia-128-CMAC, Camellia-192-CMAC, Camellia-256-CMAC, CMAC-HIGHT-128, CMAC-LEA-128, CMAC-LEA-256, CMAC-SEED-128, HMAC-SHA-1, HMAC-SHA-256, HMAC-SHA-512] as the PRF
 |[selection: 128, 192, 256, 512] bits
 |[selection: ISO/IEC 11770-6:2016 (Subclause 7.3.4) [KPF3], NIST SP 800-108 Revision 1 Update 1 (Section 4.3) [KDF in Double-Pipeline Iteration Mode]]
@@ -2570,7 +2570,7 @@ KDF Step
 |NIST SP 800-56C Revision 2 (Section 5) [Two-Step Key Derivation]
 
 |KDF-KMAC
-|Key, context string, output length, label
+|Input key(s), label, context, output length
 |[selection: KMAC128, KMAC256]
 |[selection: 128, 192, 256, 512] bits
 |NIST SP 800-108 Revision 1 Update 1 (Section 4.4 "KDF Using KMAC")
@@ -2582,12 +2582,7 @@ _Application Note {counter:remark_count}_:: _There are no standards that specify
 _In KDF-MAC-2S, if AES-N-CMAC or Camellia-N-CMAC is selected in the MAC step, then select CMAC with the same cipher and a 128-bit key in the KDF step, and select 128 as the output key size. If HMAC is selected in the MAC step, then select the same HMAC in the KDF._
 +
 _Under input parameters, if concatenated keys or intermediary keys is selected, the ST Author should describe the sources of the keys, and the order in which they are concatenated, along with any other values that are concatenated with them. This option may be chosen in instances when input keying material for the KDF comes from two independent sources, for example, a client and a server._
-+
-_If deriving a symmetric key, select any of the above rows._
-+
-_If deriving an initialization vector, an authentication secret, HMAC key, or KMAC key, select KDF-CTR, KDF-FB, KDF-DPI, KDF-HASH, KDF-XOR, or KDF-ENC._
-+
-_If deriving a secret IV or seed, select KDF-HASH, KDF-MAC-1S, or KDF-MAC-2S._
+
 
 ==== FCS_CKM_EXT.8 Password-Based Key Derivation
 


### PR DESCRIPTION
The Crypto Working Group made technical changes to this SFR, specifically:
- Added Camellia CMAC to KDF-CTR, KDF-FB, KDF-DPI
- Added 512 bits as an output key size for all KDFs
- Make "FCS_COP.1/AEAD or FCS_COP.1/SKC" a selection in KDF-ENC
- Added Camellia CMAC to KDF-MAC-2S
- Update KDF-KMAC inputs and reference

I don't have any opinion on the technical changes made by the CWG.

Additionally, I diverged from the Crypto Catalog in the following areas:
- "recommended choices" was changed to "allowed choices"
- Use "as the MAC" instead of "as randomness extraction" in KDF-MAC-2S
- Updated the application note for KDF-MAC-2S for clarity
- Updated the inputs to the SP 800-108 KDFs and moved the KDF-KMAC row (essentially, #398)
- editorial/formatting

Finally, I also incorporated #397. That application note doesn't seem to come from the Crypto WG.