### PR TITLE
Fdp sfrs

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -1598,7 +1598,7 @@ There are no KMD evaluation activities for this component.
 
 ====== TSS
 
-The evaluator shall examine the TSS and other vendor documentation and ensure they describe the methods used to verify integrity of the TSF and TSF data, both automatic checks and if supported, checks requested by the user. If more than the power-on check is selected, then each condition for the self test shall be examined.
+The evaluator shall examine the TSS and other vendor documentation and ensure they describe the methods used to demonstrate the correct operation of the TSF, verify the integrity of the TSF and its data, both automatic checks and if supported, checks requested by the user. The TSS shall also describe how the TSF responds to self-test failures. Each condition for the self-tests shall be described and examined.
 
 ====== AGD
 
@@ -1606,11 +1606,9 @@ The evaluator shall examine the operational guidance to ensure it provides autho
 
 ====== Test
 
-Test 1: The evaluator shall verify that the DSC performs an integrity check of all TSF, including data, as well as performing KATs for those functions. The evaluator shall verify failures using malformed known answer test data (for example, unexpected input or output values).
+Test 1: For each implemented self-test, the evaluator shall cause the self-test to fail and verify the TSF responds as described in the TSS.
 
-Test 2: The evaluator shall ensure that when an integrity check failure occurs specific to failing KATs and failure to verify the integrity of the TSF, the TOE will prevent any further processing of the current TSF and user data. 
-
-Test 3 [conditional]: For each condition where a self test may be initiated, the evaluator shall verify that the self tests are run as specified.
+Test 2 [conditional]: For each condition where a self-test may be initiated, the evaluator shall verify that the self-tests are performed as specified.
 
 ====== KMD
 

--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -2437,7 +2437,7 @@ There are no KMD evaluation activities for this component.
 
 ==== Replay Detection (FPT_RPL)
 
-===== FPT_RPL.1/Rollback Replay Detection (Rollback)
+===== FPT_RPL.1/FW Replay Detection (Firmware)
 
 ====== TSS
 
@@ -2451,7 +2451,7 @@ There are no AGD evaluation activities for this component.
 
 The evaluator shall repeat the following tests to cover all allowed firmware verification mechanisms as described in the TSS. For example, if the firmware verification mechanism replaces an entire partition or subset of the DSC scope containing many separate code files, the evaluator does not need to repeat the test for each individual file.
 
-Test 1: The evaluator shall attempt to execute an earlier instance or build of the software (as determined by the vendor). The evaluator shall verify that this attempt fails by checking the version identifiers or cryptographic hashes of the firmware against those previously recorded and checking that the values do not correspond to an unauthorized build.
+Test 1: The evaluator shall attempt to execute an earlier instance or build of the firmware (as determined by the vendor). The evaluator shall verify that this attempt fails by checking the version identifiers or cryptographic hashes of the firmware against those previously recorded and checking that the values do not correspond to an unauthorized build.
 
 Test 2: The evaluator shall attempt to execute a current or later instance and shall verify that the firmware execution succeeds.
 

--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -985,38 +985,6 @@ Testing for this SFR is performed as part of FCS_CKM.2.
 
 There are no KMD evaluation activities for this component.
 
-==== Factory Reset (Extended - FDP_FRS_EXT)
-
-===== FDP_FRS_EXT.1 Factory Reset
-
-====== TSS
-
-The evaluator shall examine the TSS to determine that it describes each of the conditions which may lead to a factory reset.
-
-====== AGD
-
-The evaluator shall examine the operational guidance to ensure that it describes the ways the administrator can set the conditions to initiate a factory reset if this is supported.
-
-====== Test
-
-Test 1 [conditional]: If [.underline]#activation by external interface# is selected in FDP_FRS_EXT.1.1, the evaluator shall identify all external interfaces that reset the DSC to factory settings. For each external interface, the evaluator shall perform the following steps:
-
-. Create an SDE or SDO.
-. Verify the presence of the item created in the previous step.
-. Initiate the factory reset using the given external interface.
-. Verify the item created in Step #1. no longer exists.
-
-Test 2 [conditional]: If [.underline]#presentation of ...# is selected in FDP_FRS_EXT.1.1, the evaluator shall identify all functions that reset the DSC to factory settings and their respective required authorization data. For each function and for each authorization method (i.e., type of requured authorization data), the evaluator shall perform the following steps:
-
-. Create an SDE or SDO.
-. Verify the presence of the item created in the previous step.
-. Initiate the factory reset using the given function and authorization data.
-. Verify the item created in Step #1. no longer exists.
-
-====== KMD
-
-There are no KMD evaluation activities for this component.
-
 ==== Import from Outside the TOE (Extended - FDP_ITC_EXT)
 
 ===== FDP_ITC_EXT.1 Parsing of SDEs
@@ -1159,7 +1127,7 @@ Test 1: If the administrator is able to configure any of the variables for autho
 
 Test 2: After reaching the limit for unsuccessful authorization attempts as in Test 1 above, the evaluator shall proceed as follows. If the action selected in FIA_AFL_EXT.1.3 is included in the ST then the evaluator shall confirm by testing that following the operational guidance and performing each action specified in the ST to re-enable access results in successful access. If the time period selection in FIA_AFL_EXT.1.3 is included in the ST, then the evaluator shall wait for just less than the time period configured in Test 1 and show that an authorization attempt using valid credentials does not result in successful access. The evaluator shall then wait until just after the time period configured in Test 1 and show that an authorization attempt using valid credentials results in successful access.
 
-Test 3 [conditional]: If [.underline]#factory reset the TOE wiping out all non-permanent SDEs and SDOs, as described by FDP_FRS_EXT.2# is selected in FIA_AFL_EXT.1.3, the evaluator shall perform the test required by FDP_FRS_EXT.2 with step 5 replaced with "The evaluator shall initiate a factory reset by deliberately meeting or surpassing the threshold for unsuccessful authorization attempts, depending on whether [.underline]#meets# or [.underline]#surpasses# is selected in FIA_AFL_EXT.1.3."
+Test 3 [conditional]: If [.underline]#factory reset the TOE wiping out all non-permanent SDEs and SDOs, as described by FDP_FRS_EXT.1# is selected in FIA_AFL_EXT.1.3, the evaluator shall perform the test required by FDP_FRS_EXT.1 with step 5 replaced with "The evaluator shall initiate a factory reset by deliberately meeting or surpassing the threshold for unsuccessful authorization attempts, depending on whether [.underline]#meets# or [.underline]#surpasses# is selected in FIA_AFL_EXT.1.3."
 
 ====== KMD
 
@@ -2282,25 +2250,39 @@ There are no KMD evaluation activities for this component.
 
 ==== Factory Reset (Extended - FDP_FRS_EXT)
 
-===== FDP_FRS_EXT.2 Factory Reset Behavior
+===== FDP_FRS_EXT.1 Factory Reset
 
 ====== TSS
+
+The evaluator shall examine the TSS to determine that it describes each of the conditions which may lead to a factory reset.
 
 The evaluator shall examine the TSS to determine the pre-installed SDOs that are reverted to their factory settings when a factory reset occurs, what the factory settings are for those SDOs, and that the TSS states that all non-permanent SDEs and SDOs are destroyed.
 
 ====== AGD
 
+The evaluator shall examine the operational guidance to ensure that it describes the ways the administrator can set the conditions to initiate a factory reset.
+
 The evaluator shall examine the operational guidance and verify that it identifies the pre-installed SDOs that are reverted to their initial values when a factory reset has been performed.
 
 ====== Test
 
-The evaluator shall perform the following test:
+Test 1 [conditional]: If [.underline]#activation by external interface# is selected in FDP_FRS_EXT.1.1, the evaluator shall identify all external interfaces that reset the DSC to factory settings. For each external interface, the evaluator shall perform the following steps:
 
-. The evaluator shall use each supported role to create or import an SDE or SDO that has known data. 
-. The evaluator shall then verify that the created SDE/SDO resides either within the DSC, or under the control of the DSC. 
+. The evaluator shall use each supported role to create or import an SDE or SDO that has known data.
+. The evaluator shall then verify that the created SDE/SDO resides either within the DSC, or under the control of the DSC.
 . The evaluator shall perform some operation for each created or imported SDE/SDO in step 1 that demonstrates that the SDE/SDO has been set to the indicated value.
-. For each pre-installed SDO that is identified in FDP_FRS_EXT.2.1, the evaluator shall perform some operation to verify what the current value of that SDO is.
-. The evaluator shall initiate a factory reset.
+. For each pre-installed SDO that is identified in FDP_FRS_EXT.1.2, the evaluator shall perform some operation to verify what the current value of that SDO is.
+. The evaluator shall initiate a factory reset using the given external interface.
+. For each created or imported SDE/SDO that is identified in step 3, the evaluator shall re-attempt the operation and verify that it no longer completes successfully because the SDE/SDO data has been erased.
+. For each pre-installed SDO that is identified in step 4, the evaluator shall re-attempt the operation and verify that the SDOs have been set to their factory default values.
+
+Test 2 [conditional]: If [.underline]#presentation of ...# is selected in FDP_FRS_EXT.1.1, the evaluator shall identify all functions that reset the DSC to factory settings and their respective required authorization data. For each function and for each authorization method (i.e., type of required authorization data), the evaluator shall perform the following steps:
+
+. The evaluator shall use each supported role to create or import an SDE or SDO that has known data.
+. The evaluator shall then verify that the created SDE/SDO resides either within the DSC, or under the control of the DSC.
+. The evaluator shall perform some operation for each created or imported SDE/SDO in step 1 that demonstrates that the SDE/SDO has been set to the indicated value.
+. For each pre-installed SDO that is identified in FDP_FRS_EXT.1.2, the evaluator shall perform some operation to verify what the current value of that SDO is.
+. The evaluator shall initiate a factory reset using the given function and authorization data.
 . For each created or imported SDE/SDO that is identified in step 3, the evaluator shall re-attempt the operation and verify that it no longer completes successfully because the SDE/SDO data has been erased.
 . For each pre-installed SDO that is identified in step 4, the evaluator shall re-attempt the operation and verify that the SDOs have been set to their factory default values.
 
@@ -2665,7 +2647,7 @@ However, if the evaluator is unable to perform some other required EA because th
 |FCS_STG_EXT.1
 
 |Factory Reset
-|FDP_FRS_EXT.1, [FDP_FRS_EXT.2]
+|[FDP_FRS_EXT.1]
 
 |Root of Trust for Reporting
 |[FPT_ROT_EXT.3]

--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -2397,33 +2397,11 @@ There are no KMD evaluation activities for this component.
 
 ==== Mutable/Immutable Firmware (Extended - FPT_MFW_EXT)
 
-===== FPT_MFW_EXT.2 Basic Firmware Integrity
+===== FPT_MFW_EXT.2 Firmware Integrity
 
 ====== TSS
 
-The evaluator shall verify that the TSS describes which critical memory is measured for these integrity values and how the measurement is performed (including which TOE software measures the memory integrity values, how that software accesses the critical memory, and which algorithms are used).
-
-====== AGD
-
-If the integrity values are provided to the administrator, the evaluator shall verify that the AGD guidance contains instructions for retrieving these values and information for interpreting them. For example, if multiple measurements are taken, what those measurements are and how changes to those values relate to changes in the device state.
-
-====== Test
-
-Note that the following test may require the developer to provide access to a test platform that provides the evaluator with tools that are not typically available to end users.
-
-The evaluator shall repeat the following test for each measurement:
-
-The evaluator shall boot the TOE in an approved state and record the measurement taken. The evaluator shall modify the critical memory or value that is measured. The evaluator shall reboot the TOE and verify that the measurement changed.
-
-====== KMD
-
-There are no KMD evaluation activities for this component.
-
-===== FPT_MFW_EXT.3 Firmware Authentication with Identity of Guarantor
-
-====== TSS
-
-The evaluator shall examine the TSS to ensure it describes the methods and identities used to verify integrity and authenticity of the firmware. The TSS shall identify the Guarantor and how to verify its identity.
+The evaluator shall examine the TSS to ensure it describes the methods (i.e., cryptographic algorithms) and identities (e.g., code signing certificates) used to verify integrity and authenticity of the firmware. The TSS shall identify the Guarantor (e.g., root certificate authority or trusted public key) and how to verify its identity.
 
 ====== AGD
 
@@ -2435,13 +2413,23 @@ The TOE guarantees the authenticity of the firmware using the identity of the Gu
 
 *Test 1: Verify Authentic Firmware*
 
-The evaluator shall trigger the TOE to load and evaluate the authenticity of authentic firmware according the methods described in the TSS. The evaluator shall ensure that the TOE provides a clear indication of the success of the evaluation to consider the test a 'Pass', otherwise, the test is a 'Fail'.
+The evaluator shall trigger the TOE to load and evaluate the integrity and authenticity of authentic firmware before execution, according the methods described in the TSS. The evaluator shall ensure that the TOE provides a clear indication of the success of the evaluation to consider the test a 'Pass', otherwise, the test is a 'Fail'.
 
 *Test 2: Verify Unauthentic Firmware*
 
-The evaluator shall deliberately modify authentic firmware. 
+The evaluator shall deliberately modify the authentic firmware.
 
-The evaluator shall trigger the TOE to load and evaluate the authenticity of the deliberately modified firmware according the methods described in the TSS. The evaluator shall ensure that the TOE provides a clear indication of the failure of the evaluation to consider the test a 'Pass', otherwise, the test is a 'Fail'.
+The evaluator shall trigger the TOE to load and evaluate the integrity and authenticity of the deliberately modified firmware before execution, according the methods described in the TSS. The evaluator shall ensure that the TOE provides a clear indication of the failure of the evaluation to consider the test a 'Pass', otherwise, the test is a 'Fail'.
+
+*Test 3: Verify Authentic Firmware Updates*
+
+The evaluator shall trigger the TOE to load and evaluate the integrity and authenticity of an authentic firmware update, according the methods described in the TSS. The evaluator shall ensure that the TOE provides a clear indication of the success of the evaluation to consider the test a 'Pass', otherwise, the test is a 'Fail'.
+
+*Test 4: Verify Unauthentic Firmware Updates*
+
+The evaluator shall deliberately modify the authentic firmware update.
+
+The evaluator shall trigger the TOE to load and evaluate the authenticity of the deliberately modified firmware update, according the methods described in the TSS. The evaluator shall ensure that the TOE provides a clear indication of the failure of the evaluation to consider the test a 'Pass', otherwise, the test is a 'Fail'.
 
 ====== KMD
 

