### PR TITLE
Merge FPT_MFW_EXT.2 and FPT_MFW_EXT.3

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -2340,33 +2340,11 @@ There are no KMD evaluation activities for this component.
 
 ==== Mutable/Immutable Firmware (Extended - FPT_MFW_EXT)
 
-===== FPT_MFW_EXT.2 Basic Firmware Integrity
+===== FPT_MFW_EXT.2 Firmware Integrity
 
 ====== TSS
 
-The evaluator shall verify that the TSS describes which critical memory is measured for these integrity values and how the measurement is performed (including which TOE software measures the memory integrity values, how that software accesses the critical memory, and which algorithms are used).
-
-====== AGD
-
-If the integrity values are provided to the administrator, the evaluator shall verify that the AGD guidance contains instructions for retrieving these values and information for interpreting them. For example, if multiple measurements are taken, what those measurements are and how changes to those values relate to changes in the device state.
-
-====== Test
-
-Note that the following test may require the developer to provide access to a test platform that provides the evaluator with tools that are not typically available to end users.
-
-The evaluator shall repeat the following test for each measurement:
-
-The evaluator shall boot the TOE in an approved state and record the measurement taken. The evaluator shall modify the critical memory or value that is measured. The evaluator shall reboot the TOE and verify that the measurement changed.
-
-====== KMD
-
-There are no KMD evaluation activities for this component.
-
-===== FPT_MFW_EXT.3 Firmware Authentication with Identity of Guarantor
-
-====== TSS
-
-The evaluator shall examine the TSS to ensure it describes the methods and identities used to verify integrity and authenticity of the firmware. The TSS shall identify the Guarantor and how to verify its identity.
+The evaluator shall examine the TSS to ensure it describes the methods (i.e., cryptographic algorithms) and identities (e.g., code signing certificates) used to verify integrity and authenticity of the firmware. The TSS shall identify the Guarantor (e.g., root certificate authority or trusted public key) and how to verify its identity.
 
 ====== AGD
 
@@ -2378,13 +2356,23 @@ The TOE guarantees the authenticity of the firmware using the identity of the Gu
 
 *Test 1: Verify Authentic Firmware*
 
-The evaluator shall trigger the TOE to load and evaluate the authenticity of authentic firmware according the methods described in the TSS. The evaluator shall ensure that the TOE provides a clear indication of the success of the evaluation to consider the test a 'Pass', otherwise, the test is a 'Fail'.
+The evaluator shall trigger the TOE to load and evaluate the integrity and authenticity of authentic firmware before execution, according the methods described in the TSS. The evaluator shall ensure that the TOE provides a clear indication of the success of the evaluation to consider the test a 'Pass', otherwise, the test is a 'Fail'.
 
-*Test 2: Verify Unauthentic Firmware*
+*Test 1: Verify Authentic Firmware*
 
-The evaluator shall deliberately modify authentic firmware. 
+The evaluator shall deliberately modify the authentic firmware.
 
-The evaluator shall trigger the TOE to load and evaluate the authenticity of the deliberately modified firmware according the methods described in the TSS. The evaluator shall ensure that the TOE provides a clear indication of the failure of the evaluation to consider the test a 'Pass', otherwise, the test is a 'Fail'.
+The evaluator shall trigger the TOE to load and evaluate the integrity and authenticity of the deliberately modified firmware before execution, according the methods described in the TSS. The evaluator shall ensure that the TOE provides a clear indication of the failure of the evaluation to consider the test a 'Pass', otherwise, the test is a 'Fail'.
+
+*Test 3: Verify Authentic Firmware Updates*
+
+The evaluator shall trigger the TOE to load and evaluate the integrity and authenticity of an authentic firmware update, according the methods described in the TSS. The evaluator shall ensure that the TOE provides a clear indication of the success of the evaluation to consider the test a 'Pass', otherwise, the test is a 'Fail'.
+
+*Test 4: Verify Unauthentic Firmware Updates*
+
+The evaluator shall deliberately modify the authentic firmware update.
+
+The evaluator shall trigger the TOE to load and evaluate the authenticity of the deliberately modified firmware update, according the methods described in the TSS. The evaluator shall ensure that the TOE provides a clear indication of the failure of the evaluation to consider the test a 'Pass', otherwise, the test is a 'Fail'.
 
 ====== KMD
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1790,7 +1790,7 @@ FPT_MFW_EXT.1 Mutable/Immutable Firmware
 
 FPT_MFW_EXT.1.1:: The TSF shall be maintained as [selection: _immutable, mutable_] firmware.
 
