### PR TITLE
Make FCS_CKM_EXT.7 selection-based

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -561,50 +561,6 @@ The evaluator shall examine the KMD to ensure that all keys and keying material 
 
 Note that where selections include 'destruction of reference to the key directly followed by a request for garbage collection' (for volatile memory) then the evaluator shall examine the KMD to ensure that it explains the nature of the destruction of the reference, the request for garbage collection, and of the garbage collection process itself.
 
-===== FCS_CKM_EXT.7 Cryptographic Key Agreement
-
-====== TSS
-
-The evaluator shall ensure that the selected RSA, DH, and ECDH key agreement schemes correspond to the key generation schemes selected in FCS_CKM.1/AKG. If the ST selects DH, the TSS shall describe how the implementation meets the relevant sections of RFC 3526 (Section 3-7) or RFC 7919 (Appendices A.1-A.5). If the ST selects ECIES, the TSS shall describe the key sizes and algorithms (e.g. elliptic curve point multiplication, ECDH with either NIST or Brainpool curves, a symmetric cipher permitted by FCS_COP.1/SKC, a hash algorithm permitted by FCS_COP.1/Hash, and a MAC algorithm permitted by FCS_COP.1/KeyedHash or FCS_COP.1/CMAC) that are supported for the ECIES implementation.
-
-The evaluator shall ensure that, for each key agreement scheme, the size of the derived keying material is at least the same as the intended strength of the key agreement scheme, and where feasible this should be twice the intended security strength of the key agreement scheme.
-
-For each key agreement scheme, the TSS shall list the associated key derivation function if applicable.
-
-====== AGD
-
-The evaluator shall verify that the guidance instructs the administrator how to configure the TOE to use the selected key agreement scheme.
-
-====== Test
-
-The algorithm tests might require access to a development version of the TOE or a test platform that provides tools not typically found on factory products.
-
-The developer shall provide sufficient information to the evaluator to properly define the implementation of the algorithm. The evaluator shall define at least one test group (a configuration of algorithm properties and associated test cases) for each combination of the following parameters, according to the implementation of the algorithm:
-
-* Modulus size (KAS2)
-* Domain parameters (DH)
-* Curve (ECDH, ECIES)
-* Key agreement role (initiator or responder)
-* Hash algorithm (if applicable)
-* Associated data pattern (if applicable)
-* KDF configuration (if applicable)
-
-Each test group shall consist of at least 10 test cases meeting the following requirements:
-
-* Test cases shall be generated according to the parameter configuration of the test group.
-* Each test case shall consist of an arbitrary "owner" private key, an arbitrary "peer" public key, an arbitrary associated data string (if applicable), and the corresponding shared secret or derived key.
-* A representative sample of the domain of supported associated data sizes shall be tested.
-* A representative sample of the domain of supported shared secret sizes shall be tested.
-* A representative sample of the domain of supported derived key sizes shall be tested.
-
-For each test case in each test group, the evaluator shall verify that the TSF generates the correct shared secret or derived key.
-
-The evaluator shall be able to provide a rationale as to the sufficiency of the test groups and test cases in exercising the algorithm. Test cases shall be generated using a known-good implementation to ensure the correct result is produced by the TSF. The evaluator shall determine the proper known-good implementation and provide a rationale for its use for testing. Internal or external implementations are acceptable with a sufficient rationale.
-
-====== KMD
-
-There are no KMD evaluation activities for this component.
-
 ==== Cryptographic Operation (FCS_COP)
 
 ===== FCS_COP.1/Hash Cryptographic Operation - Hashing
@@ -2031,6 +1987,50 @@ Testing for this SFR is performed under the corresponding functions based on the
 ===== KMD
 
 The developer is allowed to provide additional details of the key access operations and cryptographic methods in the KMD. The evaluator shall verify the accuracy of any additional descriptions (if present).