--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -1081,7 +1081,7 @@ There are no KMD evaluation activities for this component.
 
 ====== TSS
 
-The evaluator shall confirm that the ST author describes the methods for protecting the integrity of SDOs stored with the TOE, and shall identify the iteration of FCS_COP.1/Hash, FCS_COP.1/KeyedHash, FCS_COP.1/SigVer or FCS_COP.1/KeyWrap that covers any cryptographic algorithm used. The evaluator shall also confirm that the TSS describes the response upon the detection of an integrity error.
+The evaluator shall examine the TSS to determine that it describes the protection for SDOs and the methods of protection (e.g. protected storage, hashing, digital signatures, key wrapping, etc.). The evaluator shall also confirm that the TSS describes the response upon the detection of an integrity error.
 
 The evaluator shall confirm that the TSS describes the actions the TSF takes when the integrity verification fails for an SDO, including the circumstances that cause a notification to be sent when this occurs.
 

--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -189,32 +189,23 @@ For definitions of standard CC terminology, see [CC] part 1.
 |Root Encryption Key 
 |An encryption key that serves as the anchor of a hierarchy of keys.
 
-|Root of Trust 
-|A root of trust performs one or more security specific functions; establishing the foundation on which all trust in a system is placed. [NIST-ROTM]
+|Root of Trust (RoT)
+|A RoT performs one or more security specific functions; establishing the foundation on which all trust in a system is placed. [NIST-ROTM]
 
-|Root of Trust for Authorization 
-|(As defined by [GP_ROT]) The Root of Trust for Authorization provides reliable capabilities to assess authorization tokens and determine whether or not they satisfy policies for access control.
-
-|Root of Trust for Confidentiality 
+|Root of Trust for Confidentiality
 |(As defined by [GP_ROT]) The Root of Trust for Confidentiality maintains shielded locations for the purpose of storing sensitive data, such as secret keys and passwords.
 
-|Root of Trust for Integrity 
+|Root of Trust for Integrity
 |(As defined by [GP_ROT]) The Root of Trust for Integrity maintains shielded locations for the purpose of storing and protecting the integrity of non-secret critical security parameters and platform characteristics. Critical security parameters include, but are not limited to, authorization values, public keys, and public key certificates.
 
-|Root of Trust for Measurement 
+|Root of Trust for Measurement
 |(As defined by [GP_ROT]) The Root of Trust for Measurement provides the ability to reliably create platform characteristics.
 
-|Root of Trust for Reporting 
+|Root of Trust for Reporting
 |(As defined by [GP_ROT]) The Root of Trust for Reporting reliably reports platform characteristics. It provides an interface that limits its services to providing reports on its platform characteristics authenticated by a platform identity.
 
-|Root of Trust for Storage 
-|A root of trust that acts as the Root of Trust for Confidentiality and the Root of Trust for Integrity.
-
-|Root of Trust for Update 
-|A root of trust responsible for updating the firmware.
-
-|Root of Trust for Verification 
-|A root of trust responsible for verifying digital signatures.
+|Root of Trust for Verification
+|(As defined by [GP_ROT]) The Root of Trust for Verification verifies the integrity and authenticity of signed objects. Objects may include, but are not limited to, public keys, code, and data.
 
 |Security Data Element 
 |A Critical Security Parameter, such as a cryptographic key or authorization token.
@@ -1486,9 +1477,9 @@ The evaluator shall then induce a voltage glitch outside of the specified normal
 
 There are no KMD evaluation activities for this component.
 
-==== Root of Trust (Extended - FPT_PRO_EXT)
+==== Root of Trust (Extended - FPT_ROT_EXT)
 
-===== FPT_PRO_EXT.1 Root of Trust
+===== FPT_ROT_EXT.1 Root of Trust
 
 ====== TSS
 
@@ -1497,6 +1488,10 @@ The evaluator shall examine the TSS to ensure that it describes how Root of Trus
 [conditional] For immutable Root of Trust data, the evaluator shall ensure there are no mechanisms to update the Root of Trust.
 
 [conditional] For mutable Root of Trust data, the evaluator shall ensure the Root of Trust update mechanism uses an approved method for authenticating the source of the update.
+
+The evaluator shall ensure that the TSS describes how the Root of Trust prevents unauthorized disclosure and unauthorized modification to SDOs. The evaluator shall also examine the TSS to verify that it uses approved mechanisms to protect the confidentiality of secret SDOs and to protect the integrity of SDOs.
+
+The evaluator shall ensure that the TSS identifies the Roots of Trust it provides (including but not limited to the Roots of Trust identified in the selections in this requirement) and describes their function in the context of the TOE. The TSS shall describe the cryptographic algorithms in use for the Roots of Trust.
 
 ====== AGD
 
@@ -1519,58 +1514,6 @@ For mutable Root of Trust data, the evaluator shall perform the following tests:
 ====== KMD
 
 The evaluator shall ensure that the KMD describes either a pre-installed identity (contained within an SDO), or a process on how the TOE creates an identity. IEEE 802.1ar is one example of a standard which a device can use to create such an identity. 
-
-==== Root of Trust Services (Extended - FPT_ROT_EXT)
-
-===== FPT_ROT_EXT.1 Root of Trust Services
-
-====== TSS
-
-The evaluator shall ensure that the TSS identifies the Roots of Trust it provides (including but not limited to the Roots of Trust identified in the selections in this requirement) and describes their function in the context of the TOE. The TSS shall describe the cryptographic algorithms in use for the Roots of Trust.
-
-====== AGD
-
-There are no AGD evaluation activities for this component.
-
-====== Test
-
-*_Root of Trust for Storage_*
-
-Testing for this component is performed through evaluation of FCS_CKM.1, FCS_STG_EXT.1 and FPT_PHP.3.
-
-*_Root of Trust for Authorization_*
-
-Testing for this component is performed through evaluation of FIA_AFL_EXT.1.
-
-*_Root of Trust for Measurement_*
-
-Testing for this component is performed through evaluation of FCS_COP.1/Hash.
-
-*_Root of Trust for Reporting_*
-
-Testing for this component is performed through evaluation of FCS_COP.1/SigGen.
-
-====== KMD
-
-There are no KMD evaluation activities for this component.
-
-===== FPT_ROT_EXT.2 Root of Trust for Storage
-
-====== TSS
-
-The evaluator shall ensure that the TSS describes how the Root of Trust for Storage prevents unauthorized access (including unauthorized disclosure and unauthorized modification) to SDOs. The evaluator shall also examine the TSS to verify that it uses approved mechanisms to protect the confidentiality of secret SDOs and to protect the integrity of SDOs.
-
-====== AGD
-
-There are no AGD evaluation activities for this component.
-
-====== Test
-
-Testing for this component is performed through evaluation of FCS_CKM.1, FCS_STG_EXT.1, FDP_SDC.2, FDP_SDI.2 and FPT_PHP.3.
-
-====== KMD
-
-There are no KMD evaluation activities for this component.
 
 ==== Replay Prevention (FPT_RPL)
 
@@ -1764,9 +1707,9 @@ Note that test 4 shall only be performed for those interfaces where physical int
 
 There are no KMD evaluation activities for this component.
 
-==== Root of Trust (Extended - FPT_PRO_EXT)
+==== Root of Trust (Extended - FPT_ROT_EXT)
 
-===== FPT_PRO_EXT.2 Data Integrity Measurements
+===== FPT_ROT_EXT.2 Root of Trust for Measurement
 
 ====== TSS
 
@@ -1804,9 +1747,7 @@ Refer to [DSC cPP] for more information about what could constitute DSC data or 
 
 There are no KMD evaluation activities for this component.
 
-==== Root of Trust Services (Extended - FPT_ROT_EXT)
-
-===== FPT_ROT_EXT.3 Root of Trust for Reporting Mechanisms
+===== FPT_ROT_EXT.3 Root of Trust for Reporting
 
 ====== TSS
 
@@ -1818,7 +1759,7 @@ In addition, the evaluator shall examine the TSS and ensure that it describes ho
 
 ====== AGD
 
-The evaluator shall examine the guidance documentation to confirm it describes how to enable the root of trust for reporting mechanism on the TOE, how to generate a report, and how reports are verified as genuine.
+The evaluator shall examine the guidance documentation to confirm it describes how to enable the Root of Trust for Reporting mechanism on the TOE, how to generate a report, and how reports are verified as genuine.
 
 ====== Test
 
@@ -1826,13 +1767,37 @@ Note that the following test may require the developer to provide access to a te
 
 The evaluator shall perform the following tests:
 
-Test 1: The evaluator shall enable the root of trust for reporting mechanism on the TOE and generate a report.
+Test 1: The evaluator shall enable the Root of Trust for Reporting mechanism on the TOE and generate a report.
 
 Test 2: The evaluator shall confirm the generated report is valid.
 
 Test 3: The evaluator shall modify the signature of a valid report and confirm the report is invalid. 
 
 Test 4: The evaluator shall modify the contents of a valid report and confirm the report is invalid.
+
+====== KMD
+
+There are no KMD evaluation activities for this component.
+
+===== FPT_ROT_EXT.4 Root of Trust for Verification
+
+====== TSS
+
+The evaluator shall examine the TSS and ensure that it describes the cryptographically verifiable identities for the Root of Trust for Verification, how they relate to the Root of Trust identified in FPT_ROT_EXT.1.1, and how they are used.
+
+====== AGD
+
+[conditional] If the DSC provides a service to perform the verification, the evaluator shall examine the guidance documentation to confirm it describes how to access this service.
+
+====== Test
+
+Note that the following test may require the developer to provide access to a test platform that provides the evaluator with tools that are not typically available to end users.
+
+The evaluator shall perform the following tests:
+
+Test 1: The evaluator shall confirm that an object with a valid signature is successfully verified by the Root of Trust for Verification.
+
+Test 2: The evaluator shall modify the signature on any object verified by the Root of Trust for Verification and confirm the verification fails.
 
 ====== KMD
 
@@ -2702,8 +2667,8 @@ However, if the evaluator is unable to perform some other required EA because th
 |Factory Reset
 |FDP_FRS_EXT.1, [FDP_FRS_EXT.2]
 
-|Generation of Data Integrity Measurements
-|[FPT_PRO_EXT.2]
+|Root of Trust for Reporting
+|[FPT_ROT_EXT.3]
 
 |Generation of Secrets
 |FIA_SOS.2

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1739,7 +1739,7 @@ FPT_MFW_EXT.1 Mutable/Immutable Firmware
 FPT_MFW_EX.1.1:: The TSF shall be maintained as [selection:
 +
 * _immutable firmware_
-* _mutable firmware conforming to FPT_FLS.1/FW, FPT_MFW_EXT.2, and FPT_RPL.1/Rollback_
+* _mutable firmware conforming to FPT_FLS.1/FW, FPT_MFW_EXT.2, and FPT_RPL.1/FW_
 ].
 
 ==== FPT_MOD_EXT.1 Debug Modes
@@ -2034,8 +2034,8 @@ The following rationale provides justification for each security problem definit
 |FPT_MFW_EXT.2 (selection-based)
 |This requirement ensures that the TSF can verify that its mutable firmware integrity remains intact and any firmware updates to the TSF are genuine.
 
-|FPT_RPL.1/Rollback (selection-based)
-|This requirement ensures that the TSF will not permit rollback attempts of its firmware.
+|FPT_RPL.1/FW (selection-based)
+|This requirement ensures that the TSF will not permit loading earlier versions of its firmware.
 
 .11+|T.WEAK_CRYPTO
 |FCS_CKM.1
@@ -2940,17 +2940,17 @@ FPT_MFW_EXT.2.1:: The TSF shall verify the integrity and authenticity of its fir
 
 FPT_MFW_EXT.2.1:: The TSF shall verify the integrity and authenticity of its firmware updates using [selection: _a cryptographic hash as specified in FCS_COP.1/Hash, a keyed hash as specified in FCS_COP.1/KeyedHash, a message authentication code as specified in FCS_COP.1/CMAC, a digital signature as specified in FCS_COP.1/SigVer, authenticated encryption as specified in FCS_COP.1/AEAD_].
 
-_Application Note {counter:remark_count}_:: _Data and firmware integrity is not applicable for immutable firmware._
+_Application Note {counter:remark_count}_:: _Firmware integrity and authenticity is not applicable for immutable firmware._
 
-==== FPT_RPL.1/Rollback Replay Detection (Rollback)
+==== FPT_RPL.1/FW Replay Detection (Firmware)
 
-FPT_RPL.1/Rollback Replay Detection (Rollback)
+FPT_RPL.1/FW Replay Detection (Firmware)
 
-FPT_RPL.1.1/Rollback:: The TSF shall detect replay for the following entities: [_previous firmware builds_].
+FPT_RPL.1.1/FW:: The TSF shall detect replay for the following entities: [_earlier firmware builds_].
 
-FPT_RPL.1.2/Rollback:: The TSF shall *prevent the execution of the loaded firmware and* perform [*selection, choose one of*: _[assignment: other actions], no other actions_] when replay is detected.
+FPT_RPL.1.2/FW:: The TSF shall *prevent the execution of the earlier firmware and* perform [*selection, choose one of*: _[assignment: other actions], no other actions_] when replay is detected.
 
-_Application Note {counter:remark_count}_:: _The TSF data is used as a guarantee of the ordinal identifier of the firmware instance. When a firmware load is requested, the TSF ensures the authenticated firmware ordinal identifier is greater than or equal to the previously authenticated firmware identifier. For example, this could be accomplished by ensuring the validated instance of the firmware to be loaded is greater than or equal to the instance previously validated and loaded into the TOE. By loading a previous instance of firmware, it potentially opens up the device to known vulnerabilities._
+_Application Note {counter:remark_count}_:: _The TSF data is used as a guarantee of the ordinal identifier of the firmware instance. When a firmware load is requested, the TSF ensures the authenticated firmware ordinal identifier is greater than or equal to the previously authenticated firmware identifier. For example, this could be accomplished by ensuring the validated instance of the firmware to be loaded is greater than or equal to the instance previously validated and loaded into the TOE. By loading an earlier instance of firmware, it potentially opens up the device to known vulnerabilities._
 
 ==== FPT_STM_EXT.1 Reliable Time Counting
 