-_Application Note {counter:remark_count}_:: _If [.underline]#mutable# is selected in FPT_MFW_EXT.1.1, the selection-based SFRs FPT_FLS.1/FW, FPT_MFW_EXT.2, FPT_MFW_EXT.3, and FPT_RPL.1/Rollback must be claimed._
+_Application Note {counter:remark_count}_:: _If [.underline]#mutable# is selected in FPT_MFW_EXT.1.1, the selection-based SFRs FPT_FLS.1/FW, FPT_MFW_EXT.2, FPT_RPL.1/Rollback must be claimed._
 
 ==== FPT_MOD_EXT.1 Debug Modes
 
@@ -2074,7 +2074,7 @@ The following rationale provides justification for each security problem definit
 |FDP_DAU.1/Prove (selection-based)
 |This requirement defines the Prove service that can be used to invoke the Roots of Trust for Measurement and Reporting and provide affirmation of the validity of TSF and stored data.
 
-.5+|T.UNAUTH_UPDATE
+.4+|T.UNAUTH_UPDATE
 |FPT_MFW_EXT.1 
 |This requirement specifies whether the TOE's firmware is mutable or immutable.
 
@@ -2082,10 +2082,7 @@ The following rationale provides justification for each security problem definit
 |This requirement requires the TSF to take action to preserve its secure operation if a rollback attempt or invalid firmware update is detected.
 
 |FPT_MFW_EXT.2 (selection-based)
-|This requirement ensures that the TSF can generate evidence that its mutable firmware integrity remains intact.
-
-|FPT_MFW_EXT.3 (selection-based)
-|This requirement ensures that any firmware updates to the TSF are genuine.
+|This requirement ensures that the TSF can verify that its mutable firmware integrity remains intact and any firmware updates to the TSF are genuine.
 
 |FPT_RPL.1/Rollback (selection-based)
 |This requirement ensures that the TSF will not permit rollback attempts of its firmware.
@@ -2898,41 +2895,19 @@ _Application Note {counter:remark_count}_:: _A DSC's ability to handle failures 
 +
 _The phrase "secure state" refers to a state in which the TOE has consistent TSF data and a TSF that can correctly enforce the policy. The TOE must ensure that no further processing of TSF or user data takes place while in an insecure state. This state may be the initial "boot" of a clean system, or it might be some check-pointed state. It is expected that in most cases, the TOE will halt and require a reset or re-initialization to return to a known secure state._
 
-==== FPT_MFW_EXT.2 Basic Firmware Integrity
+==== FPT_MFW_EXT.2 Firmware Integrity
 
-FPT_MFW_EXT.2 Basic Firmware Integrity
+FPT_MFW_EXT.2 Firmware Integrity
 
-FPT_MFW_EXT.2.1:: The TSF shall have the ability to verify the integrity of the firmware.
+FPT_MFW_EXT.2.1:: The TSF shall verify the integrity and authenticity of its firmware before execution using [selection: _a cryptographic hash as specified in FCS_COP.1/Hash, a keyed hash as specified in FCS_COP.1/KeyedHash, a message authentication code as specified in FCS_COP.1/CMAC, a digital signature as specified in FCS_COP.1/SigVer, authenticated encryption as specified in FCS_COP.1/AEAD_].
 
-FPT_MFW_EXT.2.2:: The TSF shall provide a capability to generate evidence of the integrity of the firmware.
+FPT_MFW_EXT.2.1:: The TSF shall verify the integrity and authenticity of its firmware updates using [selection: _a cryptographic hash as specified in FCS_COP.1/Hash, a keyed hash as specified in FCS_COP.1/KeyedHash, a message authentication code as specified in FCS_COP.1/CMAC, a digital signature as specified in FCS_COP.1/SigVer, authenticated encryption as specified in FCS_COP.1/AEAD_].
 
 _Application Note {counter:remark_count}_:: _Data and firmware integrity is not a required component of this cPP in all cases because some DSCs will have immutable firmware._
 +