+
+===== FCS_CKM_EXT.7 Cryptographic Key Agreement
+
+====== TSS
+
+The evaluator shall ensure that the selected RSA, DH, and ECDH key agreement schemes correspond to the key generation schemes selected in FCS_CKM.1/AKG. If the ST selects DH, the TSS shall describe how the implementation meets the relevant sections of RFC 3526 (Section 3-7) or RFC 7919 (Appendices A.1-A.5). If the ST selects ECIES, the TSS shall describe the key sizes and algorithms (e.g. elliptic curve point multiplication, ECDH with either NIST or Brainpool curves, a symmetric cipher permitted by FCS_COP.1/SKC, a hash algorithm permitted by FCS_COP.1/Hash, and a MAC algorithm permitted by FCS_COP.1/KeyedHash or FCS_COP.1/CMAC) that are supported for the ECIES implementation.
+
+The evaluator shall ensure that, for each key agreement scheme, the size of the derived keying material is at least the same as the intended strength of the key agreement scheme, and where feasible this should be twice the intended security strength of the key agreement scheme.
+
+For each key agreement scheme, the TSS shall list the associated key derivation function if applicable.
+
+====== AGD
+
+The evaluator shall verify that the guidance instructs the administrator how to configure the TOE to use the selected key agreement scheme.
+
+====== Test
+
+The algorithm tests might require access to a development version of the TOE or a test platform that provides tools not typically found on factory products.
+
+The developer shall provide sufficient information to the evaluator to properly define the implementation of the algorithm. The evaluator shall define at least one test group (a configuration of algorithm properties and associated test cases) for each combination of the following parameters, according to the implementation of the algorithm:
+
+* Modulus size (KAS2)
+* Domain parameters (DH)
+* Curve (ECDH, ECIES)
+* Key agreement role (initiator or responder)
+* Hash algorithm (if applicable)
+* Associated data pattern (if applicable)
+* KDF configuration (if applicable)
+
+Each test group shall consist of at least 10 test cases meeting the following requirements:
+
+* Test cases shall be generated according to the parameter configuration of the test group.
+* Each test case shall consist of an arbitrary "owner" private key, an arbitrary "peer" public key, an arbitrary associated data string (if applicable), and the corresponding shared secret or derived key.
+* A representative sample of the domain of supported associated data sizes shall be tested.
+* A representative sample of the domain of supported shared secret sizes shall be tested.
+* A representative sample of the domain of supported derived key sizes shall be tested.
+
+For each test case in each test group, the evaluator shall verify that the TSF generates the correct shared secret or derived key.
+
+The evaluator shall be able to provide a rationale as to the sufficiency of the test groups and test cases in exercising the algorithm. Test cases shall be generated using a known-good implementation to ensure the correct result is produced by the TSF. The evaluator shall determine the proper known-good implementation and provide a rationale for its use for testing. Internal or external implementations are acceptable with a sufficient rationale.
+
+====== KMD
+
+There are no KMD evaluation activities for this component.
 
 ===== FCS_CKM_EXT.8 Password-Based Key Derivation
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -647,7 +647,7 @@ _Application Note {counter:remark_count}_:: _Cryptographic keys can include KEKs
 
 FCS_CKM.2 Cryptographic Key Distribution
 
-FCS_CKM.2.1:: The TSF shall distribute cryptographic keys in accordance with a specified cryptographic key distribution method [*selection*: _key encapsulation as specified in FCS_COP.1/KeyEncap, key wrapping as specified in FCS_COP.1/KeyWrap, key wrapping as specified in FCS_COP.1/AEAD, physically protected channels as specified in FTP_ITP_EXT.1, encrypted data buffers as specified in FTP_ITE_EXT.1, cryptographically protected data channels as specified in FTP_ITC_EXT.1_] that meets the following: [_none_].
+FCS_CKM.2.1:: The TSF shall distribute cryptographic keys in accordance with a specified cryptographic key distribution method [*selection*: _key encapsulation as specified in FCS_COP.1/KeyEncap, key wrapping as specified in FCS_COP.1/KeyWrap, physically protected channels as specified in FTP_ITP_EXT.1, encrypted data buffers as specified in FTP_ITE_EXT.1, cryptographically protected data channels as specified in FTP_ITC_EXT.1_] that meets the following: [_none_].
 
 
 _Application Note {counter:remark_count}_:: _This SFR assumes there is no pre-shared key between the parties._
@@ -1423,7 +1423,7 @@ FDP_ITC_EXT.1 Parsing of SDEs
 
 FDP_ITC_EXT.1.1:: The TSF shall support importing SDEs using [*selection*: _physically protected channels as specified in FTP_ITP_EXT.1, encrypted data buffers as specified in FTP_ITE_EXT.1, cryptographically protected data channels as specified in FTP_ITC_EXT.1_].
 
