### PR TITLE
Appnote16-20

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1385,7 +1385,7 @@ FDP_ITC_EXT.1.4:: The TSF shall bind SDEs to security attributes using [assignme
 
 _Application Note {counter:remark_count}_:: _The way the TSF checks the integrity of the SDE depends on the method of importation. For example, the encrypted data channel may provide data integrity as part of its service._
 +
-_When a TSF parses an SDE, it should generate security attributes and create an SDO by binding the security attributes to the SDE._
+_When a TSF parses an SDE, an SDO will be created by binding it to generated security attributes._
 
 ==== FDP_ITC_EXT.2 Parsing of SDOs
 
@@ -1403,7 +1403,7 @@ FDP_ITC_EXT.2.5:: The TSF shall ensure that interpretation of the security attri
 
 _Application Note {counter:remark_count}_:: _The way the TSF checks the integrity of the SDO depends on the method of importation. For example, the encrypted data channel may provide data integrity as part of its service._
 +
-_When a TSF parses an SDO, it should already have a set of security attributes. However, the TSF may modify these attributes, if authorized, to comply with security policies on the TOE._
+_When a TSF parses an SDO, it may already have a set of security attributes. However, the TSF may modify these attributes, if authorized, to comply with security policies on the TOE._
 
 ==== FDP_RIP.1 Subset Residual Information Protection
 
@@ -1437,11 +1437,7 @@ FDP_SDI.2.2:: Upon detection of a data integrity error, the TSF shall [
 * _prohibit the use of the altered data_
 * _send notification of the error where applicable_].
 
-_Application Note {counter:remark_count}_:: _This SFR deals with the mechanism that protects the integrity of the SDEs and security attributes within an SDO. This provides the binding data that ensures the prevention of unauthorized changes to the SDEs and attributes. It is not expected that a single key will be protected from corruption by multiple of these methods; however, a product may use one integrity-protection method for one type of key and a different method for other types of keys._
-+
-_The cryptographic requirements for cryptographic hashes and digital signatures apply here._
-+
-_No specific requirement is placed here on the nature of the integrity protection data, but the Security Target shall describe this protection measure, and shall identify the iteration of FCS_COP.1/CMAC, FCS_COP.1/Hash, FCS_COP.1/KeyedHash, FCS_COP.1/SigVer, or FCS_COP.1/KeyWrap that covers any cryptographic algorithm used._
+_Application Note {counter:remark_count}_:: _This SFR deals with the mechanism that protects the integrity of the SDEs and security attributes within an SDO. This provides the binding data that ensures the prevention of unauthorized changes to the SDEs and attributes. While a single key may not be protected by multiple methods, the TOE may implement multiple methods and utilize them for different types of keys as appropriate._
 +
 _The integrity protection data in FDP_SDI.2.1 is included in the list of attributes identified in FMT_MSA.1, and protects the value of the SDEs and of the SDO security attributes._
 +

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1345,11 +1345,11 @@ FDP_ACF.1.4:: The TSF shall explicitly deny access of subjects to objects based 
 
 _Application Note {counter:remark_count}_:: _The expectation of this SFR is that the reader is given sufficient information to determine, for each object controlled by the TOE, the operations that can be performed on it based on the subject attempting to perform the operation, and whether this is conditional based on attribute values or any other circumstances._
 +
-_It is expected that many of the subject-object-operation combinations will always be prohibited by the TSF, either because the target object is not externally modifiable or because the subject lacks the ability to perform the operation in question._
+_Many of the subject-object-operation combinations in the TOE will always be prohibited by the TSF, either because the target object is not externally modifiable or because the subject lacks the ability to perform the operation in question._
 +
-_The ST author is not expected to create an exhaustive list of subject-object-operation combinations; it is sufficient to list those that are always permitted and those that are conditionally permitted with the expectation that all remaining combinations are prohibited._
+_Subject-object-operation combinations that are always permitted and those that are conditionally permitted, combined with rules about the remaining combinations such as blacket prohibition of access is sufficient._
 +
-_FDP_ACF.1.3 and FDP_ACF.1.4 allow the ST author to optionally specify override conditions to resolve otherwise contradictory Access Control SFP rules. For example, the rule "S.Admin may always modify the SDO.Conf attribute of any OB.P_SDO or OB.T_SDO object" may be overridden by a statement in FDP_ACF.1.4 that identifies any particular SDO objects as non-modifiable regardless of subject authorizations._
+_FDP_ACF.1.3 and FDP_ACF.1.4 allow for optional override conditions to resolve otherwise contradictory Access Control SFP rules. For example, the rule "S.Admin may always modify the SDO.Conf attribute of any OB.P_SDO or OB.T_SDO object" may be overridden by a statement in FDP_ACF.1.4 that identifies any particular SDO objects as non-modifiable regardless of subject authorizations._
 +
 _The DSC may contain pre-installed SDOs. The DSC will enforce access control for pre-installed SDOs like any other SDO it contains or manages._
 


### PR DESCRIPTION
App note 18 seems like a hidden dependency in that it is stating that specific SDEs are also subject to FCS_CKM.6. I actually don't think that is necessary, since the two requirements are not mutually exclusive. Maybe this should just say something about FCS_CKM.6 is an acceptable method for destruction when appropriate.

App note 19 similarly seems to be quite prescriptive in the types of required data. These could be added as selections or even suggested assignments in the SFR itself. I would probably recommend selections, not the assignment.