-_The TOE guarantees the integrity of the firmware by verifying its integrity._
-+
-_Verifying the integrity of the firmware could be accomplished by guaranteeing the validity of firmware within the TOE prior to execution._
+_Verifying the integrity and authenticity of the firmware could be accomplished by guaranteeing the validity of firmware within the TOE prior to execution._
 +
 _This requirement covers the case of ensuring the firmware is trustworthy in immutable form or mutable through any firmware updates, since the integrity and authenticity are checked prior to execution._
-+
-_FCS_COP.1/SigVer applies if the TOE provides the capability to update the TOE firmware and uses digital signatures for update verification. FCS_COP.1/CMAC or FCS_COP.1/KeyedHash applies if the TOE provides the capability to update the TOE firmware and uses MAC verification for update verification. The ST author should choose the algorithm implemented to perform digital signatures or MAC verification. For the algorithms chosen, the ST author should make the appropriate assignments/selections to specify the parameters that are implemented for that algorithm._
-
-==== FPT_MFW_EXT.3 Firmware Authentication with Identity of Guarantor
-
-FPT_MFW_EXT.3 Firmware Authentication with Identity of Guarantor
-
-FPT_MFW_EXT.3.1:: The TSF shall have the ability to verify the authenticity of the firmware.
-
-FPT_MFW_EXT.3.2:: The TSF shall provide a capability to generate evidence of the authenticity of the firmware.
-
-_Application Note {counter:remark_count}_:: _Firmware authentication is not a required component of this cPP in all cases because some DSCs will have immutable firmware._
-+
-_The TOE guarantees the authenticity of the firmware by verifying its signature._
-+
-_Verifying the authenticity of the firmware could be accomplished by guaranteeing the validity of firmware within the TOE prior to execution._
-+
-_This requirement covers the case of ensuring the firmware is trustworthy in immutable form or mutable through any firmware updates, since the integrity and authenticity are checked prior to execution._
-+
-_FCS_COP.1/SigVer applies if the TOE provides the capability to update the TOE firmware and uses digital signatures for update verification. The ST author should choose the algorithm implemented to perform digital signatures. For the algorithms chosen, the ST author should make the appropriate assignments/selections to specify the parameters that are implemented for that algorithm._
 
 ==== FPT_RPL.1/Rollback Replay Detection (Rollback)
 
@@ -3520,23 +3495,17 @@ This family defines requirements for specified types of firmware and the managem
 [ditaa,"FPT_MFW_EXT"]
 ....
                                                        +---+
-                                                    +->| 1 |
-                                                    |  +---+
-    +--------------------------------------------+  |
+    +--------------------------------------------+  +->| 1 |
     |                                            |  |  +---+
-    | FPT_MFW_EXT Mutable/Immutable Firmware     +--+->| 2 |
+    | FPT_MFW_EXT Mutable/Immutable Firmware     +--+
     |                                            |  |  +---+
-    +--------------------------------------------+  |
-                                                    |  +---+
-                                                    +->| 3 |
+    +--------------------------------------------+  +->| 2 |
                                                        +---+
 ....
 
 FPT_MFW_EXT.1 Mutable/Immutable Firmware, requires the TSF to identify whether its firmware resides in mutable or immutable storage.
 
-FPT_MFW_EXT.2 Basic Firmware Integrity, requires the TSF to assert the integrity of the firmware.
-
-FPT_MFW_EXT.3 Firmware Authentication with Identity of Guarantor, requires the TSF to assert the authenticity of the firmware.
+FPT_MFW_EXT.2 Firmware Integrity, requires the TSF to assert the integrity and authenticity of the firmware.
 
 *Management: FPT_MFW_EXT.1*
 
@@ -3544,11 +3513,11 @@ The following actions could be considered for the management functions in FMT:
 
 * Update TOE firmware and pre-installed SDOs.
 
-*Management: FPT_MFW_EXT.2, FPT_MFW_EXT.3*
+*Management: FPT_MFW_EXT.2*
 
 No specific management functions are identified.
 
-*Audit: FPT_MFW_EXT.1, FPT_MFW_EXT.2, FPT_MFW_EXT.3*
+*Audit: FPT_MFW_EXT.1, FPT_MFW_EXT.2*
 
 There are no auditable events foreseen.
 
@@ -3560,27 +3529,16 @@ Dependencies:: No dependencies.
 [vertical]
 FPT_MFW_EXT.1.1:: The TSF shall be maintained as [selection: _immutable, mutable_] firmware.
 
