### PR TITLE
Appnoteupdate

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -1254,7 +1254,7 @@ There are no KMD evaluation activities for this component.
 
 ====== TSS
 
-The evaluator shall examine the TSS to determine that it describes each of the options for reauthorization.
+The evaluator shall examine the TSS to determine that it describes each of the policy options for reauthorization.
 
 ====== AGD
 

--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -1296,7 +1296,7 @@ There are no KMD evaluation activities for this component.
 
 ====== TSS
 
-The evaluator shall confirm that the TSS describes the modification constraints for each SDO security attribute. 
+The evaluator shall confirm that the TSS describes the modification constraints for each SDO security attribute. The TSS shall specify any additional constraints that are relevant but not directly called out in the table.
 
 ====== AGD
 
@@ -1314,7 +1314,7 @@ There are no KMD evaluation activities for this component.
 
 ====== TSS
 
-The evaluator shall confirm that the TSS describes the initialization process for importing and generating SDOs. The TSS shall describe each type of SDO.Type and any additional attributes that are beyond the ones listed. In particular, it shall describe all attributes assigned to the SDO during parsing. Additionally, list any further restrictions of the allowed values for the minimum list of attributes.
+The evaluator shall confirm that the TSS describes the initialization process for importing and generating SDOs. The TSS shall describe each type of SDO.Type and any additional attributes that are beyond the ones listed. The TSS shall describe any implicit attributes for pre-installed SDOs as well as those stored in special locations. In particular, it shall describe all attributes assigned to the SDO during parsing. Additionally, list any further restrictions of the allowed values for the minimum list of attributes.
 
 The evaluator shall confirm that the TSS describes the allowed values for each of the attributes.
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -616,6 +616,8 @@ Extended SFRs (i.e. those SFRs that are not defined in [CC2]) are identified by 
 
 === Cryptographic Support
 
+The DSC ensures that the cryptography used is commensurate with the with the SDEs and SDOs that are being protected based on the selections made in the SFRs. The shortest key strength determines the overall security strength for the DSC.
+
 ==== FCS_CKM.1 Cryptographic Key Generation
 
 FCS_CKM.1 Cryptographic Key Generation
@@ -629,7 +631,7 @@ FCS_CKM.1.1:: The TSF shall generate cryptographic keys in accordance with a spe
 +
 ] [.line-through]#and specified cryptographic key sizes [_assignment: cryptographic key sizes_] that meet the following: [_assignment: list of standards_]#.
 
-_Application Note {counter:remark_count}_:: _Cryptographic keys can include KEKs that protect keys as well as the keys used to protect SDEs and SDOs. DSCs should use key strengths commensurate with protecting the chosen symmetric encryption key strengths._
+_Application Note {counter:remark_count}_:: _Cryptographic keys can include KEKs that protect keys as well as the keys used to protect SDEs and SDOs._
 
 ==== FCS_CKM.2 Cryptographic Key Distribution
 
@@ -638,7 +640,7 @@ FCS_CKM.2 Cryptographic Key Distribution
 FCS_CKM.2.1:: The TSF shall distribute cryptographic keys in accordance with a specified cryptographic key distribution method [*selection*: _key encapsulation as specified in FCS_COP.1/KeyEncap, key wrapping as specified in FCS_COP.1/KeyWrap, physically protected channels as specified in FTP_ITP_EXT.1, encrypted data buffers as specified in FTP_ITE_EXT.1, cryptographically protected data channels as specified in FTP_ITC_EXT.1_] that meets the following: [_none_].
 
 
-_Application Note {counter:remark_count}_:: _This SFR assumes there is no pre-shared key between the parties._
+_Application Note {counter:remark_count}_:: _This SFR is for cases where there are no pre-shared key between the parties._
 
 ==== FCS_CKM.6 Timing and event of cryptographic key destruction
 
@@ -646,7 +648,7 @@ FCS_CKM.6 Timing and event of cryptographic key destruction
 
 FCS_CKM.6.1:: The TSF shall destroy [assignment: _list of cryptographic keys (including keying material)_] when [selection: _no longer needed, [assignment: other circumstances for key or keying material destruction]_].
 