-FDP_ITC_EXT.1.2:: The TSF shall verify the integrity of the SDE using [*selection*: _message authentication code as specified in FCS_COP.1/CMAC, cryptographic hash as specified in FCS_COP.1/Hash, keyed hash as specified in FCS_COP.1/KeyedHash, key wrap encryption algorithm as specified in FCS_COP.1/KeyWrap, authenticated encryption algorithm as specified in FCS_COP.1/AEAD, digital signature as specified in FCS_COP.1/SigVer, integrity verification supported by FDP_ITC_EXT.1.1_].
+FDP_ITC_EXT.1.2:: The TSF shall verify the integrity of the SDE using [*selection*: _message authentication code as specified in FCS_COP.1/CMAC, cryptographic hash as specified in FCS_COP.1/Hash, keyed hash as specified in FCS_COP.1/KeyedHash, key wrap encryption algorithm as specified in FCS_COP.1/KeyWrap, digital signature as specified in FCS_COP.1/SigVer, integrity verification supported by FDP_ITC_EXT.1.1_].
 
 FDP_ITC_EXT.1.3:: The TSF shall ignore any security attributes associated with the user data when imported from outside the TOE.
 
@@ -1439,7 +1439,7 @@ FDP_ITC_EXT.2 Parsing of SDOs
 
 FDP_ITC_EXT.2.1:: The TSF shall support importing SDOs using [*selection*: _physically protected channels as specified in FTP_ITP_EXT.1, encrypted data buffers as specified in FTP_ITE_EXT.1, cryptographically protected data channels as specified in FTP_ITC_EXT.1_].
 
-FDP_ITC_EXT.2.2:: The TSF shall verify the integrity of the SDO using [*selection*: _message authentication code as specified in FCS_COP.1/CMAC, cryptographic hash as specified in FCS_COP.1/Hash, keyed hash as specified in FCS_COP.1/KeyedHash, key wrap encryption algorithm as specified in FCS_COP.1/KeyWrap, authenticated encryption algorithm as specified in FCS_COP.1/AEAD, digital signature as specified in FCS_COP.1/SigVer, integrity verification supported by FDP_ITC_EXT.2.1_].
+FDP_ITC_EXT.2.2:: The TSF shall verify the integrity of the SDO using [*selection*: _message authentication code as specified in FCS_COP.1/CMAC, cryptographic hash as specified in FCS_COP.1/Hash, keyed hash as specified in FCS_COP.1/KeyedHash, key wrap encryption algorithm as specified in FCS_COP.1/KeyWrap, digital signature as specified in FCS_COP.1/SigVer, integrity verification supported by FDP_ITC_EXT.2.1_].
 
 FDP_ITC_EXT.2.3:: The TSF shall use the security attributes associated with the imported user data.
 
@@ -1476,7 +1476,7 @@ _Application Note {counter:remark_count}_:: _This SFR applies to SDOs with the c
 
 FDP_SDI.2 Stored Data Integrity Monitoring and Action
 
