### PR TITLE
Address NIAP #13

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -981,7 +981,7 @@ There are no KMD evaluation activities for this component.
 
 ====== TSS
 
-The evaluator shall examine the TSS to ensure that it describes how it protects the SDO references, authorization data, against access from unauthorized entities. In particular, it should describe how it provides confidentiality of the data while it resides outside the TOE after export.
+The evaluator shall examine the TSS to ensure that it describes how it protects the wrapped authorization data and wrapped SDOs against access from unauthorized entities. In particular, it should describe how it provides confidentiality of the data while it resides outside the TOE after export.
 
 ====== AGD
 
@@ -989,7 +989,7 @@ There are no guidance evaluation activities for this component.
 
 ====== Test
 
-There are no test evaluation activities for this component.
+Testing for this SFR is performed as part of FCS_CKM.2.
 
 ====== KMD
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1345,9 +1345,9 @@ _The DSC may contain pre-installed SDOs. The DSC will enforce access control for
 
 FDP_ETC_EXT.2 Propagation of SDOs
 
-FDP_ETC_EXT.2.1:: The TSF shall propagate only SDO references, wrapped authorization data, and wrapped SDOs such that only [selection: _the TOE, authorized users_] can access them.
+FDP_ETC_EXT.2.1:: The TSF shall propagate only wrapped authorization data and wrapped SDOs such that only [selection: _the TOE, authorized users_] can access them.
 
-_Application Note {counter:remark_count}_:: _This SFR imposes security requirements on data being propagated (exported) outside the TOE. The "SDO reference" is a pointer to an object that resides in the TOE; this can be thought of as a token to the object. The "users" in the "authorized users" selection includes all roles (i.e. ADM-R, MFGADM-R, CApp-R)._
+_Application Note {counter:remark_count}_:: _This SFR imposes security requirements on data being propagated (exported) outside the TOE. The "users" in the "authorized users" selection includes all roles (i.e. ADM-R, MFGADM-R, CApp-R)._
 
 ==== FDP_FRS_EXT.1 Factory Reset
 
@@ -3299,7 +3299,7 @@ Hierarchical to:: No other components.
 
 Dependencies:: FCS_COP.1 Cryptographic Operation
 [vertical]
-FDP_ETC_EXT.2.1:: The TSF shall propagate only SDO references, wrapped authorization data, and wrapped SDOs such that only [selection: _the TOE, authorized users_] can access them.
+FDP_ETC_EXT.2.1:: The TSF shall propagate only wrapped authorization data and wrapped SDOs such that only [selection: _the TOE, authorized users_] can access them.
 
 ==== FDP_FRS_EXT Factory Reset
 


### PR DESCRIPTION
Closes #440 

Remove "SDO references" from the SFR requirement, since it doesn't make sense to "protect" them against access from unauthorized entities and the references are an implementation detail.

Then, refer to FCS_CKM.2 for the tests, as this SDO export/propagation is covered by key distribution.