### PR TITLE
Appnote50-54

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -2664,13 +2664,13 @@ FCS_CKM_EXT.8 Password-Based Key Derivation
 
 FCS_CKM_EXT.8.1:: The TSF shall perform password-based key derivation functions in accordance with a specified cryptographic algorithm HMAC-[selection: _SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512_], with iteration count of [assignment: _number of iterations_] using a randomly generated salt of length [assignment: _equal to or greater than 128_] and output cryptographic key sizes {empty}[selection: _128, 192, 256, [assignment: greater than 128]_] bits that meet the following standard: NIST SP 800-132 Section 5.3 (PBKDF2).
 
-_Application Note {counter:remark_count}_:: _Password-based key derivation is different from regular key derivation in that passwords have very limited entropy. As a result, one must add additional constraints, work, or entropy to achieve acceptable levels of security when using password-based key derivation algorithms. This component only adds work through increased iterations and use of salts; it does not consider additional constraints or entropy._
+_Application Note {counter:remark_count}_:: _Password-based key derivation is different from regular key derivation in that passwords have very limited entropy. As a result, additional constraints, work, or entropy to achieve acceptable levels of security when using password-based key derivation algorithms are needed. This component only adds work through increased iterations and use of salts; it does not consider additional constraints or entropy._
 +
-_The TSF is allowed to use PBKDF2 to condition passwords in the context of password-based authentication. In this scenario, the output of PBKDF2 is not directly used as a cryptographic key, but only stored as a reference value (commonly called "password hash") to compare against when performing authentication. The "cryptographic key size" selected in this element must correspond to the length of the password hash._
+_The TSF is allowed to use PBKDF2 to condition passwords in the context of password-based authentication. In this scenario, the output of PBKDF2 is not directly used as a cryptographic key, but only stored as a reference value (commonly called "password hash") to compare against when performing authentication. The "cryptographic key size" selected in this element corresponds to the length of the password hash._
 +
 _NIST recommends a minimum "number of iterations" of 1000 but prefers the largest number feasible given performance constraints._
 +
-_NIST recommends that the randomly generated portion of the salt have length of at least 128 bits and must be derived from a Random Bit Generation. Therefore FCS_CKM_EXT.8 depends on FCS_OTV_EXT.1._
+_NIST recommends that the randomly generated portion of the salt have length of at least 128 bits and is derived from a Random Bit Generation. Therefore FCS_CKM_EXT.8 depends on FCS_OTV_EXT.1._
 
 ==== FCS_COP.1/AEAD Cryptographic Operation - Authenticated Encryption with Associated Data
 
@@ -2817,8 +2817,6 @@ The following table provides the allowed choices for completion of the selection
 
 |===
 
-_Application Note {counter:remark_count}_:: _NIST SP 800-57 Part 1 Revision 5 Section 5.6.2 specifies that the size of key used to protect the key being transported should be at least the security strength of the key it is protecting._
-
 ==== FCS_COP.1/KeyWrap Cryptographic Operation - Key Wrapping
 
 FCS_COP.1/KeyWrap Cryptographic Operation - Key Wrapping
@@ -2892,7 +2890,9 @@ NIST FIPS PUB 202 Section 5 [KECCAK]
 
 |===
 
-_Application Note {counter:remark_count}_:: _The functions in cSHAKE depend on the output length d., i.e. SHAKEd is either SHAKE128 for d = 128 or SHAKE256 for d = 256. Similarly, KECCAK[2d] is either KECCAK[256] for d = 128 or KECCAK[512] for d = 256. Note that KECCAK is a cryptographic primitive which should have no direct interface exposed to the user of the TOE._
+_Application Note {counter:remark_count}_:: _The functions in cSHAKE depend on the output length d., i.e. SHAKEd is either SHAKE128 for d = 128 or SHAKE256 for d = 256. Similarly, KECCAK[2d] is either KECCAK[256] for d = 128 or KECCAK[512] for d = 256._
++
+_Note that KECCAK is a cryptographic primitive which is not expected to have a direct interface exposed to the user of the TOE._
 
 === User Data Protection
 ==== FDP_DAU.1/Prove Basic Data Authentication (for Use with the Prove Service)
@@ -2903,7 +2903,7 @@ FDP_DAU.1.1/Prove:: The TSF shall provide a capability to generate evidence that
 
 FDP_DAU.1.2/Prove:: The TSF shall provide [assignment: _list of subjects_] with the ability to verify evidence of the validity of the indicated information.
 
-_Application Note {counter:remark_count}_:: _This SFR describes the output of the Prove service provided by the DSC. The evidence of validity or authenticity, or other evidence derived, is expected to be processed by the RoT for Measurement. Additionally, the use of a RoT for Reporting presupposes a logging capability or other means of generating state information that could be conveyed to external entities. Therefore, FDP_DAU.1.1/Prove must be claimed if-and-only-if [.underline]#Root of Trust for Measurement# and [.underline]#Root of Trust for Reporting# are both selected in FPT_ROT_EXT.1.1. An 'authenticated user' in the sense of the selection in FDP_DAU.1.1/Prove means a user who has been authenticated by the DSC according to the mechanisms of FIA_UAU.5._
+_Application Note {counter:remark_count}_:: _This SFR describes the output of the Prove service provided by the DSC. The evidence of validity or authenticity, or other evidence derived, is expected to be processed by the RoT for Measurement. Additionally, the use of a RoT for Reporting presupposes a logging capability or other means of generating state information that could be conveyed to external entities. Therefore, FDP_DAU.1.1/Prove is claimed if-and-only-if [.underline]#Root of Trust for Measurement# and [.underline]#Root of Trust for Reporting# are both selected in FPT_ROT_EXT.1.1. An 'authenticated user' in the sense of the selection in FDP_DAU.1.1/Prove means a user who has been authenticated by the DSC according to the mechanisms of FIA_UAU.5._
 +
 _In FDP_DAU.1.1/Prove, the DSC will issue a validity-stamped or authenticity-stamped piece of data. In this case, validity-stamped means that the form of the issued data enables an external entity to verify that the data has been issued via the DSC's Prove service. The implementation might be via a DSC cryptographic signature, or a MAC using a symmetric key shared with the receiver, for example. Authenticity-stamped means that the receiver of the data can verify that the user providing this data is authentic._
 +


### PR DESCRIPTION
App notes 50-54. One app note is deleted as it is handed by an earlier note about key sizes being properly chosen.