-_Application Note {counter:remark_count}_:: _The TOE will have mechanisms to destroy keys, including intermediate keys and key material, by using an approved method as specified in FCS_CKM.6.2. Examples of keys include intermediate keys, leaf keys, encryption keys, and signing keys. Key material includes seeds, authentication secrets, passwords, PINs, and other secret values used to derive keys. The ST Author shall list all such keys and keying material that are subject to destruction in the first assignment._
+_Application Note {counter:remark_count}_:: _The TOE will have mechanisms to destroy keys, including intermediate keys and key material, by using an approved method as specified in FCS_CKM.6.2. Examples of keys include intermediate keys, leaf keys, encryption keys, and signing keys. Key material includes seeds, authentication secrets, passwords, PINs, and other secret values used to derive keys. All such keys and keying material that are subject to destruction in the first assignment._
 +
 _This SFR does not apply to the public component of asymmetric key pairs or to keys that are permitted to remain stored, such as device identification keys._
 
@@ -683,9 +685,7 @@ FCS_COP.1/Hash Cryptographic Operation - Hashing
 
 FCS_COP.1.1/Hash:: The TSF shall perform [_cryptographic hashing_] in accordance with a specified cryptographic algorithm [*selection*: _SHA-1, SHA-224, SHA-256, SHA-384, SHA-512, SHA-512/224, SHA-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512_] that meets the following: [*selection*: _ISO/IEC 10118-3:2018 [SHA, SHA3], FIPS PUB 180-4 [SHA], FIPS PUB 202 [SHA3]_].
 
-_Application Note {counter:remark_count}_:: _The hash selection shall be consistent with the overall strength of the algorithm used for signature generation. For example, the TOE should choose SHA-256 for 2048-bit RSA or ECC with P-256; SHA-384 for 3072-bit RSA, 4096-bit RSA, or ECC with P-384; and SHA-512 for ECC with P-521. The ST author selects the standard based on the algorithms selected._
-+
-_SHA-1 may be used as a general hash function and for the following applications: generating and verifying hash-based message authentication codes (HMACs), key derivation functions (KDFs), and random bit/number generation. SHA-1 may also be used for verifying old digital signatures and time stamps, if this is explicitly allowed by the application domain. SHA-1 shall not be used in applications in which collision resistance is needed._
+_Application Note {counter:remark_count}_:: _SHA-1 may be used as a general hash function and for the following applications: generating and verifying hash-based message authentication codes (HMACs), key derivation functions (KDFs), and random bit/number generation. SHA-1 may also be used for verifying old digital signatures and time stamps, if this is explicitly allowed by the application domain. SHA-1 shall not be used in applications in which collision resistance is needed._
 
 ==== FCS_COP.1/KeyedHash Cryptographic Operation - Keyed Hash
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1575,11 +1575,11 @@ FMT_MSA.1.1:: The TSF shall enforce the [_Access Control SFP_] to restrict the a
 
 |===
 
-_Application Note {counter:remark_count}_:: _<<SDOAttrib>> defines the required constraints on security attribute modification. The Security Target completes the other parts not specified here (along with any other information for other security attributes relevant to a particular TOE)._
+_Application Note {counter:remark_count}_:: _<<SDOAttrib>> defines the required constraints on security attribute modification._
 +
 _The assignments of authorized subjects in <<SDOAttrib>> may be defined by the ST author in terms of roles or in terms of an action such as presentation of a valid authentication token of a particular type (in this case the ST author identifies in an Application Note the other SFRs that govern the action)._
 +
-_The TSF vendor may pre-install SDOs with default attributes. The Security Target should make clear which attributes may be changed or are prohibited from changing based on the ADM-R and MFGADM-R roles (as applicable). It should also distinguish between authorization values required to use pre-installed SDOs and authorization values required to change the attributes of pre-installed SDOs._
+_The TSF vendor may pre-install SDOs with default attributes. The ST author explains which attributes may be changed or are prohibited from changing based on the ADM-R and MFGADM-R roles (as applicable). The ST author also distinguishes between authorization values required to use pre-installed SDOs and authorization values required to change the attributes of pre-installed SDOs._
 +
 _<<SDOAttrib>> lists SDO ID as "cannot be modified". In some cases, a change in the attributes may cause a change in the SDO ID. In these cases, a change in the SDO ID causes the creation of a new SDO and possibly the loss of the old SDO._
 +