-*FPT_MFW_EXT.2 Basic Firmware Integrity*
+*FPT_MFW_EXT.2 Firmware Integrity*
 [horizontal]
 Hierarchical to:: No other components.
 
 Dependencies:: FPT_MFW_EXT.1 Mutable/Immutable Firmware +
 FCS_COP.1 Cryptographic Operation
 [vertical]
-FPT_MFW_EXT.2.1:: The TSF shall have the ability to verify the integrity of the firmware.
+FPT_MFW_EXT.2.1:: The TSF shall verify the integrity and authenticity of its firmware before execution using [selection: _a cryptographic hash as specified in FCS_COP.1/Hash, a keyed hash as specified in FCS_COP.1/KeyedHash, a message authentication code as specified in FCS_COP.1/CMAC, a digital signature as specified in FCS_COP.1/SigVer, authenticated encryption as specified in FCS_COP.1/AEAD_].
 
-FPT_MFW_EXT.2.2:: The TSF shall provide a capability to generate evidence of the integrity of the firmware.
-
-*FPT_MFW_EXT.3 Firmware Authentication with Identity of Guarantor*
-[horizontal]
-Hierarchical to:: No other components.
-
-Dependencies:: FPT_MFW_EXT.1 Mutable/Immutable Firmware +
-FCS_COP.1 Cryptographic Operation
-[vertical]
-FPT_MFW_EXT.3.1:: The TSF shall have the ability to verify the authenticity of the firmware.
-
-FPT_MFW_EXT.3.2:: The TSF shall provide a capability to generate evidence of the authenticity of the firmware.
+FPT_MFW_EXT.2.2:: The TSF shall verify the integrity and authenticity of its firmware updates using [selection: _a cryptographic hash as specified in FCS_COP.1/Hash, a keyed hash as specified in FCS_COP.1/KeyedHash, a message authentication code as specified in FCS_COP.1/CMAC, a digital signature as specified in FCS_COP.1/SigVer, authenticated encryption as specified in FCS_COP.1/AEAD_].
 
 ==== FPT_MOD_EXT Debug Modes
 
@@ -4596,14 +4554,6 @@ FCS_COP.1
 
 FCS_COP.1 - included
 
-|FPT_MFW_EXT.3 
-|FPT_MFW_EXT.1 
-
-FCS_COP.1 
-|FPT_MFW_EXT.1 - included
-
-FCS_COP.1 - included
-
 |FPT_RPL.1/Rollback 
 |No dependencies
 |N/A
@@ -4871,9 +4821,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FPT_MFW_EXT.1 !Mutable/Immutable Firmware
 
-!FPT_MFW_EXT.2 !Basic Firmware Integrity
-
-!FPT_MFW_EXT.3 !Firmware Authentication with Identity of Guarantor
+!FPT_MFW_EXT.2 !Firmware Integrity
 
 !===
 
@@ -4969,9 +4917,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FPT_PRO_EXT.2 !Data Integrity Measurements
 
-!FPT_MFW_EXT.2 !Basic Firmware Integrity
-
-!FPT_MFW_EXT.3 !Firmware Authentication with Identity of Guarantor
+!FPT_MFW_EXT.2 !Firmware Integrity
 
 !FDP_FRS_EXT.2 !Factory Reset Behavior
 


### PR DESCRIPTION
Both FPT_MFW_EXT.2 and FPT_MFW_EXT.3 are selection-based SFRs that are only included when "mutable" firmware is used. There are no situations in which one is selected without the other. Consequently, it is more appropriate to merge these SFRs into one SFR that covers the requirements for both.

Additionally, FPT_MFW_EXT.2 seems to unnecessarily pull in requirements from the Root of Trust for Measurements. This seems like a scope creep that should be avoided, as some TOEs do not want/need to provide these measurements.

For this reason, the new SFR contains two core requirements: integrity checking on boot (i.e., before firmware execution), and integrity checking of firmware updates. The new SFR also forces the ST author to explicitly select the algorithms used to verify the integrity (and authenticity).

It is expected that the list of allowed cryptographic algorithms here should be reduced. While hash or MAC algorithms are sometimes used to verify the integrity of firmware prior to execution, it is almsot never appropriate to use symmetric (i.e., hash, MAC, AEAD) cryptography to verify firmware updates.