-FDP_SDI.2.1:: The TSF shall monitor *SDOs and SDEs* controlled by the TSF for [_integrity errors_] on all objects, based on the following attributes: [*selection*: _[assignment: attribute associated with presence in protected storage], message authentication code as specified in FCS_COP.1/CMAC, cryptographic hash as specified in FCS_COP.1/Hash, keyed hash as specified in FCS_COP.1/KeyedHash, digital signature as specified in FCS_COP.1/SigVer, key wrap encryption algorithm as specified in FCS_COP.1/KeyWrap, authenticated encryption algorithm as specified in FCS_COP.1/AEAD_].
+FDP_SDI.2.1:: The TSF shall monitor *SDOs and SDEs* controlled by the TSF for [_integrity errors_] on all objects, based on the following attributes: [*selection*: _[assignment: attribute associated with presence in protected storage], message authentication code as specified in FCS_COP.1/CMAC, cryptographic hash as specified in FCS_COP.1/Hash, keyed hash as specified in FCS_COP.1/KeyedHash, digital signature as specified in FCS_COP.1/SigVer, key wrap encryption algorithm as specified in FCS_COP.1/KeyWrap_].
 
 FDP_SDI.2.2:: Upon detection of a data integrity error, the TSF shall [
 +
@@ -1487,7 +1487,7 @@ _Application Note {counter:remark_count}_:: _This SFR deals with the mechanism t
 +
 _The cryptographic requirements for cryptographic hashes and digital signatures apply here._
 +
-_No specific requirement is placed here on the nature of the integrity protection data, but the Security Target shall describe this protection measure, and shall identify the iteration of FCS_COP.1/CMAC, FCS_COP.1/Hash, FCS_COP.1/KeyedHash, FCS_COP.1/KeyVer, FCS_COP.1/KeyWrap or FCS_COP.1/AEAD that covers any cryptographic algorithm used._
+_No specific requirement is placed here on the nature of the integrity protection data, but the Security Target shall describe this protection measure, and shall identify the iteration of FCS_COP.1/CMAC, FCS_COP.1/Hash, FCS_COP.1/KeyedHash, FCS_COP.1/SigVer, or FCS_COP.1/KeyWrap that covers any cryptographic algorithm used._
 +
 _The integrity protection data in FDP_SDI.2.1 is included in the list of attributes identified in FMT_MSA.1, and protects the value of the SDEs and of the SDO security attributes._
 +

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -689,54 +689,6 @@ _The selection for destruction of data in non-volatile memory includes block era
 +
 _Some selections allow assignment of "some value that does not contain any CSP." This means that the TOE uses some specified data not drawn from an RBG meeting FCS_RBG requirements, and not being any of the particular values listed as other selection options. The point of the phrase "does not contain any sensitive data" is to ensure that the overwritten data is carefully selected, and not taken from a general pool that might contain data that itself requires confidentiality protection._
 
-==== FCS_CKM_EXT.7 Cryptographic Key Agreement
-
-FCS_CKM_EXT.7 Cryptographic Key Agreement
-
-FCS_CKM_EXT.7.1:: The TSF shall derive shared cryptographic keys with input from multiple parties in accordance with specified cryptographic key agreement algorithms [*selection*: _cryptographic algorithm_] and specified cryptographic parameters [*selection*: _cryptographic algorithm parameters_] that meet the following: [*selection*: _list of standards_].
-
-The following table provides the allowed choices for completion of the selection operations of FCS_CKM_EXT.7.
-
-.Allowed choices for FCS_CKM_EXT.7
-[[KeyAgreement]]
-[cols=".^1,.^2,.^2,.^2",options=header]
-|===
-
-|Identifier
-|Cryptographic Algorithm
-|Cryptographic Algorithm Parameters
-|List of Standards
-
-|KAS2
-|RSA
-|Modulus of size [selection: 2048, 3072, 4096, 6144, 8192] bits
-|NIST SP 800-56B Revision 2 (Section 8.3) [KAS2]
-
-|DH
-|Finite Field Cryptography Diffie-Hellman
-|Static domain parameters approved for [selection: IKE groups [selection: MODP-2048, MODP-3072, MODP-4096, MODP-6144, MODP-8192], TLS groups [selection: ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192]]
-|NIST SP 800-56A Revision 3 (Section 5.7.1.1) [DH]
-
-[selection: RFC 3526 [IKE Groups], RFC 7919 [TLS Groups]]
-
-|ECDH
-|Elliptic Curve Diffie-Hellman
-|Elliptic Curve [selection: P-256, brainpoolP256r1, P-384, brainpoolP384r1, P-521, brainpoolP512r1]
-|NIST SP 800-56A Revision 3 (Section 5.7.1.2) [ECDH]
-
-[selection: NIST SP 800-186 (Section 3.2.1) [NIST Curves], RFC 5639 (Section 3) [Brainpool curves]]
-
-|ECDH-Ed
-|ECDH with Montgomery Curves
-|Domain parameters approved for elliptic curves [selection: curve25519, curve448]
-|RFC 7748 (Section 5) [ECDH-Ed]
-
-NIST SP 800-186 (Section 3.2.2) [Montgomery Curves]
-
-|===
-
-_Application Note {counter:remark_count}_:: _ST authors should consider the assumptions that opposite parties in the operational environment contribute keying material that meets the same requirements._
-
 ==== FCS_COP.1/Hash Cryptographic Operation - Hashing
 
 FCS_COP.1/Hash Cryptographic Operation - Hashing
@@ -2657,6 +2609,54 @@ _In KDF-MAC-2S, if AES-N-CMAC or Camellia-N-CMAC is selected in the MAC step, th
 +
 _Under input parameters, if concatenated keys or intermediary keys is selected, the ST Author should describe the sources of the keys, and the order in which they are concatenated, along with any other values that are concatenated with them. This option may be chosen in instances when input keying material for the KDF comes from two independent sources, for example, a client and a server._
 
+==== FCS_CKM_EXT.7 Cryptographic Key Agreement
+
+FCS_CKM_EXT.7 Cryptographic Key Agreement
+
+FCS_CKM_EXT.7.1:: The TSF shall derive shared cryptographic keys with input from multiple parties in accordance with specified cryptographic key agreement algorithms [*selection*: _cryptographic algorithm_] and specified cryptographic parameters [*selection*: _cryptographic algorithm parameters_] that meet the following: [*selection*: _list of standards_].
+
+The following table provides the allowed choices for completion of the selection operations of FCS_CKM_EXT.7.
+
+.Allowed choices for FCS_CKM_EXT.7
+[[KeyAgreement]]
+[cols=".^1,.^2,.^2,.^2",options=header]
+|===
+
+|Identifier
+|Cryptographic Algorithm
+|Cryptographic Algorithm Parameters
+|List of Standards
+
+|KAS2
+|RSA
+|Modulus of size [selection: 2048, 3072, 4096, 6144, 8192] bits
+|NIST SP 800-56B Revision 2 (Section 8.3) [KAS2]
+
+|DH
+|Finite Field Cryptography Diffie-Hellman
+|Static domain parameters approved for [selection: IKE groups [selection: MODP-2048, MODP-3072, MODP-4096, MODP-6144, MODP-8192], TLS groups [selection: ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192]]
+|NIST SP 800-56A Revision 3 (Section 5.7.1.1) [DH]
+
+[selection: RFC 3526 [IKE Groups], RFC 7919 [TLS Groups]]
+
+|ECDH
+|Elliptic Curve Diffie-Hellman
+|Elliptic Curve [selection: P-256, brainpoolP256r1, P-384, brainpoolP384r1, P-521, brainpoolP512r1]
+|NIST SP 800-56A Revision 3 (Section 5.7.1.2) [ECDH]
+
+[selection: NIST SP 800-186 (Section 3.2.1) [NIST Curves], RFC 5639 (Section 3) [Brainpool curves]]
+
+|ECDH-Ed
+|ECDH with Montgomery Curves
+|Domain parameters approved for elliptic curves [selection: curve25519, curve448]
+|RFC 7748 (Section 5) [ECDH-Ed]
+
+NIST SP 800-186 (Section 3.2.2) [Montgomery Curves]
+
+|===
+
+_Application Note {counter:remark_count}_:: _ST authors should consider the assumptions that opposite parties in the operational environment contribute keying material that meets the same requirements._
+
 ==== FCS_CKM_EXT.8 Password-Based Key Derivation
 
 FCS_CKM_EXT.8 Password-Based Key Derivation
@@ -2995,6 +2995,7 @@ FTP_ITE_EXT.1.1:: The TSF shall encrypt data for transfer between the TOE and [_
 +
 * _Pre-shared keys;_
 * _Key agreement according to FCS_CKM_EXT.7;_
+* _Key encapsulation according to FCS_COP.1/KeyEncap;_
 * _Keys exchanged using a physically protected communication mechanism conformant with FTP_ITP_EXT.1_].
 
 _Application Note {counter:remark_count}_:: _This requirement applies to encrypted data communications between the TOE and external entities that do not use a physically protected mechanism conforming to FTP_ITP_EXT.1, or a cryptographically protected data channel as conforming to FTP_ITC_EXT.1. For example, if data is transferred through encrypted buffers (or blobs) then this requirement applies. If data is transferred through a physically protected channel, then FTP_ITP_EXT.1 applies. This requirement would apply, for example, for communications implemented through a shared data buffer._
@@ -4029,7 +4030,7 @@ FCS_CKM.2 - included
 
 FCS_CKM.5 - (selection-based SFR) included
 
-FCS_CKM_EXT.7 - included
+FCS_CKM_EXT.7 - (selection-based SFR) included
 
 FCS_CKM_EXT.8 - (selection-based SFR) included
 
@@ -4067,28 +4068,6 @@ FCS_CKM.1 - included
 
 FCS_CKM.5 - (selection-based SFR) included
 
-|FCS_CKM_EXT.7 
-|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.8]
-
-[FCS_CKM.2 or FCS_COP.1]
-
-FCS_CKM.6 
-|FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
-
-FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
-
-FCS_CKM.1 - included
-
-FCS_CKM.5 - (selection-based SFR) included
-
-FCS_CKM_EXT.8 - (selection-based SFR) included
-
-FCS_CKM.2 - included
-
-FCS_COP.1 - included
-
-FCS_CKM.6 - included
-
 |FCS_COP.1/Hash 
 |No dependencies.
 |There are no keys involved with hashing, so no cryptograhpic key-based dependencies are necessary.