@@ -4481,7 +4481,7 @@ FCS_COP.1
 
 FCS_COP.1 - included
 
-|FPT_RPL.1/Rollback 
+|FPT_RPL.1/FW
 |No dependencies
 |N/A
 
@@ -4834,7 +4834,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FPT_FLS.1/FW !Failure with Preservation of Secure State (Firmware)
 
-!FPT_RPL.1/Rollback !Replay Detection (Rollback)
+!FPT_RPL.1/FW !Replay Detection (Firmware)
 
 !===
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1736,10 +1736,10 @@ _Application Note {counter:remark_count}_:: _Note that a secure state does not i
 
 FPT_MFW_EXT.1 Mutable/Immutable Firmware
 
-FPT_MFW_EXT.1.1:: The TSF shall be maintained as [selection:
+FPT_MFW_EX.1.1:: The TSF shall be maintained as [selection:
 +
 * _immutable firmware_
-* _mutable firmware conforming to FPT_FLS.1/FW, FPT_MFW_EXT.2, FPT_MFW_EXT.3, and FPT_RPL.1/Rollback_
+* _mutable firmware conforming to FPT_FLS.1/FW, FPT_MFW_EXT.2, and FPT_RPL.1/Rollback_
 ].
 
 ==== FPT_MOD_EXT.1 Debug Modes
@@ -2024,7 +2024,7 @@ The following rationale provides justification for each security problem definit
 |FDP_DAU.1/Prove (selection-based)
 |This requirement defines the Prove service that can be used to invoke the Roots of Trust for Measurement and Reporting and provide affirmation of the validity of TSF and stored data.
 
-.5+|T.UNAUTH_UPDATE
+.4+|T.UNAUTH_UPDATE
 |FPT_MFW_EXT.1 
 |This requirement specifies whether the TOE's firmware is mutable or immutable.
 
@@ -2032,10 +2032,7 @@ The following rationale provides justification for each security problem definit
 |This requirement requires the TSF to take action to preserve its secure operation if a rollback attempt or invalid firmware update is detected.
 
 |FPT_MFW_EXT.2 (selection-based)
-|This requirement ensures that the TSF can generate evidence that its mutable firmware integrity remains intact.
-
-|FPT_MFW_EXT.3 (selection-based)
-|This requirement ensures that any firmware updates to the TSF are genuine.
+|This requirement ensures that the TSF can verify that its mutable firmware integrity remains intact and any firmware updates to the TSF are genuine.
 
 |FPT_RPL.1/Rollback (selection-based)
 |This requirement ensures that the TSF will not permit rollback attempts of its firmware.
@@ -2935,41 +2932,15 @@ _Application Note {counter:remark_count}_:: _A DSC's ability to handle failures 
 +
 _The phrase "secure state" refers to a state in which the TOE has consistent TSF data and a TSF that can correctly enforce the policy. The TOE ensures that no further processing of TSF or user data takes place while in an insecure state. This state may be the initial "boot" of a clean system, or it might be some check-pointed state. It is expected that in most cases, the TOE will halt and require a reset or re-initialization to return to a known secure state._
 
-==== FPT_MFW_EXT.2 Basic Firmware Integrity
+==== FPT_MFW_EXT.2 Firmware Integrity
 
-FPT_MFW_EXT.2 Basic Firmware Integrity
+FPT_MFW_EXT.2 Firmware Integrity
 
-FPT_MFW_EXT.2.1:: The TSF shall have the ability to verify the integrity of the firmware.
+FPT_MFW_EXT.2.1:: The TSF shall verify the integrity and authenticity of its firmware before execution using [selection: _a cryptographic hash as specified in FCS_COP.1/Hash, a keyed hash as specified in FCS_COP.1/KeyedHash, a message authentication code as specified in FCS_COP.1/CMAC, a digital signature as specified in FCS_COP.1/SigVer, authenticated encryption as specified in FCS_COP.1/AEAD_].
 
-FPT_MFW_EXT.2.2:: The TSF shall provide a capability to generate evidence of the integrity of the firmware.
+FPT_MFW_EXT.2.1:: The TSF shall verify the integrity and authenticity of its firmware updates using [selection: _a cryptographic hash as specified in FCS_COP.1/Hash, a keyed hash as specified in FCS_COP.1/KeyedHash, a message authentication code as specified in FCS_COP.1/CMAC, a digital signature as specified in FCS_COP.1/SigVer, authenticated encryption as specified in FCS_COP.1/AEAD_].
 
 _Application Note {counter:remark_count}_:: _Data and firmware integrity is not applicable for immutable firmware._
-+
-_The TOE guarantees the integrity of the firmware by verifying its integrity._
-+
-_Verifying the integrity of the firmware could be accomplished by guaranteeing the validity of firmware within the TOE prior to execution._
-+
-_This requirement covers the case of ensuring the firmware is trustworthy in immutable form or mutable through any firmware updates, since the integrity and authenticity are checked prior to execution._
-+
-_FCS_COP.1/SigVer applies if the TOE provides the capability to update the TOE firmware and uses digital signatures for update verification. FCS_COP.1/CMAC or FCS_COP.1/KeyedHash applies if the TOE provides the capability to update the TOE firmware and uses MAC verification for update verification. The ST author should choose the algorithm implemented to perform digital signatures or MAC verification. For the algorithms chosen, the ST author should make the appropriate assignments/selections to specify the parameters that are implemented for that algorithm._
-
-==== FPT_MFW_EXT.3 Firmware Authentication with Identity of Guarantor
-
-FPT_MFW_EXT.3 Firmware Authentication with Identity of Guarantor
-
-FPT_MFW_EXT.3.1:: The TSF shall have the ability to verify the authenticity of the firmware.
-
-FPT_MFW_EXT.3.2:: The TSF shall provide a capability to generate evidence of the authenticity of the firmware.
-
-_Application Note {counter:remark_count}_:: _Firmware authentication is not applicable for immutable firmware._
-+
-_The TOE guarantees the authenticity of the firmware by verifying its signature._
-+
-_Verifying the authenticity of the firmware could be accomplished by guaranteeing the validity of firmware within the TOE prior to execution._
-+
-_This requirement covers the case of ensuring the firmware is trustworthy in immutable form or mutable through any firmware updates, since the integrity and authenticity are checked prior to execution._
-+
-_FCS_COP.1/SigVer applies if the TOE provides the capability to update the TOE firmware and uses digital signatures for update verification. The ST author should choose the algorithm implemented to perform digital signatures. For the algorithms chosen, the ST author should make the appropriate assignments/selections to specify the parameters that are implemented for that algorithm._
 
 ==== FPT_RPL.1/Rollback Replay Detection (Rollback)
 
@@ -3529,23 +3500,17 @@ This family defines requirements for specified types of firmware and the managem
 [ditaa,"FPT_MFW_EXT"]
 ....
                                                        +---+
-                                                    +->| 1 |
-                                                    |  +---+
-    +--------------------------------------------+  |
+    +--------------------------------------------+  +->| 1 |
     |                                            |  |  +---+
-    | FPT_MFW_EXT Mutable/Immutable Firmware     +--+->| 2 |
+    | FPT_MFW_EXT Mutable/Immutable Firmware     +--+
     |                                            |  |  +---+
-    +--------------------------------------------+  |
-                                                    |  +---+
-                                                    +->| 3 |
+    +--------------------------------------------+  +->| 2 |
                                                        +---+
 ....
 
 FPT_MFW_EXT.1 Mutable/Immutable Firmware, requires the TSF to identify whether its firmware resides in mutable or immutable storage.
 
-FPT_MFW_EXT.2 Basic Firmware Integrity, requires the TSF to assert the integrity of the firmware.
-
-FPT_MFW_EXT.3 Firmware Authentication with Identity of Guarantor, requires the TSF to assert the authenticity of the firmware.
+FPT_MFW_EXT.2 Firmware Integrity, requires the TSF to assert the integrity and authenticity of the firmware.
 
 *Management: FPT_MFW_EXT.1*
 
@@ -3553,11 +3518,11 @@ The following actions could be considered for the management functions in FMT:
 
 * Update TOE firmware and pre-installed SDOs.
 
-*Management: FPT_MFW_EXT.2, FPT_MFW_EXT.3*
+*Management: FPT_MFW_EXT.2*
 
 No specific management functions are identified.
 
-*Audit: FPT_MFW_EXT.1, FPT_MFW_EXT.2, FPT_MFW_EXT.3*
+*Audit: FPT_MFW_EXT.1, FPT_MFW_EXT.2*
 
 There are no auditable events foreseen.
 
@@ -3569,27 +3534,16 @@ Dependencies:: No dependencies.
 [vertical]
 FPT_MFW_EXT.1.1:: The TSF shall be maintained as [selection: _immutable, mutable_] firmware.
 
-*FPT_MFW_EXT.2 Basic Firmware Integrity*
+*FPT_MFW_EXT.2 Firmware Integrity*
 [horizontal]
 Hierarchical to:: No other components.
 
 Dependencies:: FPT_MFW_EXT.1 Mutable/Immutable Firmware +
 FCS_COP.1 Cryptographic Operation
 [vertical]
-FPT_MFW_EXT.2.1:: The TSF shall have the ability to verify the integrity of the firmware.
+FPT_MFW_EXT.2.1:: The TSF shall verify the integrity and authenticity of its firmware before execution using [selection: _a cryptographic hash as specified in FCS_COP.1/Hash, a keyed hash as specified in FCS_COP.1/KeyedHash, a message authentication code as specified in FCS_COP.1/CMAC, a digital signature as specified in FCS_COP.1/SigVer, authenticated encryption as specified in FCS_COP.1/AEAD_].
 
-FPT_MFW_EXT.2.2:: The TSF shall provide a capability to generate evidence of the integrity of the firmware.
-
-*FPT_MFW_EXT.3 Firmware Authentication with Identity of Guarantor*
-[horizontal]
-Hierarchical to:: No other components.
-
-Dependencies:: FPT_MFW_EXT.1 Mutable/Immutable Firmware +
-FCS_COP.1 Cryptographic Operation
-[vertical]
-FPT_MFW_EXT.3.1:: The TSF shall have the ability to verify the authenticity of the firmware.
-
-FPT_MFW_EXT.3.2:: The TSF shall provide a capability to generate evidence of the authenticity of the firmware.
+FPT_MFW_EXT.2.2:: The TSF shall verify the integrity and authenticity of its firmware updates using [selection: _a cryptographic hash as specified in FCS_COP.1/Hash, a keyed hash as specified in FCS_COP.1/KeyedHash, a message authentication code as specified in FCS_COP.1/CMAC, a digital signature as specified in FCS_COP.1/SigVer, authenticated encryption as specified in FCS_COP.1/AEAD_].
 
 ==== FPT_MOD_EXT Debug Modes
 
@@ -4527,14 +4481,6 @@ FCS_COP.1
 
 FCS_COP.1 - included
 
-|FPT_MFW_EXT.3 
-|FPT_MFW_EXT.1 
-
-FCS_COP.1 
-|FPT_MFW_EXT.1 - included
-
-FCS_COP.1 - included
-
 |FPT_RPL.1/Rollback 
 |No dependencies
 |N/A
@@ -4790,9 +4736,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FPT_MFW_EXT.1 !Mutable/Immutable Firmware
 
-!FPT_MFW_EXT.2 !Basic Firmware Integrity
-
-!FPT_MFW_EXT.3 !Firmware Authentication with Identity of Guarantor
+!FPT_MFW_EXT.2 !Firmware Integrity
 
 !===
 
@@ -4884,9 +4828,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FPT_PRO_EXT.2 !Data Integrity Measurements
 
-!FPT_MFW_EXT.2 !Basic Firmware Integrity
-
-!FPT_MFW_EXT.3 !Firmware Authentication with Identity of Guarantor
+!FPT_MFW_EXT.2 !Firmware Integrity
 
 !FDP_FRS_EXT.2 !Factory Reset Behavior
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1357,16 +1357,6 @@ FDP_ETC_EXT.2.1:: The TSF shall propagate only wrapped authorization data and wr
 
 _Application Note {counter:remark_count}_:: _This SFR imposes security requirements on data being propagated (exported) outside the TOE. The "users" in the "authorized users" selection includes all roles (i.e. ADM-R, MFGADM-R, CApp-R)._
 
-==== FDP_FRS_EXT.1 Factory Reset
-
-FDP_FRS_EXT.1 Factory Reset
-
-FDP_FRS_EXT.1.1:: The TSF shall permit a factory reset of the TOE upon: [*selection*: _activation by external interface, presentation of [assignment: types of authorization data required and reference to their specification], no actions or conditions_].
-
-_Application Note {counter:remark_count}_:: _If the DSC provides factory reset and requires an authorization to carry out the operation, then the ST author selects [.underline]#presentation of ...# and fills in the authorization data accepted (e.g. a PIN or a cryptographic token based on some specification referenced in the assigned value). If the DSC provides factory reset external to the DSC without requiring authorization, then the ST author selects [.underline]#activation by external interface#. This selection is intended for use when the device containing the DSC takes responsibility for obtaining and checking the authorization for factory reset._
-+
-_If any selection other than [.underline]#no actions or conditions# is made in FDP_FRS_EXT.1.1, the selection-based SFR FDP_FRS_EXT.2 must be claimed._
-
 ==== FDP_ITC_EXT.1 Parsing of SDEs
 
 FDP_ITC_EXT.1 Parsing of SDEs
@@ -1462,7 +1452,7 @@ FIA_AFL_EXT.1.3:: When the failed authorization attempt counters [selection, cho
 * _prevent future authorization attempts for a static prescribed amount of time as determined using FPT_STM_EXT.1;_
 * _prevent future authorization attempts for an administrator configurable amount of time as determined using FPT_STM_EXT.1;_
 * _prevent all future authorization attempts indefinitely (i.e., lock), as described by FIA_AFL_EXT.2;_
-* _factory reset the TOE wiping out all non-permanent SDEs and SDOs, as described by FDP_FRS_EXT.2_
+* _factory reset the TOE wiping out all non-permanent SDEs and SDOs, as described by FDP_FRS_EXT.1_
 +
 ] for these *SDOs*.
 
@@ -1695,11 +1685,11 @@ FMT_SMF.1 Specification of Management Functions
 
 FMT_SMF.1.1:: The TSF shall be capable of performing the following management functions: [
 +
-* _Reset TOE to factory state for FDP_FRS_EXT.1_
 * _Configure authorization policies for TOE resources_
 +
 _[selection:_
 +
+** _Reset TOE to factory state for FDP_FRS_EXT.1_
 ** _set authorization failure parameters for FIA_AFL_EXT.1,_
 ** _update TOE firmware,_
 ** _update pre-installed SDOs,_
@@ -1936,7 +1926,7 @@ The following rationale provides justification for each security problem definit
 |FRU_FLT.1
 |This requirement ensures that fault injection attempts do not interfere with the enforcement of access control against protected data.
 
-|FDP_FRS_EXT.2 (selection-based)
+|FDP_FRS_EXT.1 (selection-based)
 |This requirement ensures that all user-specific SDOs are purged upon factory reset and may indicate any factory default SDOs that are reset to their initial values.
 
 .12+|T.SDE_TRANSIT_COMPROMISE
@@ -1952,7 +1942,7 @@ The following rationale provides justification for each security problem definit
 |FDP_ETC_EXT.2
 |This requirement ensures that the confidentiality of protected data propagated outside the TOE is maintained.
 
-|FDP_FRS_EXT.1
+|FDP_FRS_EXT.1 (selection-based)
 |This requirement defines the condition in which a factory reset will be initiated, which triggers a purge of stored SDEs.
 
 |FDP_ITC_EXT.1
@@ -2878,13 +2868,18 @@ _Data that would need to be validity-stamped includes data over which the DSC is
 +
 _For data that is validity-stamped, the DSC does nothing but respond to a request to issue the data; thus, authentication of the user issuing the data is not needed and is covered by FDP_DAU.1/Prove. Otherwise, in the case the DSC has no understanding of this data, a step is needed via FIA_UAU.5 by which the DSC authenticates the user for this service, and that the DSC or Prove service will therefore vouch for the user, not the validity of the data itself._
 
-==== FDP_FRS_EXT.2 Factory Reset Behavior
+==== FDP_FRS_EXT.1 Factory Reset
 
-FDP_FRS_EXT.2 Factory Reset Behavior
+FDP_FRS_EXT.1 Factory Reset
 
-FDP_FRS_EXT.2.1:: Upon initiation of a factory reset, the TSF shall destroy [_all non-permanent SDEs and SDOs_] and restore the following *pre-installed SDOs* to their factory settings: [_assignment: *pre-installed SDOs to be* restored by a factory reset_].
+FDP_FRS_EXT.1.1:: The TSF shall permit a factory reset of the TOE upon: [selection: _activation by external interface, presentation of [assignment: types of authorization data required and reference to their specification]_].
 
-_Application Note {counter:remark_count}_:: _Not all DSCs permit factory reset functionality. Those that do are expected to perform a factory reset in a manner that prevents any inadvertent disclosure of security-relevant data that was present on the DSC prior to the factory reset. For DSCs that permit factory reset functionality (as indicated by selection of [.underline]#factory reset the TOE wiping out all non-permanent SDEs and SDOs, as described by FDP_FRS_EXT.2# in FIA_AFL_EXT.1.3, or by [.underline]#no actions or conditions# NOT being selected in FDP_FRS_EXT.1.1), this SFR must be claimed._
+FDP_FRS_EXT.1.2:: Upon initiation of a factory reset, the TSF shall destroy all non-permanent SDEs and SDOs and restore the following TSF data to their factory settings: [assignment: _pre-installed SDOs that are to be restored by factory reset_].
+
+_Application Note {counter:remark_count}_::
+_Not all DSCs permit factory reset functionality. Those that do are expected to perform a factory reset in a manner that prevents any inadvertent disclosure of security-relevant data that was present on the DSC prior to the factory reset. For DSCs that permit factory reset functionality (as indicated by selection of [.underline]#factory reset the TOE wiping out all non-permanent SDEs and SDOs, as described by FDP_FRS_EXT.1# in FIA_AFL_EXT.1.3 or [.underline]#Reset TOE to factory state for FDP_FRS_EXT.1# in FMT_SMF.1), this SFR is claimed._
++
+_If the DSC requires an authorization to carry out the operation, then the ST author selects [.underline]#presentation of ...# and fills in the authorization data accepted (e.g. a PIN or a cryptographic token based on some specification referenced in the assigned value). If the DSC provides factory reset external to the DSC without requiring authorization, then the ST author selects [.underline]#activation by external interface#. This selection is intended for use when the device containing the DSC takes responsibility for obtaining and checking the authorization for factory reset._
 
 === Identification and Authentication
 ==== FIA_AFL_EXT.2 Authorization Failure Response
@@ -3269,22 +3264,16 @@ This family defines requirements for the conditions that may trigger TOE factory
 [#img-FDP_FRS_EXT] 
 [ditaa,"FDP_FRS_EXT"]
 ....
-                                                     
-                                                    
-                                                       +---+
-    +--------------------------------------------+  |->| 1 |
-    |                                            |  |  +---+
-    | FDP_FRS_EXT Factory Reset                  +--+
-    |                                            |  |  +---+
-    +--------------------------------------------+  |->| 2 |
-                                                       +---+
-                                                    
-                                                    
+
+    +--------------------------------------------+
+    |                                            |     +---+
+    | FDP_FRS_EXT Export Factory Reset           +---->| 1 |
+    |                                            |     +---+
+    +--------------------------------------------+
+
 ....
 
-FDP_FRS_EXT.1 Factory Reset, requires the TSF to allow factory resets under specified conditions.
-
-FDP_FRS_EXT.2 Factory Reset Behavior, requires the TSF to destroy certain TSF data and restore other TSF data after a factory reset is initiated.
+FDP_FRS_EXT.1 Factory Reset, requires the TSF to allow destroy certain TSF data and restore other TSF data under specified conditions.
 
 *Management: FDP_FRS_EXT.1*
 
@@ -3292,11 +3281,7 @@ The following actions could be considered for the management functions in FMT:
 
 * Reset TOE to factory state.
 
-*Management: FDP_FRS_EXT.2*
-
-No specific management functions are identified.
-
-*Audit: FDP_FRS_EXT.1, FDP_FRS_EXT.2*
+*Audit: FDP_FRS_EXT.1*
 
 There are no auditable events foreseen.
 
@@ -3304,17 +3289,11 @@ There are no auditable events foreseen.
 [horizontal]
 Hierarchical to:: No other components.
 
-Dependencies:: FDP_FRS_EXT.2 Factory Reset Behavior
+Dependencies:: No dependencies.
 [vertical]
-FDP_FRS_EXT.1.1:: The TSF shall permit a factory reset of the TOE upon: [assignment: _conditions under which a factory reset is authorized_].
+FDP_FRS_EXT.1.1:: The TSF shall permit a factory reset of the TOE upon: [selection: _activation by external interface, presentation of [assignment: types of authorization data required and reference to their specification]_].
 
-*FDP_FRS_EXT.2 Factory Reset Behavior*
-[horizontal]
-Hierarchical to:: No other components.
-
-Dependencies:: FDP_FRS_EXT.1 Factory Reset
-[vertical]
-FDP_FRS_EXT.2.1:: Upon initiation of a factory reset, the TSF shall destroy [assignment: _TSF data that is destroyed by factory reset_] and restore the following TSF data to their factory settings: [assignment: _TSF data that is restored by factory reset_].
+FDP_FRS_EXT.1.2:: Upon initiation of a factory reset, the TSF shall destroy all non-permanent SDEs and SDOs and restore the following TSF data to their factory settings: [assignment: _pre-installed SDOs that are to be restored by factory reset_].
 
 ==== FDP_ITC_EXT Import from Outside of the TOE
 
@@ -4060,10 +4039,6 @@ FMT_MSA.3 - included
 |FCS_COP.1 
 |FCS_COP.1 - included
 
-|FDP_FRS_EXT.1 
-|FDP_FRS_EXT.2 
-|FDP_FRS_EXT.2 - (selection-based SFR) included
-
 |FDP_ITC_EXT.1 
 |FCS_COP.1 
 
@@ -4438,9 +4413,9 @@ FCS_CKM.6 - included
 |No dependencies
 |N/A
 
-|FDP_FRS_EXT.2 
-|FDP_FRS_EXT.1 
-|FDP_FRS_EXT.1 - included
+|FDP_FRS_EXT.1
+|No dependencies
+|N/A
 
 |FIA_AFL_EXT.2
 |FIA_AFL_EXT.1
@@ -4627,7 +4602,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FPT_ROT_EXT.1 !Root of Trust
 
-!FDP_FRS_EXT.2 !Factory Reset Behavior
+!FDP_FRS_EXT.1 !Factory Reset
 
 !FIA_AFL_EXT.2 !Authorization Failure Response
 
@@ -4797,7 +4772,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_RBG.5 !Random Bit Generation (Combining Entropy Sources)
 
-!FDP_FRS_EXT.2 !Factory Reset Behavior
+!FDP_FRS_EXT.1 !Factory Reset
 
 !===
 
@@ -4822,8 +4797,6 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 !FRU_FLT.1 !Degraded Fault Tolerance
 
 !FPT_MFW_EXT.2 !Firmware Integrity
-
-!FDP_FRS_EXT.2 !Factory Reset Behavior
 
 !FPT_FLS.1/FW !Failure with Preservation of Secure State (Firmware)
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1818,7 +1818,7 @@ _Application Note {counter:remark_count}_:: _The TSF receives authorization from
 
 FPT_TST.1 TSF Testing
 
-FPT_TST.1.1:: The TSF shall run a suite of the following self-tests *during power-on start-up* {empty}[selection: [.underline]#periodically during normal operation, at the request of the authorized user, *at no other condition,* at the conditions [_assignment: conditions under which self-test should occur_]]# to demonstrate the correct operation of {empty}[[.underline]#the TSF#]: [assignment: _list of self-tests run by the TSF_].
+FPT_TST.1.1:: The TSF shall run a suite of the following self-tests *during initial start-up* and {empty}[selection: [.underline]#*at no other condition,* periodically during normal operation, at the request of the authorized user, at the conditions [_assignment: conditions under which self-test should occur_]]# to demonstrate the correct operation of {empty}[[.underline]#the TSF#]: [assignment: _list of self-tests run by the TSF_].
 
 FPT_TST.1.2:: The TSF shall provide authorized users with the capability to verify the integrity of {empty}[[.underline]#TSF data#].
 
@@ -1828,7 +1828,7 @@ _Application Note {counter:remark_count}_:: _This requirement intends to cover i
 +
 _TSF integrity testing provides the ability to test the TSF's correct operation. These tests are expected to be performed automatically and autonomously at start-up but may also be performed periodically during operation, at the request of the authorized user, or when other conditions are met. It also provides the ability to verify the integrity of TSF data and executable code._
 +
-_All cryptographic functions come with known answer tests (KATs). In addition to verifying the integrity of the firmware executing the TSF, the DSC should also verify the integrity of any data associated with the TSF (such as constants for cryptographic algorithms) as well as performing the KATs._
+_All cryptographic algorithms come with known answer tests (KATs). In addition to verifying the integrity of the firmware executing the TSF, the DSC should also verify the integrity of any data associated with the TSF (such as constants for cryptographic algorithms) as well as performing the KATs._
 
 === Resource Utilization
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -173,10 +173,10 @@ image::SDOcomposition.png[]
 
 An SDO is created by combining SDEs with some attributes. Each SDE used to create the SDO reaches the DSC in one of the following ways:
 
-* By parsing SDEs received via secure channels (see O.PARSE_PROTECTION). 
+* By parsing SDEs received via secure channels.
 * By generating the SDEs locally on the DSC as part of the Provisioning service. 
 
-An SDO may include one or more SDEs from one or both of these sources. In the Provisioning step, the relevant SDEs are then bound together with a set of attributes resulting in an SDO. Explicit binding occurs when the DSC includes one or more SDEs along with their attributes in a formatted structure to form the SDO. An X.509 certificate is just one example of an SDO (where the signature in the certificate provides the binding of the attributes contained). A DSC protects the integrity of an SDO (see O.DATA_PROTECTION).
+An SDO may include one or more SDEs from one or both of these sources. In the Provisioning step, the relevant SDEs are then bound together with a set of attributes resulting in an SDO. Explicit binding occurs when the DSC includes one or more SDEs along with their attributes in a formatted structure to form the SDO. An X.509 certificate is just one example of an SDO (where the signature in the certificate provides the binding of the attributes contained). A DSC protects the integrity of an SDO and confidentiality of SDEs in an SDO, if so configured.
 
 Explicit binding may also occur when the DSC wraps an SDO prior to storing it externally. <<SDOcomposition>> shows an example SDO with binding data used to secure an arbitrary number of SDEs.
 
@@ -226,7 +226,7 @@ DSCs provide seven core security services to a platform as illustrated in <<Core
 |The DSC shall create SDOs from parsed or generated SDEs and attributes using binding mechanisms to apply integrity protection to the SDEs together with their attributes.
 
 |Protect
-|The DSC shall manage protected storage for all SDOs. DSCs may implement local storage internal to the DSC boundary or utlilize external storage outside the DSC boundary. A DSC shall maintain the integrity and confidentiality (if required) of SDOs stored both inside and outside the boundary.
+|The DSC shall manage protected storage for all SDOs. DSCs may implement local storage internal to the DSC boundary or utlilize external storage outside the DSC boundary. A DSC shall maintain the integrity and confidentiality (if required) of SDOs and SDEs stored both inside and outside the boundary.
 
 |Process
 |The DSC shall modify and use SDOs or their attributes on behalf of authorized entities. The Process service shall coordinate with the Protect service for storage of the SDOs while not in use and shall collaborate with the Prove service to authenticate the requesting entity and validate their authorization for access to the SDO in the requested mode. The Process service shall submit an SDO to the Purge service when it is no longer needed by the platform.
@@ -282,10 +282,10 @@ Security Attributes: The following list contains the minimum security attributes
 * EPS.ID - The External Platform Storage (EPS) identifier. This attribute is optional for a passive EPS (i.e. plain memory that only stores information). If the DSC uses an active EPS to manage storage, then support for this attribute is required.
 * SDO.* - The SDO Security Attributes:
 ** SDO.ID - SDO Identifier
-** SDO.Type - SDO Type
-** SDO.AuthData - SDO Reference authorization data
+** SDO.Type - SDO type
+** SDO.AuthData - SDO reference authorization data
 ** SDO.Reauth - SDO re-authorization conditions
-** SDO.Conf - SDO confidential SDE list
+** SDO.Conf - SDO confidential SDE list, indicating which SDEs in this SDO should be confidential
 ** SDO.Export - SDO export flag
 ** SDO.Integrity - SDO integrity protection data
 ** SDO.Bind - SDO binding data
@@ -433,9 +433,9 @@ Roles may play an important part in key hierarchies. One of the simplest models 
 
 ==== Protected Storage Locations
 
-This cPP covers several different types of storage locations for keys and critical security parameters (CSPs) such as authentication tokens. Some DSCs may have a generous amount of protected storage internal to themselves, which allows it to accommodate all keys and CSPs in operational use, whether the DSC is performing operations to administer itself or operations on behalf of users. Other DSCs may have a minimal amount of protected storage locations with just enough to accommodate root keys along with a limited number of operational keys and CSPs for user authorized sessions.
+This cPP covers several different types of storage locations for SDOs, SDEs, and other sensitive TSF and user data. Some DSCs may have a generous amount of protected storage internal to themselves, which allows it to accommodate all these items in operational use, whether the DSC is performing operations to administer itself or operations on behalf of users. Other DSCs may have a minimal amount of protected storage locations with just enough to accommodate root keys along with a limited number of operational keys and data for user authorized sessions.
 
-For those cases in which the DSC relies on storage external to itself to accommodate all the keys and CSPs on which applications expect it to operate, it will either have to support secure channels to another DSC with a more generous allocation of protected storage locations, or use a series of wrapping keys to protect private keys and CSPs while outside of the DSC. Whether the DSC is powered on or powered off, the DSC is expected to provide support for protected storage locations for its Root Keys. If the DSC uses external storage without secure channels, then it should be ready to wrap both Intermediate Keys as well as the Leaf Objects. This implies that there will be some sort of structure on each of these items stored external to the DSC. The next section discusses that structure.
+For those cases in which the DSC relies on storage external to itself to accommodate all the items on which applications expect it to operate, it will either have to support secure channels to another DSC with a more generous allocation of protected storage locations, or use a series of wrapping keys to protect the confidentiality and integrity of this sensitive data while outside of the DSC. Whether the DSC is powered on or powered off, the DSC is expected to provide support for protected storage locations for its root keys. If the DSC uses external storage without secure channels, then it should be ready to wrap both Intermediate Keys as well as the Leaf Objects. This implies that there will be some sort of structure on each of these items stored external to the DSC. The next section discusses that structure.
 
 A conformant TOE may include "write-once" storage such as single-use eFuses. Since data is written to any such storage as part of the initial provisioning of the TOE, the data is considered immutable once the TOE has entered its evaluated configuration. The integrity of this data is maintained through the physical properties of its storage medium.
 
@@ -443,7 +443,7 @@ A conformant TOE may include "write-once" storage such as single-use eFuses. Sin
 
 This section is used to map keys and authentication tokens to SDEs and SDOs. This cPP does not impose a strict structure on the items in the key hierarchy. An X.509 certificate is one example of a strict structure of a key with attributes. Collecting attributes of an SDE and composing an SDO structure with an SDE and attribute fields imposes temporal and storage penalties in all cases. In certain resource-constrained cases the attributes could be implicit. 
 
-In the previous section on protected storage locations, a DSC may have to use storage external to itself. In these cases, an SDO of a wrapped key may contain a number of important attributes, such as a pointer to its parent, authorization values, and other indications of the functions allowed (encrypt vs. sign). Alternatively, some or all attributes may be implied, which means that only the keys or CSPs themselves exist outside the DSC. In either case, the sensitive values, such as private keys, secret keys, and CSPs, should be encrypted when outside the DSC. The parents of these objects are either Intermediate Keys, or encrypting Root Keys.
+In the previous section on protected storage locations, a DSC may have to use storage external to itself. In these cases, an SDO of a wrapped key may contain a number of important attributes, such as a pointer to its parent, authorization values, and other indications of the functions allowed (encrypt vs. sign). Alternatively, some or all attributes may be implied, which means that only the SDEs themselves exist outside the DSC. In either case, the sensitive values, such as private keys, secret keys, and authorization data, should be encrypted when outside the DSC. The parents of these objects are either Intermediate Keys, or encrypting Root Keys.
 
 Some DSCs may want to distinguish between SDEs created within itself from SDEs ingested from an external source. Additionally, some DSCs may output SDEs without additional context or attributes from the DSC. A DSC, in some contexts, will not distinguish an ingested SDE from raw keys.
 
@@ -1406,32 +1406,43 @@ _Application Note {counter:remark_count}_:: _When an SDE is a key then it is als
 
 FDP_SDC.2 Stored data confidentiality with dedicated method
 
-FDP_SDC.2.1:: The TSF shall ensure the confidentiality of [.line-through]#the# {empty}[[.underline]#the following user data [_authorization data, [assignment: SDEs identified in the confidential SDE list attribute of an SDO]_]#] according to [assignment: *SDEs identified in the confidential SDE list attribute of an SDO*] while it is stored under the control of the TSF.
+FDP_SDC.2.1:: The TSF shall ensure the confidentiality of [.line-through]#the# {empty}[[.underline]#the following user data [_authorization data, [assignment: SDEs identified in the SDO.Conf attribute of an SDO]_]#] according to [*selection*:
++
+* _presence in DSC protected storage,_
+* _authenticated encryption as defined in FCS_COP.1/AEAD_,
+* _key encapsulation as defined in FCS_COP.1/KeyEncap_,
+* _key wrapping as defined in FCS_COP.1/KeyWrap_,
+* _symmetric-key cryptography as defined in FCS_COP.1/SKC_
++
+] while it is stored under the control of the TSF.
 
 FDP_SDC.2.2:: The TSF shall ensure the confidentiality of the user data specified in FDP_SDC.2.1 without user intervention.
 
-_Application Note {counter:remark_count}_:: _This SFR applies to SDOs with the confidential-SDE attribute set to require confidentiality, especially secret and private keys, Allowed Random Number Generators' state data, and vendor verification reference data. If SDEs do not require confidentiality, then its omission from this list indicates that confidentiality is not required. This SFR also applies to all authorization data appearing in the attribute list under SDO.AuthData as well as any administrator authorization data which may be stored implicitly._
+_Application Note {counter:remark_count}_:: _This SFR applies to SDOs with the SDO.Conf attribute set to require confidentiality of its SDEs, especially secret keys, private keys, and DRBG state data. Omission from the list under SDO.Conf indicates that an SDE is not required to be confidential. This SFR also applies to all authorization data appearing in the attribute list under SDO.AuthData as well as any administrator authorization data which may be stored implicitly._
 
 ==== FDP_SDI.2 Stored Data Integrity Monitoring and Action
 
 FDP_SDI.2 Stored Data Integrity Monitoring and Action
 
-FDP_SDI.2.1:: The TSF shall monitor *SDOs and SDEs* controlled by the TSF for [_integrity errors_] on all objects, based on the following attributes: [*selection*: _[assignment: attribute associated with presence in protected storage], message authentication code as specified in FCS_COP.1/CMAC, cryptographic hash as specified in FCS_COP.1/Hash, keyed hash as specified in FCS_COP.1/KeyedHash, digital signature as specified in FCS_COP.1/SigVer, key wrap encryption algorithm as specified in FCS_COP.1/KeyWrap_].
+FDP_SDI.2.1:: The TSF shall monitor *SDOs and SDEs* controlled by the TSF for [_integrity errors_] on all objects, based on the following attributes: [*selection*:
++
+* _[assignment: attribute associated with presence in DSC protected storage]_,
+* _message authentication code as defined in FCS_COP.1/CMAC_,
+* _hash as defined in FCS_COP.1/Hash_,
+* _nessage authentication code as defined in FCS_COP.1/KeyedHash_,
+* _encapsulated key as defined in FCS_COP.1/KeyEncap_,
+* _wrapped key as defined in FCS_COP.1/KeyWrap_,
+* _digital signature as defined in FCS_COP.1/SigGen and FCS_COP.1/SigVer_,
+* _hash as defined in FCS_COP.1/XOF_
++
+].
 
 FDP_SDI.2.2:: Upon detection of a data integrity error, the TSF shall [
 +
 * _prohibit the use of the altered data_
 * _send notification of the error where applicable_].
 
-_Application Note {counter:remark_count}_:: _This SFR deals with the mechanism that protects the integrity of the SDEs and security attributes within an SDO. This provides the binding data that ensures the prevention of unauthorized changes to the SDEs and attributes. It is not expected that a single key will be protected from corruption by multiple of these methods; however, a product may use one integrity-protection method for one type of key and a different method for other types of keys._
-+
-_The cryptographic requirements for cryptographic hashes and digital signatures apply here._
-+
-_No specific requirement is placed here on the nature of the integrity protection data, but the Security Target shall describe this protection measure, and shall identify the iteration of FCS_COP.1/CMAC, FCS_COP.1/Hash, FCS_COP.1/KeyedHash, FCS_COP.1/SigVer, or FCS_COP.1/KeyWrap that covers any cryptographic algorithm used._
-+
-_The integrity protection data in FDP_SDI.2.1 is included in the list of attributes identified in FMT_MSA.1, and protects the value of the SDEs and of the SDO security attributes._
-+
-_When an SDO is parsed, its integrity is checked when it is imported into the TOE._
+_Application Note {counter:remark_count}_:: _This SFR deals with the mechanism that protects the integrity of the SDEs and security attributes within an SDO, as provided in the SDO.Integrity attribute. This provides the binding data that ensures the prevention of unauthorized changes to the SDEs and attributes. It is not expected that a single SDE will be protected from corruption by multiple of these methods; however, a product may use one integrity-protection method for one type of SDE and a different method for other types of SDE._
 
 === Identification and Authentication
 
@@ -1770,10 +1781,10 @@ _Application Note {counter:remark_count}_:: _One expects that only authorized so
 
 FPT_ROT_EXT.1.3:: The TSF shall provide a Root of Trust for Confidentiality to prevent unauthorized disclosure of SDOs, using the following techniques: [selection:
 +
-* _Authenticated encryption as defined in FCS_COP.1/AEAD_,
-* _Key encapsulation as defined in FCS_COP.1/KeyEncap_,
-* _Key wrapping as defined in FCS_COP.1/KeyWrap_,
-* _Symmetric-key cryptography as defined in FCS_COP.1/SKC,_
+* _authenticated encryption as defined in FCS_COP.1/AEAD_,
+* _key encapsulation as defined in FCS_COP.1/KeyEncap_,
+* _key wrapping as defined in FCS_COP.1/KeyWrap_,
+* _symmetric-key cryptography as defined in FCS_COP.1/SKC_
 +
 ].
 
@@ -1952,7 +1963,7 @@ The following rationale provides justification for each security problem definit
 |This requirement ensures that all SDOs parsed by the TOE are transmitted over a secure channel.
 
 |FDP_SDC.2
-|This requirement ensures that the confidentiality of authorization data is protected prior to storage.
+|This requirement ensures that the confidentiality of authorization data is protected.
 
 |FPT_ITT.1 (optional)
 |This requirement ensures that confidentiality and integrity is maintained in cases where data is transmitted between physically separate parts of a distributed TOE.
@@ -1980,7 +1991,7 @@ The following rationale provides justification for each security problem definit
 |This requirement provides a cryptographic operation for asserting the authenticity of SDOs.
 
 |FDP_SDI.2
-|This requirement ensures that SDEs/SDOs are monitored for integrity violations.
+|This requirement ensures that SDOs are monitored for integrity violations.
 
 |FPT_TST.1
 |This requirement defines the mechanisms used to verify and attest to the integrity of the TSF.
@@ -2002,7 +2013,7 @@ The following rationale provides justification for each security problem definit
 |This requirement ensures that all SDOs parsed by the TOE have verifiable integrity.
 
 |FDP_SDC.2
-|This requirement ensures that SDEs/SDOs are stored with confidentiality and that all authorization data is protected prior to storage.
+|This requirement ensures that SDEs are stored confidentially (if required) and that all authorization data is protected.
 
 |FDP_ITC_EXT.1
 |This requirement ensures that all SDEs parsed by the TOE include appropriate binding metadata.

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -244,7 +244,7 @@ DSCs provide seven core security services to a platform as illustrated in <<Core
 
 ==== Roots of Trust
 
-This collaborative Protection Profile (cPP) assumes a DSC will contain a Root of Trust (RoT) that is comprised of the compute engine, one set of firmware code, and pre-installed SDOs, including a unique identity bound to the hardware. The firmware code may be immutable, or it may be mutable but with controlled, authenticated, and authorized updates allowed to ensure continued integrity of the RoT. This code may provide one or more RoT services, such as a RoT for Measurement, Verification, or Reporting. The unique identity bound to the hardware should be immutable and third parties should be able to authenticate the manufacturer of the Root of Trust through its unique identity (e.g., the unique identity may be a credential signed by the manufacturer).
+This collaborative Protection Profile (cPP) assumes a DSC will contain a Root of Trust (RoT) that is comprised of the compute engine, one set of firmware code, and pre-installed SDOs, including a unique identity bound to the hardware. The firmware code may be immutable, or it may be mutable but with controlled, authenticated, and authorized updates allowed to ensure continued integrity of the RoT. This code may provide one or more RoT services, such as a RoT for Measurement, Reporting, or Verification. The unique identity bound to the hardware should be immutable and third parties should be able to authenticate the manufacturer of the Root of Trust through its unique identity (e.g., the unique identity may be a credential signed by the manufacturer).
 
 ==== DSC Characteristics
 
@@ -1762,47 +1762,52 @@ _Any physical external casing or potting material of the TOE is considered an 'e
 +
 _The TOE's protection against abnormal temperature and voltage can be considered equivalent to what is required by assertion AS07.77 of [ISO-TR]._
 
-==== FPT_PRO_EXT.1 Root of Trust
+==== FPT_ROT_EXT.1 Root of Trust
 
-FPT_PRO_EXT.1 Root of Trust
+FPT_ROT_EXT.1 Root of Trust
 
-FPT_PRO_EXT.1.1:: The TSF shall contain an SDO that contains the identity of the Root of Trust.
+FPT_ROT_EXT.1.1:: The TSF shall contain an SDO that contains the identity of the Root of Trust.
 
-_Application Note {counter:remark_count}_:: _Every DSC is expected to have a single RoT that comprises the DSC hardware and pre-installed SDOs, from which services (e.g. Storage, Authorization, etc.) can be offered._
+_Application Note {counter:remark_count}_:: _Every DSC is expected to have a single RoT that comprises the DSC hardware and pre-installed SDOs, from which services (e.g. Confidentiality, Integrity, Measurement, etc.) can be offered._
 +
 _Depending on the use case and the way status registers are used, unique identity keys may be bound to the TOE, the TOE platform, or both._
 +
 _The sole presence of unique identity keys linking to the RoT does not prove authenticity without the use of digital signatures._
 
-FPT_PRO_EXT.1.2:: The TSF shall maintain Root of Trust data as [selection: _immutable, mutable if and only if its mutability is controlled by a unique identifiable owner_].
+FPT_ROT_EXT.1.2:: The TSF shall maintain Root of Trust data as [selection: _immutable, mutable if and only if its mutability is controlled by a unique identifiable owner_].
 
-_Application Note {counter:remark_count}_:: _One expects that only authorized sources can modify the single RoT, such as through a secure update._
+_Application Note {counter:remark_count}_:: _One expects that only authorized sources can modify the single RoT, such as through a secure firmware update._
+
+FPT_ROT_EXT.1.3:: The TSF shall provide a Root of Trust for Confidentiality to prevent unauthorized disclosure of SDOs, using the following techniques: [selection:
 +
-_The process of authenticating the source of a secure update may involve querying the identity of the manufacturer, contained on a pre-installed SDO. If this identity is in the form of an X.509 certificate containing a signature verification key signed by the manufacturer, then the authentication process is sufficient._
+* _Authenticated encryption as defined in FCS_COP.1/AEAD_,
+* _Key encapsulation as defined in FCS_COP.1/KeyEncap_,
+* _Key wrapping as defined in FCS_COP.1/KeyWrap_,
+* _Symmetric-key cryptography as defined in FCS_COP.1/SKC,_
 +
-_A unique identifiable owner is assumed to be one with an ADM-R role; however, there may be circumstances where the owner does not take on an ADM-R role, which should be documented._
+].
 
-==== FPT_ROT_EXT.1 Root of Trust Services
-
-FPT_ROT_EXT.1 Root of Trust Services
-
-FPT_ROT_EXT.1.1:: The TSF shall provide a Root of Trust for Storage, a Root of Trust for Authorization, and [selection: _Root of Trust for Measurement, Root of Trust for Reporting, no others_] based on the Root of Trust identified in FPT_PRO_EXT.1.1.
-
-:xrefstyle: short
-
-_Application Note {counter:remark_count}_:: _This document uses the [GP_ROT] definitions for RoT for Storage (denoted as the combination of RoT for Confidentiality and RoT for Integrity), Authorization, Measurement, and Reporting. DSCs use Roots of Trust for Storage to protect SDOs. <<Identification and Authentication>> has a number of requirements for ensuring the TSF has functionality to authorize a user in order to access an SDO, including FIA_UAU.6._
+FPT_ROT_EXT.1.4:: The TSF shall provide a Root of Trust for Integrity to prevent unauthorized modification of SDOs, using the following techniques: [selection:
 +
-_If both [.underline]#Root of Trust for Measurement# and [.underline]#Root of Trust for Reporting# are selected in FPT_ROT_EXT.1.1, the selection-based SFR FDP_DAU.1/Prove must be claimed._
+* _Authenticated encryption as defined in FCS_COP.1/AEAD_,
+* _CMAC as defined in FCS_COP.1/CMAC_,
+* _Hashing as defined in FCS_COP.1/Hash_,
+* _Keyed hashing as defined in FCS_COP.1/KeyedHash_,
+* _Key encapsulation as defined in FCS_COP.1/KeyEncap_,
+* _Key wrapping as defined in FCS_COP.1/KeyWrap_,
+* _Signature verification as defined in FCS_COP.1/SigVer_,
+* _XOF as defined in FCS_COP.1/XOF_
++
+].
 
-:xrefstyle: full
-
-==== FPT_ROT_EXT.2 Root of Trust for Storage
-
-FPT_ROT_EXT.2 Root of Trust for Storage
-
-FPT_ROT_EXT.2.1:: The TSF shall prevent unauthorized access to SDOs associated with the Root of Trust for Storage.
-
-_Application Note {counter:remark_count}_:: _TOEs may use shielded locations or cryptographic protections to prevent unauthorized access to SDOs. Unauthorized access includes unauthorized disclosure of secret SDOs (e.g. secret keys, private keys) and unauthorized modification of both secret and non-secret SDOs (e.g. public keys, certificates). Use FDP_SDC.2 to protect the confidentiality of secret SDOs associated with the RoT for Storage. Use FDP_SDI.2 to protect the integrity of SDOs associated with the RoT for Storage._
+FPT_ROT_EXT.1.5:: The TSF shall provide the following additional Root of Trust services: [selection:
++
+* _Measurement as defined in FPT_ROT_EXT.2_,
+* _Reporting as defined in FPT_ROT_EXT.3_,
+* _Verification as defined in FPT_ROT_EXT.4_,
+* _no additional services_
++
+] based on the identity identified in FPT_ROT_EXT.1.1.
 
 ==== FPT_RPL.1/Authorization Replay Prevention
 
@@ -1896,7 +1901,7 @@ The following rationale provides justification for each security problem definit
 |FMT_MSA.3 
 |This requirement defines the default access restrictions that are enforced on SDO attributes if not overridden by specific access control policy rules.
 
-.8+|T.UNAUTHORIZED_ACCESS
+.7+|T.UNAUTHORIZED_ACCESS
 |FMT_SMF.1 
 |This requirement defines the management functions that are provided by the TOE to authorized subjects.
 
@@ -1909,11 +1914,8 @@ The following rationale provides justification for each security problem definit
 |FPT_PHP.3 
 |This requirement ensures that some mechanism is in place to thwart unauthorized attempts to access protected functions or data through physical tampering of the TOE.
 
-|FPT_PRO_EXT.1 
+|FPT_ROT_EXT.1
 |This requirement defines the RoT for the TOE, which is used to derive all access control functionality.
-
-|FPT_ROT_EXT.2 
-|This requirement enforces the RoT for Storage to enforce access control against SDOs.
 
 |FPT_RPL.1/Authorization
 |This requirement ensures that access control restrictions cannot be bypassed through replay of operations.
@@ -1993,7 +1995,7 @@ The following rationale provides justification for each security problem definit
 |FPT_TST.1
 |This requirement defines the mechanisms used to verify and attest to the integrity of the TSF.
 
-|FPT_PRO_EXT.2 (optional)
+|FPT_ROT_EXT.2 (selection-based)
 |This requirement ensures that the TSF can measure the integrity of its stored data.
 
 |FCS_COP.1/CMAC (selection-based)
@@ -2002,7 +2004,7 @@ The following rationale provides justification for each security problem definit
 |FPT_FLS.1/FW (selection-based)
 |This requirement requires the TSF to take action to preserve its secure operation if any violations to its firmware integrity are detected.
 
-.7+|T.WEAK_OWNERSHIP_BINDING
+.6+|T.WEAK_OWNERSHIP_BINDING
 |FDP_ITC_EXT.1
 |This requirement ensures that all SDEs parsed by the TOE have verifiable integrity.
 
@@ -2012,19 +2014,16 @@ The following rationale provides justification for each security problem definit
 |FDP_SDC.2
 |This requirement ensures that SDEs/SDOs are stored with confidentiality and that all authorization data is protected prior to storage.
 
-|FPT_ROT_EXT.1
-|This requirement defines the RoT services that are available for the protection of data.
-
 |FDP_ITC_EXT.1
 |This requirement ensures that all SDEs parsed by the TOE include appropriate binding metadata.
 
-|FPT_ROT_EXT.3 (optional)
-|This requirement allows the TSF to provide a RoT for Reporting that can provide assured information about the stored SDEs.
+|FPT_ROT_EXT.3 (selection-based)
+|This requirement allows the TSF to provide a Root of Trust for Reporting that can provide assured information about the stored data.
 
 |FDP_DAU.1/Prove (selection-based)
 |This requirement defines the Prove service that can be used to invoke the Roots of Trust for Measurement and Reporting and provide affirmation of the validity of TSF and stored data.
 
-.4+|T.UNAUTH_UPDATE
+.5+|T.UNAUTH_UPDATE
 |FPT_MFW_EXT.1 
 |This requirement specifies whether the TOE's firmware is mutable or immutable.
 
@@ -2033,6 +2032,9 @@ The following rationale provides justification for each security problem definit
 
 |FPT_MFW_EXT.2 (selection-based)
 |This requirement ensures that the TSF can verify that its mutable firmware integrity remains intact and any firmware updates to the TSF are genuine.
+
+|FPT_ROT_EXT.4 (selection-based)
+|This requirement allows the TSF to provide a Root of Trust for Verification that can ensure the integrity and authenticity of signed firmware.
 
 |FPT_RPL.1/FW (selection-based)
 |This requirement ensures that the TSF will not permit loading earlier versions of its firmware.
@@ -2306,34 +2308,6 @@ FCS_RBG.6.1:: The TSF shall provide a [selection: _hardware, software, [assignme
 FPT_ITT.1 Basic Internal TSF Data Transfer Protection
 
 FPT_ITT.1.1:: The TSF shall protect TSF data from {empty}[[.underline]#disclosure#] *and [selection: _modification, no other actions_]* when it is transmitted between separate parts of the TOE.
-
-==== FPT_PRO_EXT.2 Data Integrity Measurements
-
-FPT_PRO_EXT.2 Data Integrity Measurements
-
-FPT_PRO_EXT.2.1:: The TSF shall be able to quantify the integrity of the data protected by the TOE by generating integrity measurements and assertions.
-
-_Application Note {counter:remark_count}_:: _The generation of these integrity measurements and assertions is the creation of OB.Pstate._
-+
-_Data protected by the TOE includes DSC firmware, DSC configuration data, and user data. DSC configuration data may include permanent SDEs or SDOs such as immutable or mutable root keys, authorization values, and authentication tokens (i.e. DSC.ID, OB.P_SDO, OB.FAACntr, OB.AntiReplay, and OB.Context). User data may include transient SDEs and SDOs as well as authorization values and authentication tokens bound to these SDEs and SDOs (i.e. OB.T_SDO)._
-
-FPT_PRO_EXT.2.2:: The TSF shall accumulate platform characteristics using a consistent [assignment: _description of process for accumulating platform characteristics_] process in which verified quantifiable measurements and assertions are accumulated by the RoT for Measurement to prove the integrity of its SDOs.
-
-_Application Note {counter:remark_count}_:: _Although a platform may enter any state possible — including undesirable or insecure states — it can use platform characteristics, including integrity measurements and assertions, along with logging and reporting to accurately report the state derived from data attributing to those states. In this context, platform characteristics can include, but is not limited to, cryptographic hashes of binary data, security-critical configurations, register values (including status registers) and milestones, such as verification of firmware, or transitioning from a boot phase to an operational phase. A platform characteristic may also represent the state of some entity outside the DSC. A process independent from the DSC or the host containing the DSC may evaluate the platform characteristics and determine an appropriate action._
-
-==== FPT_ROT_EXT.3 Root of Trust for Reporting Mechanisms 
-
-FPT_ROT_EXT.3 Root of Trust for Reporting Mechanisms
-
-FPT_ROT_EXT.3.1:: The TSF shall be able to attest to a state as represented by platform characteristics with a Root of Trust for Reporting mechanism that uses for its identity [selection: _a cryptographically verifiable identity in FPT_PRO_EXT.1, an alias key bound to the cryptographically verifiable identity in FPT_PRO_EXT.1_] and using a signature algorithm as specified in FCS_COP.1**/SigGen**.
-
-_Application Note {counter:remark_count}_:: _While it is possible for a group of components to share a single unique group identifier, it is important to ensure that individual components have their own unique identifiers relative to each other._
-+
-_Resident keys or aliases are designed such that they are never visible outside the subset of DSC scope containing the RoT services and are only to be used for encryption. Therefore, possession of such aliases or keys can only be proved indirectly by using it to decrypt a value that has been encrypted with a corresponding public key. In this way, these resident keys or aliases can provide for authentication based on decryption operations instead of producing a digital signature._
-+
-_The DSC responds to requests from an external entity to attest to the provenance and integrity of platform characteristics contained within the DSC._
-+
-_Integrity reporting is the process of attesting to platform characteristics (including those recorded in status registers in a DSC). The philosophy behind integrity measurement, logging, and reporting is that a platform may enter any state possible—including undesirable or insecure states—but can still accurately report measurements derived from data attributing to those states. In this context, data can include, but is not limited to, code, security-critical configurations, values of registers, including status registers. An independent process may evaluate the integrity states and determine an appropriate response._
 
 === Flaw Remediation
 
@@ -2896,7 +2870,7 @@ FDP_DAU.1.1/Prove:: The TSF shall provide a capability to generate evidence that
 
 FDP_DAU.1.2/Prove:: The TSF shall provide [assignment: _list of subjects_] with the ability to verify evidence of the validity of the indicated information.
 
-_Application Note {counter:remark_count}_:: _This SFR describes the output of the Prove service provided by the DSC. The evidence of validity or authenticity, or other evidence derived, is expected to be processed by the RoT for Measurement. Additionally, the use of a RoT for Reporting presupposes a logging capability or other means of generating state information that could be conveyed to external entities. Therefore, FDP_DAU.1.1/Prove is claimed if-and-only-if [.underline]#Root of Trust for Measurement# and [.underline]#Root of Trust for Reporting# are both selected in FPT_ROT_EXT.1.1. An 'authenticated user' in the sense of the selection in FDP_DAU.1.1/Prove means a user who has been authenticated by the DSC according to the mechanisms of FIA_UAU.5._
+_Application Note {counter:remark_count}_:: _This SFR describes the output of the Prove service provided by the DSC. The evidence of validity or authenticity, or other evidence derived, is expected to be processed by the Root of Trust for Measurement. Additionally, the use of a Root of Trust for Reporting presupposes a logging capability or other means of generating state information that could be conveyed to external entities. Therefore, FDP_DAU.1.1/Prove is claimed if-and-only-if FPT_ROT_EXT.2 and FPT_ROT_EXT.3 are both included. An 'authenticated user' in the sense of the selection in FDP_DAU.1.1/Prove means a user who has been authenticated by the DSC according to the mechanisms of FIA_UAU.5._
 +
 _In FDP_DAU.1.1/Prove, the DSC will issue a validity-stamped or authenticity-stamped piece of data. In this case, validity-stamped means that the form of the issued data enables an external entity to verify that the data has been issued via the DSC's Prove service. The implementation might be via a DSC cryptographic signature, or a MAC using a symmetric key shared with the receiver, for example. Authenticity-stamped means that the receiver of the data can verify that the user providing this data is authentic._
 +
@@ -2951,6 +2925,40 @@ FPT_RPL.1.1/FW:: The TSF shall detect replay for the following entities: [_earli
 FPT_RPL.1.2/FW:: The TSF shall *prevent the execution of the earlier firmware and* perform [*selection, choose one of*: _[assignment: other actions], no other actions_] when replay is detected.
 
 _Application Note {counter:remark_count}_:: _The TSF data is used as a guarantee of the ordinal identifier of the firmware instance. When a firmware load is requested, the TSF ensures the authenticated firmware ordinal identifier is greater than or equal to the previously authenticated firmware identifier. For example, this could be accomplished by ensuring the validated instance of the firmware to be loaded is greater than or equal to the instance previously validated and loaded into the TOE. By loading an earlier instance of firmware, it potentially opens up the device to known vulnerabilities._
+
+==== FPT_ROT_EXT.2 Root of Trust for Measurement
+
+FPT_ROT_EXT.2 Root of Trust for Measurement
+
+FPT_ROT_EXT.2.1:: The TSF shall be able to quantify the integrity of the data protected by the TOE by generating integrity measurements and assertions.
+
+_Application Note {counter:remark_count}_:: _The generation of these integrity measurements and assertions is the creation of OB.Pstate._
++
+_Data protected by the TOE includes DSC firmware, DSC configuration data, and user data. DSC configuration data may include permanent SDEs or SDOs such as immutable or mutable root keys, authorization values, and authentication tokens (i.e. DSC.ID, OB.P_SDO, OB.FAACntr, OB.AntiReplay, and OB.Context). User data may include transient SDEs and SDOs as well as authorization values and authentication tokens bound to these SDEs and SDOs (i.e. OB.T_SDO)._
+
+FPT_ROT_EXT.2.2:: The TSF shall accumulate platform characteristics using a consistent [assignment: _description of process for accumulating platform characteristics_] process in which verified quantifiable measurements and assertions are accumulated by the Root of Trust for Measurement.
+
+_Application Note {counter:remark_count}_:: _Although a platform may enter any state possible — including undesirable or insecure states — it can use platform characteristics, including integrity measurements and assertions, along with logging and reporting to accurately report the state derived from data attributing to those states. In this context, platform characteristics can include, but is not limited to, cryptographic hashes of binary data, security-critical configurations, register values (including status registers) and milestones, such as verification of firmware, or transitioning from a boot phase to an operational phase. A platform characteristic may also represent the state of some entity outside the DSC. A process independent from the DSC or the host containing the DSC may evaluate the platform characteristics and determine an appropriate action._
+
+==== FPT_ROT_EXT.3 Root of Trust for Reporting
+
+FPT_ROT_EXT.3 Root of Trust for Reporting
+
+FPT_ROT_EXT.3.1:: The TSF shall be able to attest to a state as represented by platform characteristics with a Root of Trust for Reporting mechanism that uses for its identity [selection: _a cryptographically verifiable identity in FPT_ROT_EXT.1, a key bound to the cryptographically verifiable identity in FPT_ROT_EXT.1_] and using a signature algorithm as defined in FCS_COP.1/SigGen.
+
+_Application Note {counter:remark_count}_:: _While it is possible for a group of components to share a single unique group identifier, it is important to ensure that individual components have their own unique identifiers relative to each other._
++
+_Resident keys or aliases are designed such that they are never visible outside the subset of DSC scope containing the RoT services and are only to be used for encryption. Therefore, possession of such aliases or keys can only be proved indirectly by using it to decrypt a value that has been encrypted with a corresponding public key. In this way, these resident keys or aliases can provide for authentication based on decryption operations instead of producing a digital signature._
++
+_The DSC responds to requests from an external entity to attest to the provenance and integrity of platform characteristics contained within the DSC._
++
+_Integrity reporting is the process of attesting to platform characteristics (including those recorded in status registers in a DSC). The philosophy behind integrity measurement, logging, and reporting is that a platform may enter any state possible—including undesirable or insecure states—but can still accurately report measurements derived from data attributing to those states. In this context, data can include, but is not limited to, code, security-critical configurations, values of registers, including status registers. An independent process may evaluate the integrity states and determine an appropriate response._
+
+==== FPT_ROT_EXT.4 Root of Trust for Verification
+
+FPT_ROT_EXT.4 Root of Trust for Verification
+
+FPT_ROT_EXT.4.1:: The TSF shall [selection: _verify the integrity and authenticity, provide a service to verify the integrity and authenticity_] of signed objects using [selection: _a cryptographically verifiable identity in FPT_ROT_EXT.1, a key bound to the cryptographically verifiable identity in FPT_ROT_EXT.1_] and using a signature algorithm as defined in FCS_COP.1/SigVer.
 
 ==== FPT_STM_EXT.1 Reliable Time Counting
 
@@ -3026,14 +3034,12 @@ This Appendix provides a definition for all of the extended components introduce
 | Security Management (FMT) 
 | FMT_MOF_EXT Management of Functions in TSF
 
-.5+| Protection of the TSF (FPT) 
+.4+| Protection of the TSF (FPT)
 | FPT_MFW_EXT Mutable/Immutable Firmware
 
 | FPT_MOD_EXT Debug Modes
 
-| FPT_PRO_EXT Root of Trust
-
-| FPT_ROT_EXT Root of Trust Services
+| FPT_ROT_EXT Root of Trust
 
 | FPT_STM_EXT Reliable Time Counting
 
@@ -3582,125 +3588,120 @@ Dependencies:: No dependencies.
 [vertical]
 FPT_MOD_EXT.1.1:: The TSF shall provide no access to debug modes.
 
-==== FPT_PRO_EXT Root of Trust
+==== FPT_ROT_EXT Root of Trust
 
 *Family Behavior*
 
-This family defines requirements for the TOE's implementation of a Root of Trust and its ability to use this to assert the integrity of its stored data.
-
-*Component Leveling*
-
-[#img-FPT_PRO_EXT] 
-[ditaa,"FPT_PRO_EXT"]
-....
-                                                     
-                                                    
-                                                       +---+
-    +--------------------------------------------+  |->| 1 |
-    |                                            |  |  +---+
-    | FPT_PRO_EXT Root of Trust                  +--+
-    |                                            |  |  +---+
-    +--------------------------------------------+  |->| 2 |
-                                                       +---+
-                                                    
-                                                    
-....
-
-FPT_PRO_EXT.1 Root of Trust, requires the TSF to maintain a Root of Trust and identify how it is stored in memory.
-
-FPT_PRO_EXT.2 Data Integrity Measurements, requires the TSF to generate integrity measurements to assert its own integrity.
-
-*Management: FPT_PRO_EXT.1, FPT_PRO_EXT.2*
-
-No specific management functions are identified.
-
-*Audit: FPT_PRO_EXT.1, FPT_PRO_EXT.2*
-
-There are no auditable events foreseen.
-
-*FPT_PRO_EXT.1 Root of Trust*
-[horizontal]
-Hierarchical to:: No other components.
-
-Dependencies:: No dependencies.
-[vertical]
-FPT_PRO_EXT.1.1:: The TSF shall contain an SDO that contains the identity of the Root of Trust.
-
-FPT_PRO_EXT.1.2:: The TSF shall maintain Root of Trust data as [selection: _immutable, mutable if and only if its mutability is controlled by a unique identifiable owner_].
-
-*FPT_PRO_EXT.2 Data Integrity Measurements*
-[horizontal]
-Hierarchical to:: No other components.
-
-Dependencies:: No dependencies.
-[vertical]
-FPT_PRO_EXT.2.1:: The TSF shall be able to quantify the integrity of the data protected by the TOE by generating integrity measurements and assertions.
-
-FPT_PRO_EXT.2.2:: The TSF shall accumulate platform characteristics using a consistent [assignment: _description of process for accumulating platform characteristics_] process in which verified quantifiable measurements and assertions are accumulated by the RoT for Measurement to prove the integrity of its SDOs.
-
-==== FPT_ROT_EXT Root of Trust Services
-
-*Family Behavior*
-
-This family defines requirements for individual Root of Trust services that the TSF may implement.
+This family defines requirements for the Root of Trust and Root of Trust services that the TSF may implement.
 
 *Component Leveling*
 
 [#img-FPT_ROT_EXT] 
 [ditaa,"FPT_ROT_EXT"]
 ....
+
                                                        +---+
                                                     +->| 1 |
                                                     |  +---+
-    +--------------------------------------------+  |
-    |                                            |  |  +---+
-    | FPT_ROT_EXT Root of Trust Services         +--+->| 2 |
-    |                                            |  |  +---+
-    +--------------------------------------------+  |
+                                                    |
                                                     |  +---+
-                                                    +->| 3 |
+    +--------------------------------------------+  +->| 2 |
+    |                                            |  |  +---+
+    | FPT_ROT_EXT Root of Trust                  +--+
+    |                                            |  |  +---+
+    +--------------------------------------------+  +->| 3 |
                                                        +---+
+                                                    |
+                                                    |  +---+
+                                                    +->| 4 |
+                                                       +---+
+
 ....
 
-FPT_ROT_EXT.1 Root of Trust Services, requires the TSF to identify the specific Roots of Trust it provides.
+FPT_ROT_EXT.1 Root of Trust, requires the TSF to maintain a Root of Trust and prevent the unauthorized disclosure or modification of protected SDOs.
 
-FPT_ROT_EXT.2 Root of Trust for Storage, requires the TSF to prevent unauthorized access to SDOs associated with its Root of Trust for Storage.
+FPT_ROT_EXT.2 Root of Trust for Measurement, requires the TSF to collect measurements about the TSF and its platform.
 
-FPT_ROT_EXT.3 Root of Trust for Reporting Mechanisms, requires the TSF to implement a Root of Trust for Reporting in the specified manner.
+FPT_ROT_EXT.3 Root of Trust for Reporting, requires the TSF to report the collected measurements.
 
-*Management: FPT_ROT_EXT.1, FPT_ROT_EXT.2, FPT_ROT_EXT.3*
+FPT_ROT_EXT.4 Root of Trust for Verification, requires the TSF to verify the integrity and authenticity of signed objects.
+
+*Management: FPT_ROT_EXT.1, FPT_ROT_EXT.2, FPT_ROT_EXT.3, FPT_ROT_EXT.4*
 
 No specific management functions are identified.
 
-*Audit: FPT_ROT_EXT.1, FPT_ROT_EXT.2, FPT_ROT_EXT.3*
+*Audit: FPT_ROT_EXT.1, FPT_ROT_EXT.2, FPT_ROT_EXT.3, FPT_ROT_EXT.4*
 
 There are no auditable events foreseen.
 
-*FPT_ROT_EXT.1 Root of Trust Services*
+*FPT_ROT_EXT.1 Root of Trust*
 [horizontal]
 Hierarchical to:: No other components.
 
-Dependencies:: FPT_PRO_EXT.1 Root of Trust
+Dependencies:: No dependencies.
 [vertical]
-FPT_ROT_EXT.1.1:: The TSF shall provide a Root of Trust for Storage, a Root of Trust for Authorization, and [selection: _Root of Trust for Measurement, Root of Trust for Reporting, no others_].
+FPT_ROT_EXT.1.1:: The TSF shall contain an SDO that contains the identity of the Root of Trust.
 
-*FPT_ROT_EXT.2 Root of Trust for Storage*
+FPT_ROT_EXT.1.2:: The TSF shall maintain Root of Trust data as [selection: _immutable, mutable if and only if its mutability is controlled by a unique identifiable owner_].
+
+FPT_ROT_EXT.1.3:: The TSF shall provide a Root of Trust for Confidentiality to prevent unauthorized disclosure of SDOs, using the following techniques: [selection:
++
+* _Authenticated encryption as defined in FCS_COP.1/AEAD_,
+* _Key encapsulation as defined in FCS_COP.1/KeyEncap_,
+* _Key wrapping as defined in FCS_COP.1/KeyWrap_,
+* _Symmetric-key cryptography as defined in FCS_COP.1/SKC,_
++
+].
+
+FPT_ROT_EXT.1.4:: The TSF shall provide a Root of Trust for Integrity to prevent unauthorized modification of SDOs, using the following techniques: [selection:
++
+* _Authenticated encryption as defined in FCS_COP.1/AEAD_,
+* _CMAC as defined in FCS_COP.1/CMAC_,
+* _Hashing as defined in FCS_COP.1/Hash_,
+* _Keyed hashing as defined in FCS_COP.1/KeyedHash_,
+* _Key encapsulation as defined in FCS_COP.1/KeyEncap_,
+* _Key wrapping as defined in FCS_COP.1/KeyWrap_,
+* _Signature verification as defined in FCS_COP.1/SigVer_,
+* _XOF as defined in FCS_COP.1/XOF_
++
+].
+
+FPT_ROT_EXT.1.5:: The TSF shall provide the following additional Root of Trust services: [selection:
++
+* _Measurement as defined in FPT_ROT_EXT.2_,
+* _Reporting as defined in FPT_ROT_EXT.3_,
+* _Verification as defined in FPT_ROT_EXT.4_,
+* _no additional services_
++
+] based on the identity identified in FPT_ROT_EXT.1.1.
+
+*FPT_ROT_EXT.2 Root of Trust for Measurement*
 [horizontal]
 Hierarchical to:: No other components.
 
-Dependencies:: FPT_PRO_EXT.1 Root of Trust
+Dependencies:: FPT_ROT_EXT.1 Root of Trust
 [vertical]
-FPT_ROT_EXT.2.1:: The TSF shall prevent unauthorized access to SDOs associated with the Root of Trust for Storage.
+FPT_ROT_EXT.2.1:: The TSF shall be able to quantify the integrity of the data protected by the TOE by generating integrity measurements and assertions.
 
-*FPT_ROT_EXT.3 Root of Trust for Reporting Mechanisms*
+FPT_ROT_EXT.2.2:: The TSF shall accumulate platform characteristics using a consistent [assignment: _description of process for accumulating platform characteristics_] process in which verified quantifiable measurements and assertions are accumulated by the Root of Trust for Measurement.
+
+*FPT_ROT_EXT.3 Root of Trust for Reporting*
 [horizontal]
 Hierarchical to:: No other components.
 
-Dependencies:: FCS_COP.1 Cryptographic Operation +
-FPT_PRO_EXT.1 Root of Trust +
-FPT_ROT_EXT.1 Root of Trust Services
+Dependencies:: FPT_ROT_EXT.2 Root of Trust for Measurement +
+FCS_COP.1 Cryptographic Operation
 [vertical]
-FPT_ROT_EXT.3.1:: The TSF shall be able to attest to a state as represented by platform characteristics with a Root of Trust for Reporting mechanism that uses for its identity [selection: _a cryptographically verifiable identity in FPT_PRO_EXT.1, an alias key bound to the cryptographically verifiable identity in FPT_PRO_EXT.1_] and using a signature algorithm as specified in FCS_COP.1.
+FPT_ROT_EXT.3.1:: The TSF shall be able to attest to a state as represented by platform characteristics with a Root of Trust for Reporting mechanism that uses for its identity [selection: _a cryptographically verifiable identity in FPT_ROT_EXT.1, a key bound to the cryptographically verifiable identity in FPT_ROT_EXT.1_] and using a signature algorithm as defined in FCS_COP.1/SigGen.
+
+*FPT_ROT_EXT.4 Root of Trust for Verification*
+[horizontal]
+Hierarchical to:: No other components.
+
+Dependencies:: FPT_ROT_EXT.1 Root of Trust +
+FCS_COP.1 Cryptographic Operation
+[vertical]
+FPT_ROT_EXT.4.1:: The TSF shall [selection: _verify the integrity and authenticity, provide a service to verify the integrity and authenticity_] of signed objects using [selection: _a cryptographically verifiable identity in FPT_ROT_EXT.1, a key bound to the cryptographically verifiable identity in FPT_ROT_EXT.1_] and using a signature algorithm as defined in FCS_COP.1/SigVer.
 
 ==== FPT_STM_EXT Reliable Time Counting
 
@@ -4167,17 +4168,9 @@ FMT_SMR.1 - included
 |No dependencies
 |N/A
 
-|FPT_PRO_EXT.1 
+|FPT_ROT_EXT.1
 |No dependencies
 |N/A
-
-|FPT_ROT_EXT.1 
-|FPT_PRO_EXT.1 
-|FPT_PRO_EXT.1 - included
-
-|FPT_ROT_EXT.2 
-|FPT_PRO_EXT.1 
-|FPT_PRO_EXT.1 - included
 
 |FPT_RPL.1/Authorization
 |No dependencies
@@ -4236,22 +4229,6 @@ FCS_RBG.4 - (optional SFR) included
 |FPT_ITT.1 
 |No dependencies
 |N/A
-
-|FPT_PRO_EXT.2 
-|No dependencies
-|N/A
-
-|FPT_ROT_EXT.3 
-|FCS_COP.1 
-
-FPT_PRO_EXT.1 
-
-FPT_ROT_EXT.1 
-|FCS_COP.1- included
-
-FPT_PRO_EXT.1 - included
-
-FPT_ROT_EXT.1 - included
 
 |===
 
@@ -4481,6 +4458,26 @@ FCS_COP.1
 
 FCS_COP.1 - included
 
+|FPT_ROT_EXT.2
+|FPT_ROT_EXT.1
+|FPT_ROT_EXT.1 - included
+
+|FPT_ROT_EXT.3
+|FPT_ROT_EXT.2
+
+FCS_COP.1
+|FPT_ROT_EXT.2 - (selection-based SFR) included
+
+FCS_COP.1 - included
+
+|FPT_ROT_EXT.4
+|FPT_ROT_EXT.1
+
+FCS_COP.1
+|FPT_ROT_EXT.1 - included
+
+FCS_COP.1 - included
+
 |FPT_RPL.1/FW
 |No dependencies
 |N/A
@@ -4628,11 +4625,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FPT_PHP.3 !Resistance to Physical Attack
 
-!FPT_ROT_EXT.1 !Root of Trust Services
-
-!FPT_ROT_EXT.2 !Root of Trust for Storage
-
-!FPT_PRO_EXT.2 !Data Integrity Measurements
+!FPT_ROT_EXT.1 !Root of Trust
 
 !FDP_FRS_EXT.2 !Factory Reset Behavior
 
@@ -4688,13 +4681,15 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FMT_SMR.1 !Separation of Roles
 
-!FPT_ROT_EXT.1 !Root of Trust Services
-
 !FPT_RPL.1/Authorization !Replay Prevention
 
-!FPT_STM.1 !Reliable Time Counting
+!FPT_STM_EXT.1 !Reliable Time Counting
 
 !FIA_AFL_EXT.2 !Authorization Failure Response
+
+!FPT_ROT_EXT.2 !Root of Trust for Measurements
+
+!FPT_ROT_EXT.4 !Root of Trust for Verification
 
 !===
 
@@ -4716,7 +4711,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FDP_ACF.1 !Security Attribute Based Access Control
 
-!FPT_PRO_EXT.1 !Root of Trust
+!FPT_ROT_EXT.1 !Root of Trust
 
 !FPT_RPL.1/Authorization !Replay Prevention
 
@@ -4730,13 +4725,13 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_RBG.5 !Random Bit Generation (Combining Entropy Sources)
 
-!FPT_ROT_EXT.3 !Root of Trust for Reporting Mechanisms
-
 !FDP_DAU.1/Prove !Basic Data Authentication (for Use with the Prove Service)
 
 !FPT_MFW_EXT.1 !Mutable/Immutable Firmware
 
 !FPT_MFW_EXT.2 !Firmware Integrity
+
+!FPT_ROT_EXT.3 !Root of Trust for Reporting
 
 !===
 
@@ -4826,8 +4821,6 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FRU_FLT.1 !Degraded Fault Tolerance
 
-!FPT_PRO_EXT.2 !Data Integrity Measurements
-
 !FPT_MFW_EXT.2 !Firmware Integrity
 
 !FDP_FRS_EXT.2 !Factory Reset Behavior
@@ -4835,6 +4828,10 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 !FPT_FLS.1/FW !Failure with Preservation of Secure State (Firmware)
 
 !FPT_RPL.1/FW !Replay Detection (Firmware)
+
+!FPT_ROT_EXT.2 !Root of Trust for Measurements
+
+!FPT_ROT_EXT.4 !Root of Trust for Verification
 
 !===
 
@@ -4876,7 +4873,7 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 |A shortened name for Authentication Token.
 
 |Boot Critical Data 
-|Critical data that persists across power cycles and determines characteristics of the DSC. Examples of boot critical data can be DSC configuration settings, certificates, and the results of measurements obtained by the RoT for measurement.
+|Critical data that persists across power cycles and determines characteristics of the DSC. Examples of boot critical data can be DSC configuration settings, certificates, and the results of measurements obtained by the Root of Trust for measurement.
 
 |Boot Firmware 
 |The first firmware that executes during the boot process.
@@ -4941,29 +4938,20 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 |Root of Trust (RoT) 
 |A RoT performs one or more security specific functions; establishing the foundation on which all trust in a system is placed. [NIST-ROTM]
 
-|RoT for Authorization 
-|(As defined by [GP_ROT]) The RoT for Authorization provides reliable capabilities to assess authorization tokens and determine whether or not they satisfy policies for access control.
+|Root of Trust for Confidentiality
+|(As defined by [GP_ROT]) The Root of Trust for Confidentiality maintains shielded locations for the purpose of storing sensitive data, such as secret keys and passwords.
 
-|RoT for Confidentiality 
-|(As defined by [GP_ROT]) The RoT for Confidentiality maintains shielded locations for the purpose of storing sensitive data, such as secret keys and passwords.
+|Root of Trust for Integrity
+|(As defined by [GP_ROT]) The Root of Trust for Integrity maintains shielded locations for the purpose of storing and protecting the integrity of non-secret critical security parameters and platform characteristics. Critical security parameters include, but are not limited to, authorization values, public keys, and public key certificates.
 
-|RoT for Integrity 
-|(As defined by [GP_ROT]) The RoT for Integrity maintains shielded locations for the purpose of storing and protecting the integrity of non-secret critical security parameters and platform characteristics. Critical security parameters include, but are not limited to, authorization values, public keys, and public key certificates.
+|Root of Trust for Measurement
+|(As defined by [GP_ROT]) The Root of Trust for Measurement provides the ability to reliably create platform characteristics.
 
-|RoT for Measurement 
-|(As defined by [GP_ROT]) The RoT for Measurement provides the ability to reliably create platform characteristics.
+|Root of Trust for Reporting
+|(As defined by [GP_ROT]) The Root of Trust for Reporting reliably reports platform characteristics. It provides an interface that limits its services to providing reports on its platform characteristics authenticated by a platform identity.
 
-|RoT for Reporting 
-|(As defined by [GP_ROT]) The RoT for Reporting reliably reports platform characteristics. It provides an interface that limits its services to providing reports on its platform characteristics authenticated by a platform identity.
-
-|RoT for Storage 
-|A RoT that acts as the RoT for Confidentiality and the RoT for Integrity.
-
-|RoT for Update 
-|A RoT responsible for updating the firmware.
-
-|RoT for Verification 
-|A RoT responsible for verifying digital signatures.
+|Root of Trust for Verification
+|(As defined by [GP_ROT]) The Root of Trust for Verification verifies the integrity and authenticity of signed objects. Objects may include, but are not limited to, public keys, code, and data.
 
 |Security Data Element (SDE) 
 |A Critical Security Parameter, such as a cryptographic key or authorization token.
@@ -5244,7 +5232,7 @@ See [CC1] for other Common Criteria abbreviations and terminology.
 
 [GD] Grawrock, David. _Dynamics of a Trusted Platform: A building block approach_. Intel Press, 2009
 
-[GP_ROT] GlobalPlatform Technology. _Root of Trust Definitions and Requirements Version 1.1_. GlobalPlatform, June 2018
+[GP_ROT] GlobalPlatform Technology. _Root of Trust Definitions and Requirements Version 1.1.1_. GlobalPlatform, June 2022
 
 [NIST-ROTM] Lily Chen, Joshua Franklin, and Andrew Regenscheid. _NIST Special Publication 800-164 (Draft), Guidelines on Hardware Rooted Security in Mobile Devices (Draft)_, National Institute of Standards and Technology, October 2012
 


### PR DESCRIPTION
This PR contains 5 commits with the main goal to reduce the number of mandatory SFRs (just the number of SFRs in general) to allow more flexibility with the cPP.

#### Merging FPT_MFW_EXT.2 and FPT_MFW_EXT.3 is done as in #444, so that PR will be closed

Both FPT_MFW_EXT.2 and FPT_MFW_EXT.3 are selection-based SFRs that are only included when "mutable" firmware is used. There are no situations in which one is selected without the other. Consequently, it is more appropriate to merge these SFRs into one SFR that covers the requirements for both.

Additionally, FPT_MFW_EXT.2 seems to unnecessarily pull in requirements from the Root of Trust for Measurements. This seems like a scope creep that should be avoided, as some TOEs do not want/need to provide these measurements.

For this reason, the new SFR contains two core requirements: integrity checking on boot (i.e., before firmware execution), and integrity checking of firmware updates. The new SFR also forces the ST author to explicitly select the algorithms used to verify the integrity (and authenticity).

It is expected that the list of allowed cryptographic algorithms here should be reduced. While hash or MAC algorithms are sometimes used to verify the integrity of firmware prior to execution, it is almsot never appropriate to use symmetric (i.e., hash, MAC, AEAD) cryptography to verify firmware updates.

#### FPT_RPL.1/Rollback is renamed to FPT_RPL.1/FW

This is mainly for consistency with FPT_FLS.1/FW. However, I also want to point out that FPT_FLS.1/FW has significant overlap with FPT_RPL.1/Rollback and FPT_MFW_EXT.2. I prefer to avoid overlap.

#### FPT_TST.1 test are made more generic

Currently this SFR focuses heavily on TSF / TSF data integrity, but that's already covered by a lot of SFRs elsewhere (e.g., FPT_MFW_EXT.2, FPT_FLS.1/FW, some of the RoT SFRs). It makes more sense to focus on the cryptographic algorithm self-tests.

#### Root of Trust becomes a core SFR

The FPT_PRO_EXT.1, FPT_ROT_EXT.1, and FPT_ROT_EXT.2 SFRs were merged into one mandatory SFR called FPT_ROT_EXT.1. This SFR provides a few selections for the confidentiality and integrity of data. The idea is that a lot of the crypto SFRs can become selection-based based on these selections (not implemented yet). That would allow more flexibility for TOEs that don't support certain cryptographic algorithms. This SFR also specifies 3 RoT services that could be implemented (selection-based): Measurement, Reporting, and Verification.

Measurement and Reporting are simply FPT_PRO_EXT.2 and FPT_ROT_EXT.3 but renamed (and slightly edited). Verification is new, as it seems to be a useful service that can make use of the signature algorithms.

Finally, one thing to discuss here is whether or not FCS_STG_EXT.1 serves any purpose. It was already covered by the old Root of Trust for Storage, and there's many more SFRs that cover SDO protection, import, and export. Maybe it should be merged?

#### FDP_FRS_EXT.1 and FDP_FRS_EXT.2 are merged and selection-based

As explained in #474:

FDP_FRS_EXT.1 is currently a mandatory SFR but has the option "no actions or conditions" to allow the DSC **to** not support a factory reset. This does not make sense.

FMT_SMF.1 currently includes "Reset TOE to factory state for FDP_FRS_EXT.1" as a mandatory management function, but evidently the DSC is allowed to **not** support a factory reset. Again, this does not make sense.

The solution seems to be as follows:
- Move "Reset TOE to factory state for FDP_FRS_EXT.1" to the selection of management functions.
- Make FDP_FRS_EXT.1 selection-based and remove the "no actions or conditions option".

Now, it becomes straightforward to merge FDP_FRS_EXT.1 and FDP_FRS_EXT.2 into one SFR.