@@ -1671,21 +1671,19 @@ _An imported object contains the default values for each attribute, where allowe
 +
 _Unless otherwise noted, both the ADM-R and CApp-R roles can initiate the generation process. The ADM-R and CApp-R roles will provide the default values for the attributes. This SFR assumes the TSF checks SDO.Type, SDO.AuthData, SDO.Reauth, SDO.Conf, and SDO.Export for compliance with established security policies and refuses to create objects which do not comply with overriding the value of any of these attributes. In the cases of the SDO.ID and SDO.Integrity, the TSF generates these values and therefore there is no need or ability to override._
 +
-_In the case of SDO.Bind for both import and generation processes, the TSF may override values that denote a binding to the TOE, but it should not override values that denote a binding to other keys. In the case of the import process, the defined roles cannot override the default values for any binding._
+_In the case of SDO.Bind for both import and generation processes, the TSF may override values that denote a binding to the TOE, but not those values that denote a binding to other keys. In the case of the import process, the defined roles cannot override the default values for any binding._
 +
 _The SDO.AuthData attribute is data that is required in order to validate authorization of a subject to access the SDO (in each of the modes relevant to that SDO). The nature of this data will depend on the authorization mechanism used in the TOE, as described in FIA_UAU.2._
 +
 _The SDO.Reauth attribute for an individual SDO specifies the conditions where access to the SDO will require reauthorization to continue access to the SDO. Examples of TOE-specified events might be explicit revocation of authorization by a user, expiry of a time interval, or completion of a fixed number of uses since the last authorization. The re-authorization conditions are used in FIA_UAU.6 and FDP_ACF.1. These determine whether a single authorization by the SDO owner will allow any number of uses of the SDO until the end of the user's session (value 'none'), or whether each use of the SDO must be individually authorized (value 'each access'), or whether re-authorization must happen each time one of the TOE-specified events occurs._
 +
-_The SDO.Conf attribute indicates which SDEs, if any, the TOE should encrypt when not in operational use. The TOE should use the methods in FCS_COP.1/AEAD, FCS_COP.1/SKC, FCS_STG_EXT.1, or FCS_CKM_EXT.3 to protect the SDEs in this list._
+_The SDO.Conf attribute indicates which SDEs, if any, the TOE encrypts when not in operational use. The TOE should use the methods in FCS_COP.1/AEAD, FCS_COP.1/SKC, FCS_STG_EXT.1, or FCS_CKM_EXT.3 to protect the SDEs in this list._
 +
 _The SDO.Integrity attribute includes evidence that the TSF can use to protect and verify the integrity of the SDO._
 +
-_Attributes assigned by the TOE to any parsed SDOs must be described in the Security Target. Where attributes may be assigned by authorized roles, the information should also be described in operational user guidance._
+_Attributes assigned by the TOE to any parsed SDOs are described in the ST. Where attributes may be assigned by authorized roles, the information should also be described in operational user guidance._
 +
 _The TOE uses the Binding Data for an SDO to strongly link the SDO to the TOE, a parent SDO in a hierarchy, or to nothing at all. SDOs bound to nothing may freely travel from one TOE to another without restrictions. If bound to another SDO as a child to a parent in a hierarchy, it may travel only where the parent SDO travels. If bound to the TOE, it may travel to any other TOE for any reason, even if the TOE moves its parent to another TOE. Note that vendors will initialize attributes of pre-installed SDOs with default values. However, authorization values to change the attributes of pre-installed SDOs may differ from the authorization value required to use the pre-installed SDO._
-+
-_The vendor should document the implicit attributes for pre-installed SDOs and SDOs stored in special locations._
 +
 _In cases in which the SDO.ID is a cryptographic hash of the attributes and SDEs, that value may act as both SDO.ID and SDO.Integrity for the SDO._
 +
@@ -1712,7 +1710,7 @@ _[selection:_
 ** _unlock access to SDO following excessive failed authorization attempts,_
 ** _no other functions]_].
 