@@ -4105,7 +4084,7 @@ FCS_CKM.1 - included
 
 FCS_CKM.5 - (selection-based SFR) included
 
-FCS_CKM_EXT.7 - included
+FCS_CKM_EXT.7 - (selection-based SFR) included
 
 FCS_CKM_EXT.8 - (selection-based SFR) included
 
@@ -4153,7 +4132,7 @@ FCS_CKM.1 - included
 
 FCS_CKM.5 - (selection-based SFR) included
 
-FCS_CKM_EXT.7 - included
+FCS_CKM_EXT.7 - (selection-based SFR) included
 
 FCS_CKM_EXT.8 - (selection-based SFR) included
 
@@ -4433,7 +4412,7 @@ FCS_CKM.6
 
 FCS_CKM.5 - (selection-based SFR) included
 
-FCS_CKM_EXT.7 - included
+FCS_CKM_EXT.7 - (selection-based SFR) included
 
 FCS_COP.1 - included
 
@@ -4477,6 +4456,28 @@ FCS_COP.1 - included
 
 FCS_CKM.6 - included
 
+|FCS_CKM_EXT.7
+|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.8]
+
+[FCS_CKM.2 or FCS_COP.1]
+
+FCS_CKM.6
+|FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
+
+FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
+
+FCS_CKM.1 - included
+
+FCS_CKM.5 - (selection-based SFR) included
+
+FCS_CKM_EXT.8 - (selection-based SFR) included
+
+FCS_CKM.2 - included
+
+FCS_COP.1 - included
+
+FCS_CKM.6 - included
+
 |FCS_CKM_EXT.8 
 |[FCS_CKM.2 or FCS_CKM_EXT.7]
 
