### PR TITLE
Align FCS_CKM_EXT.8 with CWG

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -2611,11 +2611,15 @@ _If deriving a secret IV or seed, select KDF-HASH, KDF-MAC-1S, or KDF-MAC-2S._
 
 FCS_CKM_EXT.8 Password-Based Key Derivation
 
-FCS_CKM_EXT.8.1:: The TSF shall perform password-based key derivation functions in accordance with a specified cryptographic algorithm HMAC-[selection: _SHA-256, SHA-384, SHA-512_], with iteration count of [assignment: _number of iterations_] using a randomly generated salt of length {empty}[selection: _128, [assignment: greater than 128]_] and output cryptographic key sizes {empty}[selection: _128, 192, 256, [assignment: greater than 128]_] bits that meet the following: [_NIST SP 800-132 Section 5.3 (PBKDF2)_].
+FCS_CKM_EXT.8.1:: The TSF shall perform password-based key derivation functions in accordance with a specified cryptographic algorithm HMAC-[selection: _SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512_], with iteration count of [assignment: _number of iterations_] using a randomly generated salt of length [assignment: _equal to or greater than 128_] and output cryptographic key sizes {empty}[selection: _128, 192, 256, [assignment: greater than 128]_] bits that meet the following standard: NIST SP 800-132 Section 5.3 (PBKDF2).
 
-_Application Note {counter:remark_count}_:: _The TSF must condition a password into a string of bits prior to using it as input to algorithms that form SKs and KEKs. The TSF can perform conditioning using one of the identified hash functions or the process described in NIST SP 800-132 Section 5.3 (PBKDF2); the ST author selects the method used. NIST SP 800-132 Section 5.3 (PBKDF2) requires the use of a pseudo-random function (PRF) consisting of HMAC with an approved hash function._
+_Application Note {counter:remark_count}_:: _Password-based key derivation is different from regular key derivation in that passwords have very limited entropy. As a result, one must add additional constraints, work, or entropy to achieve acceptable levels of security when using password-based key derivation algorithms. This component only adds work through increased iterations and use of salts; it does not consider additional constraints or entropy._
 +
 _The TSF is allowed to use PBKDF2 to condition passwords in the context of password-based authentication. In this scenario, the output of PBKDF2 is not directly used as a cryptographic key, but only stored as a reference value (commonly called "password hash") to compare against when performing authentication. The "cryptographic key size" selected in this element must correspond to the length of the password hash._
++
+_NIST recommends a minimum "number of iterations" of 1000 but prefers the largest number feasible given performance constraints._
++
+_NIST recommends that the randomly generated portion of the salt have length of at least 128 bits and must be derived from a Random Bit Generation. Therefore FCS_OTV_EXT.1 shall be claimed._
 
 ==== FCS_COP.1/AEAD Cryptographic Operation (Authenticated Encryption with Associated Data)
 
@@ -3061,7 +3065,7 @@ FCS_COP.1/KeyedHash Cryptographic Operation (Keyed Hash) +
 FCS_CKM.6 Timing and event of cryptographic key destruction 
 
 [vertical]
-FCS_CKM_EXT.8.1:: The TSF shall perform password-based key derivation functions in accordance with a specified cryptographic algorithm HMAC-[selection: _SHA-256, SHA-384, SHA-512_], with iteration count of [assignment: _number of iterations_] using a randomly generated salt of length {empty}[selection: _128, [assignment: greater than 128]_] and output cryptographic key sizes {empty}[selection: _128, 192, 256 [assignment: greater than 128]_] bits that meet the following: [assignment: _list of standards_].
+FCS_CKM_EXT.8.1:: The TSF shall perform password-based key derivation functions in accordance with a specified cryptographic algorithm HMAC-[selection: _SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512_], with iteration count of [assignment: _number of iterations_] using a randomly generated salt of length [assignment: _equal to or greater than 128_] and output cryptographic key sizes {empty}[selection: _128, 192, 256, [assignment: greater than 128]_] bits that meet the following standard: NIST SP 800-132 Section 5.3 (PBKDF2).
 
 ==== FCS_OTV_EXT One-Time Value
 


### PR DESCRIPTION
The Crypto Working Group made technical changes to this SFR, specifically:
- Add SHA-3 hash functions as the PRF
- Change the salt length selection to an assignment
- (Unsure) add 512-bit output key length

I agree with these technical changes made by the CWG.

Additionally, I diverged from the Crypto Catalog in the following areas:
- In the extended component definition for this SFR, get rid of the unnecessary brackets surrounding HMAC and the standard.
- Still allow any output length larger than 128 bits as we agreed upon earlier
- editorial/formatting (in particular, change "must" to "shall" in the application note)