-_Application Note {counter:remark_count}_:: _If FPT_MFW_EXT.1 selects [.underline]#mutable firmware#, then FMT_SMF.1 must select [.underline]#Update TOE firmware and pre-installed SDOs#._
+_Application Note {counter:remark_count}_:: _If FPT_MFW_EXT.1 selects [.underline]#mutable firmware#, then FMT_SMF.1 must select [.underline]#update TOE firmware# and [.underline]#update pre-installed SDOs#._
 +
 _Recall that resetting a TOE to factory state also wipes all user data, but may not wipe out pre-installed SDOs. Configuring authorization policies includes setting policies for allowed access to SDOs._
 +

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -685,7 +685,7 @@ FCS_COP.1/Hash Cryptographic Operation - Hashing
 
 FCS_COP.1.1/Hash:: The TSF shall perform [_cryptographic hashing_] in accordance with a specified cryptographic algorithm [*selection*: _SHA-1, SHA-224, SHA-256, SHA-384, SHA-512, SHA-512/224, SHA-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512_] that meets the following: [*selection*: _ISO/IEC 10118-3:2018 [SHA, SHA3], FIPS PUB 180-4 [SHA], FIPS PUB 202 [SHA3]_].
 
-_Application Note {counter:remark_count}_:: _SHA-1 may be used as a general hash function and for the following applications: generating and verifying hash-based message authentication codes (HMACs), key derivation functions (KDFs), and random bit/number generation. SHA-1 may also be used for verifying old digital signatures and time stamps, if this is explicitly allowed by the application domain. SHA-1 shall not be used in applications in which collision resistance is needed._
+_Application Note {counter:remark_count}_:: _SHA-1 is allowed in cases where collision resistance is not required. SHA-1 may be used for the following applications: generating and verifying hash-based message authentication codes (HMACs), key derivation functions (KDFs), and random bit/number generation. SHA-1 may also be used for verifying old digital signatures and time stamps, if this is explicitly allowed by the application domain._
 
 ==== FCS_COP.1/KeyedHash Cryptographic Operation - Keyed Hash
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -616,7 +616,7 @@ Extended SFRs (i.e. those SFRs that are not defined in [CC2]) are identified by 
 
 === Cryptographic Support
 
