### PR TITLE
Align FCS_CKM_EXT.3 with CWG

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -2018,7 +2018,7 @@ The evaluator shall examine the KMD to ensure that:
 
 ====== TSS
 
-The evaluator shall verify that for each key selected cryptograhpic method the ST contains the corresponding SFR. The evaluator shall ensure the key access operations which utilize the specified cryptographic methods. Where multiple methods may be selected, the evaluator shall verify that each method's usage is described.
+The evaluator shall verify that for each key selected cryptographic method the ST contains the corresponding SFR. The evaluator shall ensure the key access operations which utilize the specified cryptographic methods. Where multiple methods may be selected, the evaluator shall verify that each method's usage is described.
 
 ===== AGD
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -2493,7 +2493,7 @@ _See FCS_RBG.1 for requirements about appropriate entropy for selected cryptogra
 
 FCS_CKM_EXT.3 Cryptographic Key Access
 
-FCS_CKM_EXT.3.1:: The TSF shall use specified cryptographic key access methods [selection: _key encapsulation *as specified in FCS_COP.1/KeyEncap*, key wrapping *as specified in FCS_COP.1/KeyWrap*, key wrapping_ *_as specified in FCS_COP.1/AEAD_*] to access keys when performing [selection: _cryptographic key usage in cryptographic operations, cryptographic key storage, cryptographic key recovery, modifications to attributes of cryptographic keys, cryptographic key destruction_].
+FCS_CKM_EXT.3.1:: The TSF shall use specified cryptographic key access methods [selection: _key encapsulation *as specified in FCS_COP.1/KeyEncap*, key wrapping *as specified in FCS_COP.1/KeyWrap*, key encryption_ *_as specified in FCS_COP.1/SKC or FCS_COP.1/AEAD_*] to access keys when performing [selection: _cryptographic key archival, cryptographic key backup, cryptographic key escrow, cryptographic key recovery, cryptographic key import, cryptographic key export_].
 
 ==== FCS_CKM.5 Cryptographic Key Derivation
 
@@ -3033,7 +3033,7 @@ FCS_COP.1/SKC Cryptographic Operation (Symmetric-Key Cryptography), or +
 FCS_COP.1/AEAD Authenticated Encryption with Associated Data]
 
 [vertical]
-FCS_CKM_EXT.3.1:: The TSF shall use specified cryptographic key access methods [selection: _key encapsulation, key wrapping, key encryption_] to access keys when performing [selection: _cryptographic key usage in cryptographic operations, cryptographic key storage, cryptographic key recovery, modifications to attributes of cryptographic keys, cryptographic key destruction_].
+FCS_CKM_EXT.3.1:: The TSF shall use specified cryptographic key access methods [selection: _key encapsulation, key wrapping, key encryption_] to access keys when performing [selection: _cryptographic key archival, cryptographic key backup, cryptographic key escrow, cryptographic key recovery, cryptographic key import, cryptographic key export_].
 
 *FCS_CKM_EXT.7 Cryptographic Key Agreement*
 [horizontal]


### PR DESCRIPTION
I don't think the Crypto Working Group made technical changes to this SFR, though the list of operations in FCS_CKM_EXT.3.1 differs from what we had in the DSC cPP. I think it's more likely the DSC iTC did something custom.

I diverged from the Crypto Catalog in the following areas:
- Move the following application notes into the SFR, as we did previously:
> If “key encapsulation” is selected, FCS_COP.1/KeyEncap must be claimed.
> If “key wrapping” is selected, FCS_COP.1/KeyWrap must be claimed.
> If “key encryption” is selected, FCS_COP.1/SKC or FCS_COP.1/AEAD must be claimed.

Note that FCS_COP.1/SKC was added to key encryption, I'm not sure if this was a change by the CWG or if the DSC iTC decided at some point it was not suitable for key encryption. If the latter, we can remove it.
- editorial/formatting