@@ -4485,7 +4486,7 @@ FCS_COP.1/KeyedHash
 FCS_CKM.6 
 |FCS_CKM.2 - included
 
-FCS_CKM_EXT.7 - included
+FCS_CKM_EXT.7 - (selection-based SFR) included
 
 FCS_COP.1/KeyedHash - included
 
@@ -4505,7 +4506,7 @@ FCS_CKM.1 - included
 
 FCS_CKM.5 - (selection-based SFR) included
 
-FCS_CKM_EXT.7 - included
+FCS_CKM_EXT.7 - (selection-based SFR) included
 
 FCS_CKM_EXT.8 - (selection-based SFR) included
 
@@ -4526,7 +4527,7 @@ FCS_CKM.1 - included
 
 FCS_CKM.5 - (selection-based SFR) included
 
-FCS_CKM_EXT.7 - included
+FCS_CKM_EXT.7 - (selection-based SFR) included
 
 FCS_CKM_EXT.8 - (selection-based SFR) included
 
@@ -4546,7 +4547,7 @@ FCS_CKM.1 - included
 
 FCS_CKM.5 - (selection-based SFR) included
 
-FCS_CKM_EXT.7 - included
+FCS_CKM_EXT.7 - (selection-based SFR) included
 
 FCS_CKM_EXT.8 - (selection-based SFR) included
 
@@ -4566,7 +4567,7 @@ FCS_CKM.1 - included
 
 FCS_CKM.5 - (selection-based SFR) included
 
-FCS_CKM_EXT.7 - included
+FCS_CKM_EXT.7 - (selection-based SFR) included
 
 FCS_CKM_EXT.8 - (selection-based SFR) included
 


### PR DESCRIPTION
Currently, FCS_CKM_EXT.7 is a mandatory SFR, which unnecessarily
restricts the DSCs that claim compliance to this PP. The SFR can be
made selection-based, since it is included in the selection for
FTP_ITE_EXT.1.