-The DSC ensures that the cryptography used is commensurate with the with the SDEs and SDOs that are being protected based on the selections made in the SFRs. The shortest key strength determines the overall security strength for the DSC.
+The DSC ensures that the cryptography used is commensurate with the SDEs and SDOs that are being protected based on the selections made in the SFRs. The shortest key strength determines the overall security strength for the DSC.
 
 ==== FCS_CKM.1 Cryptographic Key Generation
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1472,9 +1472,9 @@ FIA_AFL_EXT.1.3:: When the failed authorization attempt counters [selection, cho
 
 FIA_AFL_EXT.1.4:: The TSF shall increment the failed authorization attempt counter before it verifies the authorization.
 
-_Application Note {counter:remark_count}_:: _The product validates the authorization factors prior to determining whether user (administrator or client application) access to the SDE/SDO is permitted. In cases where validation of the authorization factors fails, the product will not allow access to SDE/SDO. The product validates the authorization factors in such a way that it does not allow an attacker to circumvent the other requirements to gain knowledge about the SDE/SDO or other keying material that protects them from inadvertent exposure._
+_Application Note {counter:remark_count}_:: _The TOE validates the authorization factors prior to determining whether user (administrator or client application) access to the SDE/SDO is permitted. In cases where validation of the authorization factors fails, the TOE blocks access to SDE/SDO. The TOE validates the authorization factors in such a way that it does not allow an attacker to circumvent the other requirements to gain knowledge about the SDE/SDO or other keying material that protects them from inadvertent exposure._
 +
-_It is possible for the TOE to have different rules for the treatment of different SDOs or groups of SDOs. For example, some SDOs may trigger a factory reset in the event of excessive authorization failures while others may only temporarily block future authorization attempts. The ST author should iterate this SFR for each distinct response the TSF can make (as defined by the selections in FIA_AFL_EXT.1.3) and the SDOs whose authorization failures will trigger these responses._
+_It is possible for the TOE to have different rules for the treatment of different SDOs or groups of SDOs. For example, some SDOs may trigger a factory reset in the event of excessive authorization failures while others may only temporarily block future authorization attempts. Iterations of this SFR for each distinct response can be used for each action the TSF can make (as defined by the selections in FIA_AFL_EXT.1.3) and the SDOs whose authorization failures will trigger these responses._
 
 ==== FIA_SOS.2 TSF Generation of Secrets
 
@@ -1484,7 +1484,7 @@ FIA_SOS.2.1:: The TSF shall provide a mechanism to generate *authorization data*
 
 FIA_SOS.2.2:: The TSF shall be able to enforce the use of TSF generated *authorization data* for [_assignment: *non-empty* list of TSF functions_].
 
-_Application Note {counter:remark_count}_:: _This SFR expects the TSF must generate authorization data from a sufficiently large key space to ensure that users cannot employ random guessing as a statistically plausible method of authorizing actions within the TOE, both for a single event and over a session._
+_Application Note {counter:remark_count}_:: _The TSF generates authorization data from a sufficiently large key space to ensure that users cannot employ random guessing as a statistically plausible method of authorizing actions within the TOE, both for a single event and over a session._
 
 ==== FIA_UAU.2 User Authentication before Any Action
 
@@ -1518,13 +1518,13 @@ _Application Note {counter:remark_count}_:: _The allowed values for the SDO.Reau
 +
 _An SDO.Reauth value of 'none' indicates that no authentication of the subject user nor of the SDO owners is necessary. It also indicates that no reauthorization for operations using the SDO is necessary._
 +
-_An SDO.Reauth value of policy indicates that there may be a more complicated set of circumstances that trigger a re-auth (re-authentication of the users and owners as well as re-authorization of the operation). This could be a policy of a time limit for which a user can use an SDO before re-authentication (e.g. 10 minutes or 24 hours). The ST should indicate the policies allowed, and how the TOE evaluates the policies. The ST should also indicate the location of those policies, and how the TOE protects the integrity of those policies._
+_An SDO.Reauth value of policy indicates that there may be a more complicated set of circumstances that trigger a re-auth (re-authentication of the users and owners as well as re-authorization of the operation). This could be a policy of a time limit for which a user can use an SDO before re-authentication (e.g. 10 minutes or 24 hours)._
 +
 _When the TSF binds a user to access an SDO, this means that the TSF has authenticated the user and that the TSF authorized the user to have the right to exercise one or more of the following actions: generate the SDO, modify the SDO, including its security attributes, use the SDO in a TOE operation, propagate or duplicate the SDO for use by a device external to the DSC, or destroy the SDO. The user may not have exclusive rights to exercise the operations listed._
 +
-_Policy as represented by the attributes in the SDO dictates whether or not a user must authenticate itself in order to authorize access to the SDO._
+_Policy as represented by the attributes in the SDO dictates whether or not a user authenticates itself in order to authorize access to the SDO._
 +
-_It is possible that the attributes of some SDOs should remain unchanged, and that the attributes of other SDOs may be changed by authorized users. If this is the case, then the ST author should iterate this SFR and indicate in the TSS which SDOs apply to each iteration._
+_It is possible that the attributes of some SDOs remain unchanged, and that the attributes of other SDOs may be changed by authorized users. Iterations of this SFR can be using to document the SDOs and how they apply to different policies._
 
 === Security Management
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -648,7 +648,7 @@ FCS_CKM.6 Timing and event of cryptographic key destruction
 
 FCS_CKM.6.1:: The TSF shall destroy [assignment: _list of cryptographic keys (including keying material)_] when [selection: _no longer needed, [assignment: other circumstances for key or keying material destruction]_].
 
-_Application Note {counter:remark_count}_:: _The TOE will have mechanisms to destroy keys, including intermediate keys and key material, by using an approved method as specified in FCS_CKM.6.2. Examples of keys include intermediate keys, leaf keys, encryption keys, and signing keys. Key material includes seeds, authentication secrets, passwords, PINs, and other secret values used to derive keys. All such keys and keying material that are subject to destruction in the first assignment._
+_Application Note {counter:remark_count}_:: _The TOE will have mechanisms to destroy keys, including intermediate keys and key material, by using an approved method as specified in FCS_CKM.6.2. Examples of keys include intermediate keys, leaf keys, encryption keys, and signing keys. Key material includes seeds, authentication secrets, passwords, PINs, and other secret values used to derive keys. All such keys and keying material are subject to destruction in the first assignment._
 +
 _This SFR does not apply to the public component of asymmetric key pairs or to keys that are permitted to remain stored, such as device identification keys._
 


### PR DESCRIPTION
This is a review of the first for App notes related to #435 and #436. A small heading has been added to the Cryptographic section heading noting about ensuring commensurate protection of keys in the DSC. This will be taken out of the remaining app notes.

This covers the first 5 app notes.