### PR TITLE
Make all FCS_COP SFRs selection-based

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -549,255 +549,6 @@ The evaluator shall examine the KMD to ensure that all keys and keying material 
 
 Note that where selections include 'destruction of reference to the key directly followed by a request for garbage collection' (for volatile memory) then the evaluator shall examine the KMD to ensure that it explains the nature of the destruction of the reference, the request for garbage collection, and of the garbage collection process itself.
 
-==== Cryptographic Operation (FCS_COP)
-
-===== FCS_COP.1/Hash Cryptographic Operation - Hashing
-
-====== TSS
-
-The evaluator shall check that the association of the hash function with other TSF cryptographic functions (for example, the digital signature verification function) is documented in the TSS. The evaluator shall also check that the TSS identifies whether the implementation is bit-oriented or byte-oriented.
-
-====== AGD
-
-The evaluator checks the AGD documents to determine that any configuration that is required to configure the required hash sizes is present. The evaluator also checks the AGD documents to confirm that the instructions for establishing the evaluated configuration use only those hash algorithms selected in the ST.
-
-====== Test
-
-The algorithm tests might require access to a development version of the TOE or a test platform that provides tools not typically found on factory products.
-
-The developer shall provide sufficient information to the evaluator to properly define the implementation of the algorithm. The evaluator shall define at least one test group (a configuration of algorithm properties and associated test cases) for each combination of the following parameters, according to the implementation of the algorithm:
-
-* Hash algorithm
-
-Each test group shall consist of at least 150 test cases meeting the following requirements:
-
-* Test cases shall be generated according to the parameter configuration of the test group.
-* Each test case shall consist of an arbitrary input message and its corresponding digest value.
-* A representative sample of the domain of supported input message sizes shall be tested.
-
-For each test case in each test group, the evaluator shall verify that the TSF generates the correct digest value.
-
-Additionally, each test group shall contain least one Monte Carlo Test (MCT) test case, consisting of an arbitrary seed and a list of 100 digest values. For hash algorithms, the MCT is defined as follows:
-----
-for i = 1 through 100
-    msg = seed
-    for j = 1 through 1000
-        digest = hash(msg)
-        msg = digest
-    output digest
-    seed = digest
-----
-
-For each MCT test case in each test group, the evaluator shall verify that the TSF generates the correct 100 digest values.
-
-The evaluator shall be able to provide a rationale as to the sufficiency of the test groups and test cases in exercising the algorithm. Test cases shall be generated using a known-good implementation to ensure the correct result is produced by the TSF. The evaluator shall determine the proper known-good implementation and provide a rationale for its use for testing. Internal or external implementations are acceptable with a sufficient rationale.
-
-====== KMD
-
-There are no KMD evaluation activities for this component.
-
-===== FCS_COP.1/KeyedHash Cryptographic Operation - Keyed Hash
-
-====== TSS
-
-The evaluator shall examine the TSS to ensure that it specifies the following values used by the HMAC and KMAC functions: output MAC length used.
-
-====== AGD
-
-There are no guidance evaluation activities for this component.
-
-====== Test
-
-The algorithm tests might require access to a development version of the TOE or a test platform that provides tools not typically found on factory products.
-
-The developer shall provide sufficient information to the evaluator to properly define the implementation of the algorithm. The evaluator shall define at least one test group (a configuration of algorithm properties and associated test cases) for each combination of the following parameters, according to the implementation of the algorithm:
-
-* Hash algorithm
-
-Each test group shall consist of at least 75 test cases meeting the following requirements:
-
-* Test cases shall be generated according to the parameter configuration of the test group.
-* Each test case shall consist of an arbitrary key, an arbitrary input message, and its corresponding MAC tag.
-* A representative sample of the domain of supported key sizes shall be tested.
-* A representative sample of the domain of supported input message sizes shall be tested.
-
-For each test case in each test group, the evaluator shall verify that the TSF generates the correct MAC tag.
-
-The evaluator shall be able to provide a rationale as to the sufficiency of the test groups and test cases in exercising the algorithm. Test cases shall be generated using a known-good implementation to ensure the correct result is produced by the TSF. The evaluator shall determine the proper known-good implementation and provide a rationale for its use for testing. Internal or external implementations are acceptable with a sufficient rationale.
-
-====== KMD
-
-There are no KMD evaluation activities for this component.
-
-===== FCS_COP.1/SigGen Cryptographic Operation - Signature Generation
-
-====== TSS
-
-The evaluator shall examine the TSS to ensure that all signature generation functions use the approved algorithms and key sizes.
-
-====== AGD
-
-There are no AGD evaluation activities for this component.
-
-====== Test
-
-The algorithm tests might require access to a development version of the TOE or a test platform that provides tools not typically found on factory products.
-
-The developer shall provide sufficient information to the evaluator to properly define the implementation of the algorithm. The evaluator shall define at least one test group (a configuration of algorithm properties and associated test cases) for each combination of the following parameters, according to the implementation of the algorithm:
-
-* Modulus size (RSA)
-* Curve (ECDSA, EC-KCDSA, EdDSA)
-* Group size (KCDSA)
-* Private key size (LMS, HSS, XMSS, XMSS^MT^)
-* Parameter set (ML-DSA, HashML-DSA)
-* Padding scheme (RSA)
-* Hash or XOF algorithm
-
-Each test group shall consist of at least 6 test cases meeting the following requirements:
-
-* Test cases shall be generated according to the parameter configuration of the test group.
-* Each test case shall consist of an arbitrary private key and an arbitrary input message to be signed.
-* A representative sample of the domain of supported message sizes shall be tested.
-
-For each test case in each test group, the evaluator shall verify that the TSF generates a signature that is structurally well-formed according to the relevant standard. Additionally, the evaluator shall use a known-good implementation to verify that the generated signature is indeed a valid signature on the input message.
-
-The evaluator shall be able to provide a rationale as to the sufficiency of the test groups and test cases in exercising the algorithm. Test cases shall be generated using a known-good implementation to ensure the correct result is produced by the TSF. The evaluator shall determine the proper known-good implementation and provide a rationale for its use for testing. Internal or external implementations are acceptable with a sufficient rationale.
-
-====== KMD
-
-There are no KMD evaluation activities for this component.
-
-===== FCS_COP.1/SigVer Cryptographic Operation - Signature Verification
-
-====== TSS
-
-The evaluator shall check the TSS to ensure that it describes the overall flow of the signature verification. This should at least include identification of the format and general location (e.g., "firmware on the hard drive device" rather than "memory location 0x00007A4B") of the data to be used in verifying the digital signature; how the data received from the operational environment are brought onto the device; and any processing that is performed that is not part of the digital signature algorithm (for instance, checking of certificate revocation lists).
-
-====== AGD
-
-There are no AGD evaluation activities for this component.
-
-====== Test
-
-The algorithm tests might require access to a development version of the TOE or a test platform that provides tools not typically found on factory products.
-
-The developer shall provide sufficient information to the evaluator to properly define the implementation of the algorithm. The evaluator shall define at least one test group (a configuration of algorithm properties and associated test cases) for each combination of the following parameters, according to the implementation of the algorithm:
-
-* Modulus size (RSA)
-* Curve (ECDSA, EC-KCDSA, EdDSA)
-* Group size (DSA, KCDSA)
-* Private key size (LMS, HSS, XMSS, XMSS^MT^)
-* Parameter set (ML-DSA, HashML-DSA)
-* Padding scheme (RSA)
-* Hash or XOF algorithm
-
-Each test group shall consist of at least 6 test cases meeting the following requirements:
-
-* Test cases shall be generated according to the parameter configuration of the test group.
-* Each test case shall consist of an arbitrary public key, an arbitrary input message, and a signature. For 5 of the 6 test cases, the public key or input message shall be modified such that the signature is invalid.
-* A representative sample of the domain of supported message sizes shall be tested.
-
-For each test case in each test group, the evaluator shall verify that the TSF correctly reports the validity of the signature for the input message.
-
-The evaluator shall be able to provide a rationale as to the sufficiency of the test groups and test cases in exercising the algorithm. Test cases shall be generated using a known-good implementation to ensure the correct result is produced by the TSF. The evaluator shall determine the proper known-good implementation and provide a rationale for its use for testing. Internal or external implementations are acceptable with a sufficient rationale.
-
-====== KMD
-
-There are no KMD evaluation activities for this component.
-
-===== FCS_COP.1/SKC Cryptographic Operation - Symmetric-Key Cryptography
-
-====== TSS
-
-The evaluator shall check that the TSS includes a description of encryption functions used for symmetric key encryption. The evaluator should check that this description of the selected encryption function includes the key sizes and modes of operations as specified in the [DSC cPP] Table "Symmetric-Key Cryptography"
-
-The evaluator shall check that the TSS describes the means by which the TOE satisfies constraints on algorithm parameters included in the selections made for 'cryptographic algorithm' and 'list of standards'. 
-
-====== AGD
-
-If the product supports multiple modes, the evaluator shall examine the vendor's documentation to determine that the method of choosing a specific mode/key size by the end user is described. 
-
-====== Test
-
-The algorithm tests might require access to a development version of the TOE or a test platform that provides tools not typically found on factory products.
-
-The developer shall provide sufficient information to the evaluator to properly define the implementation of the algorithm. The evaluator shall define at least one test group (a configuration of algorithm properties and associated test cases) for each combination of the following parameters, according to the implementation of the algorithm:
-
-* Mode of operation
-* Algorithm direction (encrypt/decrypt)
-* Key size
-
-For each test group, the evaluator shall generate at least 50 test cases meeting the following requirements:
-
-* Each test case shall consist of an arbitrary key, an arbitrary input plaintext/ciphertext, and its corresponding ciphertext/plaintext.
-* Depending on the mode of operation, an initialization vector, counter, or tweak value shall also be included in the test case.
-* A representative sample of the domain of supported input plaintext/ciphertext sizes shall be tested.
-* A representative sample of the domain of supported initialization vector sizes shall be tested (CBC, CFB, OFB mode).
-* A representative sample of the domain of supported counter sizes shall be tested (CTR mode).
-* A representative sample of the domain of supported tweak sizes shall be tested (XTS modes).
-
-For each test case in each test group, the evaluator shall verify that the TSF generates the correct ciphertext/plaintext.
-
-Additionally, each test group corresponding to a CBC, CFB, or OFB mode of operation shall contain least one Monte Carlo Test (MCT) test case, consisting of an arbitrary key, an arbitrary initialization vector, an arbitrary input plaintext/ciphertext, and a list of 100 corresponding ciphertexts/plaintexts.
-
-For encryption with a 128-bit block size, the MCT is defined as follows:
-----
-for i = 1 through 100
-    output key
-    output iv
-    output pt
-    encrypt_init(key, iv)
-    ct[1] = encrypt(pt)
-    pt = iv
-    for j = 2 through 1000
-        ct[j] = encrypt(pt)
-        pt = ct[j - 1]
-    output ct[j]
-    if key_len == block_size
-        key = key xor ct[j]
-    if 2 * key_len == 3 * block_size
-        key = key xor (lsb(ct[j - 1], block_size / 2) || ct[j])
-    if key_len == 2 * block_size
-        key = key xor (ct[j - 1] || ct[j])
-    iv = ct[j]
-    pt = ct[j - 1]
-----
-
-For decryption with a 128-bit block size, the MCT is defined as follows:
-----
-for i = 1 through 100
-    output key
-    output iv
-    output ct
-    decrypt_init(key, iv)
-    pt[1] = encrypt(ct)
-    ct = iv
-    for j = 2 through 1000
-        pt[j] = encrypt(ct)
-        ct = pt[j - 1]
-    output pt[j]
-    if key_len == block_size
-        key = key xor pt[j]
-    if 2 * key_len == 3 * block_size
-        key = key xor (lsb(pt[j - 1], block_size / 2) || pt[j])
-    if key_len == 2 * block_size
-        key = key xor (pt[j - 1] || pt[j])
-    iv = pt[j]
-    ct = pt[j - 1]
-----
-
-For each MCT test case in each test group, the evaluator shall verify that the TSF generates the correct 100 ciphertexts/plaintexts.
-
-The evaluator shall be able to provide a rationale as to the sufficiency of the test groups and test cases in exercising the algorithm. Test cases shall be generated using a known-good implementation to ensure the correct result is produced by the TSF. The evaluator shall determine the proper known-good implementation and provide a rationale for its use for testing. Internal or external implementations are acceptable with a sufficient rationale.
-
-====== KMD
-
-The evaluator shall examine the KMD to ensure that the points at which symmetric key encryption and decryption occurs are described, and that the complete data path for symmetric key encryption is described. The evaluator checks that this description is consistent with the relevant parts of the TSS.
-
-Assessment of the complete data path for symmetric key encryption includes confirming that the KMD describes the data flow from the device's host interface to the device's non-volatile memory storing the data, and gives information enabling the user data datapath to be distinguished from those situations in which data bypasses the data encryption engine (e.g. read-write operations to an unencrypted Master Boot Record area). The evaluator shall ensure that the documentation of the data path is detailed enough that it thoroughly describes the parts of the TOE that the data passes through (e.g. different memory types, processors and co-processors), its encryption state (i.e. encrypted or unencrypted) in each part, and any places where the data is stored. For example, any caching or buffering of the data should be identified and distinguished from the final destination in non-volatile memory (the latter represents the location from which the host will expect to retrieve the data in future).
-
-If support for AES-CTR is claimed and the counter value source is internal to the TOE, the evaluator shall verify that the KMD describes the internal counter mechanism used to ensure that it provides unique counter block values.
-
 ==== Random Bit Generation (FCS_RBG)
 
 ===== FCS_RBG.1 Random Bit Generation (RBG)
@@ -2081,6 +1832,84 @@ The evaluator shall be able to provide a rationale as to the sufficiency of the 
 
 There are no KMD evaluation activities for this component.
 
+===== FCS_COP.1/Hash Cryptographic Operation - Hashing
+
+====== TSS
+
+The evaluator shall check that the association of the hash function with other TSF cryptographic functions (for example, the digital signature verification function) is documented in the TSS. The evaluator shall also check that the TSS identifies whether the implementation is bit-oriented or byte-oriented.
+
+====== AGD
+
+The evaluator checks the AGD documents to determine that any configuration that is required to configure the required hash sizes is present. The evaluator also checks the AGD documents to confirm that the instructions for establishing the evaluated configuration use only those hash algorithms selected in the ST.
+
+====== Test
+
+The algorithm tests might require access to a development version of the TOE or a test platform that provides tools not typically found on factory products.
+
+The developer shall provide sufficient information to the evaluator to properly define the implementation of the algorithm. The evaluator shall define at least one test group (a configuration of algorithm properties and associated test cases) for each combination of the following parameters, according to the implementation of the algorithm:
+
+* Hash algorithm
+
+Each test group shall consist of at least 150 test cases meeting the following requirements:
+
+* Test cases shall be generated according to the parameter configuration of the test group.
+* Each test case shall consist of an arbitrary input message and its corresponding digest value.
+* A representative sample of the domain of supported input message sizes shall be tested.
+
+For each test case in each test group, the evaluator shall verify that the TSF generates the correct digest value.
+
+Additionally, each test group shall contain least one Monte Carlo Test (MCT) test case, consisting of an arbitrary seed and a list of 100 digest values. For hash algorithms, the MCT is defined as follows:
+----
+for i = 1 through 100
+    msg = seed
+    for j = 1 through 1000
+        digest = hash(msg)
+        msg = digest
+    output digest
+    seed = digest
+----
+
+For each MCT test case in each test group, the evaluator shall verify that the TSF generates the correct 100 digest values.
+
+The evaluator shall be able to provide a rationale as to the sufficiency of the test groups and test cases in exercising the algorithm. Test cases shall be generated using a known-good implementation to ensure the correct result is produced by the TSF. The evaluator shall determine the proper known-good implementation and provide a rationale for its use for testing. Internal or external implementations are acceptable with a sufficient rationale.
+
+====== KMD
+
+There are no KMD evaluation activities for this component.
+
+===== FCS_COP.1/KeyedHash Cryptographic Operation - Keyed Hash
+
+====== TSS
+
+The evaluator shall examine the TSS to ensure that it specifies the following values used by the HMAC and KMAC functions: output MAC length used.
+
+====== AGD
+
+There are no guidance evaluation activities for this component.
+
+====== Test
+
+The algorithm tests might require access to a development version of the TOE or a test platform that provides tools not typically found on factory products.
+
+The developer shall provide sufficient information to the evaluator to properly define the implementation of the algorithm. The evaluator shall define at least one test group (a configuration of algorithm properties and associated test cases) for each combination of the following parameters, according to the implementation of the algorithm:
+
+* Hash algorithm
+
+Each test group shall consist of at least 75 test cases meeting the following requirements:
+
+* Test cases shall be generated according to the parameter configuration of the test group.
+* Each test case shall consist of an arbitrary key, an arbitrary input message, and its corresponding MAC tag.
+* A representative sample of the domain of supported key sizes shall be tested.
+* A representative sample of the domain of supported input message sizes shall be tested.
+
+For each test case in each test group, the evaluator shall verify that the TSF generates the correct MAC tag.
+
+The evaluator shall be able to provide a rationale as to the sufficiency of the test groups and test cases in exercising the algorithm. Test cases shall be generated using a known-good implementation to ensure the correct result is produced by the TSF. The evaluator shall determine the proper known-good implementation and provide a rationale for its use for testing. Internal or external implementations are acceptable with a sufficient rationale.
+
+====== KMD
+
+There are no KMD evaluation activities for this component.
+
 ===== FCS_COP.1/KeyEncap Cryptographic Operation - Key Encapsulation
 
 ====== TSS
@@ -2159,6 +1988,175 @@ The evaluator shall be able to provide a rationale as to the sufficiency of the 
 ====== KMD
 
 The evaluator shall examine the KMD to ensure that it describes when the key wrapping occurs, that the KMD description is consistent with the description in the TSS, and that for all keys that are wrapped the TOE uses a method as described in the [DSC cPP] table. No uncertainty should be left over which is the wrapping key and the key to be wrapped and where the wrapping key potentially comes from i.e. is derived from.
+
+===== FCS_COP.1/SigGen Cryptographic Operation - Signature Generation
+
+====== TSS
+
+The evaluator shall examine the TSS to ensure that all signature generation functions use the approved algorithms and key sizes.
+
+====== AGD
+
+There are no AGD evaluation activities for this component.
+
+====== Test
+
+The algorithm tests might require access to a development version of the TOE or a test platform that provides tools not typically found on factory products.
+
+The developer shall provide sufficient information to the evaluator to properly define the implementation of the algorithm. The evaluator shall define at least one test group (a configuration of algorithm properties and associated test cases) for each combination of the following parameters, according to the implementation of the algorithm:
+
+* Modulus size (RSA)
+* Curve (ECDSA, EC-KCDSA, EdDSA)
+* Group size (KCDSA)
+* Private key size (LMS, HSS, XMSS, XMSS^MT^)
+* Parameter set (ML-DSA, HashML-DSA)
+* Padding scheme (RSA)
+* Hash or XOF algorithm
+
+Each test group shall consist of at least 6 test cases meeting the following requirements:
+
+* Test cases shall be generated according to the parameter configuration of the test group.
+* Each test case shall consist of an arbitrary private key and an arbitrary input message to be signed.
+* A representative sample of the domain of supported message sizes shall be tested.
+
+For each test case in each test group, the evaluator shall verify that the TSF generates a signature that is structurally well-formed according to the relevant standard. Additionally, the evaluator shall use a known-good implementation to verify that the generated signature is indeed a valid signature on the input message.
+
+The evaluator shall be able to provide a rationale as to the sufficiency of the test groups and test cases in exercising the algorithm. Test cases shall be generated using a known-good implementation to ensure the correct result is produced by the TSF. The evaluator shall determine the proper known-good implementation and provide a rationale for its use for testing. Internal or external implementations are acceptable with a sufficient rationale.
+
+====== KMD
+
+There are no KMD evaluation activities for this component.
+
+===== FCS_COP.1/SigVer Cryptographic Operation - Signature Verification
+
+====== TSS
+
+The evaluator shall check the TSS to ensure that it describes the overall flow of the signature verification. This should at least include identification of the format and general location (e.g., "firmware on the hard drive device" rather than "memory location 0x00007A4B") of the data to be used in verifying the digital signature; how the data received from the operational environment are brought onto the device; and any processing that is performed that is not part of the digital signature algorithm (for instance, checking of certificate revocation lists).
+
+====== AGD
+
+There are no AGD evaluation activities for this component.
+
+====== Test
+
+The algorithm tests might require access to a development version of the TOE or a test platform that provides tools not typically found on factory products.
+
+The developer shall provide sufficient information to the evaluator to properly define the implementation of the algorithm. The evaluator shall define at least one test group (a configuration of algorithm properties and associated test cases) for each combination of the following parameters, according to the implementation of the algorithm:
+
+* Modulus size (RSA)
+* Curve (ECDSA, EC-KCDSA, EdDSA)
+* Group size (DSA, KCDSA)
+* Private key size (LMS, HSS, XMSS, XMSS^MT^)
+* Parameter set (ML-DSA, HashML-DSA)
+* Padding scheme (RSA)
+* Hash or XOF algorithm
+
+Each test group shall consist of at least 6 test cases meeting the following requirements:
+
+* Test cases shall be generated according to the parameter configuration of the test group.
+* Each test case shall consist of an arbitrary public key, an arbitrary input message, and a signature. For 5 of the 6 test cases, the public key or input message shall be modified such that the signature is invalid.
+* A representative sample of the domain of supported message sizes shall be tested.
+
+For each test case in each test group, the evaluator shall verify that the TSF correctly reports the validity of the signature for the input message.
+
+The evaluator shall be able to provide a rationale as to the sufficiency of the test groups and test cases in exercising the algorithm. Test cases shall be generated using a known-good implementation to ensure the correct result is produced by the TSF. The evaluator shall determine the proper known-good implementation and provide a rationale for its use for testing. Internal or external implementations are acceptable with a sufficient rationale.
+
+====== KMD
+
+There are no KMD evaluation activities for this component.
+
+===== FCS_COP.1/SKC Cryptographic Operation - Symmetric-Key Cryptography
+
+====== TSS
+
+The evaluator shall check that the TSS includes a description of encryption functions used for symmetric key encryption. The evaluator should check that this description of the selected encryption function includes the key sizes and modes of operations as specified in the [DSC cPP] Table "Symmetric-Key Cryptography"
+
+The evaluator shall check that the TSS describes the means by which the TOE satisfies constraints on algorithm parameters included in the selections made for 'cryptographic algorithm' and 'list of standards'.
+
+====== AGD
+
+If the product supports multiple modes, the evaluator shall examine the vendor's documentation to determine that the method of choosing a specific mode/key size by the end user is described.
+
+====== Test
+
+The algorithm tests might require access to a development version of the TOE or a test platform that provides tools not typically found on factory products.
+
+The developer shall provide sufficient information to the evaluator to properly define the implementation of the algorithm. The evaluator shall define at least one test group (a configuration of algorithm properties and associated test cases) for each combination of the following parameters, according to the implementation of the algorithm:
+
+* Mode of operation
+* Algorithm direction (encrypt/decrypt)
+* Key size
+
+For each test group, the evaluator shall generate at least 50 test cases meeting the following requirements:
+
+* Each test case shall consist of an arbitrary key, an arbitrary input plaintext/ciphertext, and its corresponding ciphertext/plaintext.
+* Depending on the mode of operation, an initialization vector, counter, or tweak value shall also be included in the test case.
+* A representative sample of the domain of supported input plaintext/ciphertext sizes shall be tested.
+* A representative sample of the domain of supported initialization vector sizes shall be tested (CBC, CFB, OFB mode).
+* A representative sample of the domain of supported counter sizes shall be tested (CTR mode).
+* A representative sample of the domain of supported tweak sizes shall be tested (XTS modes).
+
+For each test case in each test group, the evaluator shall verify that the TSF generates the correct ciphertext/plaintext.
+
+Additionally, each test group corresponding to a CBC, CFB, or OFB mode of operation shall contain least one Monte Carlo Test (MCT) test case, consisting of an arbitrary key, an arbitrary initialization vector, an arbitrary input plaintext/ciphertext, and a list of 100 corresponding ciphertexts/plaintexts.
+
+For encryption with a 128-bit block size, the MCT is defined as follows:
+----
+for i = 1 through 100
+    output key
+    output iv
+    output pt
+    encrypt_init(key, iv)
+    ct[1] = encrypt(pt)
+    pt = iv
+    for j = 2 through 1000
+        ct[j] = encrypt(pt)
+        pt = ct[j - 1]
+    output ct[j]
+    if key_len == block_size
+        key = key xor ct[j]
+    if 2 * key_len == 3 * block_size
+        key = key xor (lsb(ct[j - 1], block_size / 2) || ct[j])
+    if key_len == 2 * block_size
+        key = key xor (ct[j - 1] || ct[j])
+    iv = ct[j]
+    pt = ct[j - 1]
+----
+
+For decryption with a 128-bit block size, the MCT is defined as follows:
+----
+for i = 1 through 100
+    output key
+    output iv
+    output ct
+    decrypt_init(key, iv)
+    pt[1] = encrypt(ct)
+    ct = iv
+    for j = 2 through 1000
+        pt[j] = encrypt(ct)
+        ct = pt[j - 1]
+    output pt[j]
+    if key_len == block_size
+        key = key xor pt[j]
+    if 2 * key_len == 3 * block_size
+        key = key xor (lsb(pt[j - 1], block_size / 2) || pt[j])
+    if key_len == 2 * block_size
+        key = key xor (pt[j - 1] || pt[j])
+    iv = pt[j]
+    ct = pt[j - 1]
+----
+
+For each MCT test case in each test group, the evaluator shall verify that the TSF generates the correct 100 ciphertexts/plaintexts.
+
+The evaluator shall be able to provide a rationale as to the sufficiency of the test groups and test cases in exercising the algorithm. Test cases shall be generated using a known-good implementation to ensure the correct result is produced by the TSF. The evaluator shall determine the proper known-good implementation and provide a rationale for its use for testing. Internal or external implementations are acceptable with a sufficient rationale.
+
+====== KMD
+
+The evaluator shall examine the KMD to ensure that the points at which symmetric key encryption and decryption occurs are described, and that the complete data path for symmetric key encryption is described. The evaluator checks that this description is consistent with the relevant parts of the TSS.
+
+Assessment of the complete data path for symmetric key encryption includes confirming that the KMD describes the data flow from the device's host interface to the device's non-volatile memory storing the data, and gives information enabling the user data datapath to be distinguished from those situations in which data bypasses the data encryption engine (e.g. read-write operations to an unencrypted Master Boot Record area). The evaluator shall ensure that the documentation of the data path is detailed enough that it thoroughly describes the parts of the TOE that the data passes through (e.g. different memory types, processors and co-processors), its encryption state (i.e. encrypted or unencrypted) in each part, and any places where the data is stored. For example, any caching or buffering of the data should be identified and distinguished from the final destination in non-volatile memory (the latter represents the location from which the host will expect to retrieve the data in future).
+
+If support for AES-CTR is claimed and the counter value source is internal to the TOE, the evaluator shall verify that the KMD describes the internal counter mechanism used to ensure that it provides unique counter block values.
 
 ===== FCS_COP.1/XOF Extendable-Output Function
 

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -679,453 +679,6 @@ _The selection for destruction of data in non-volatile memory includes block era
 +
 _Some selections allow assignment of "some value that does not contain any CSP." This means that the TOE uses some specified data not drawn from an RBG meeting FCS_RBG requirements, and not being any of the particular values listed as other selection options. The point of the phrase "does not contain any sensitive data" is to ensure that the overwritten data is carefully selected, and not taken from a general pool that might contain data that itself requires confidentiality protection._
 
-==== FCS_COP.1/Hash Cryptographic Operation - Hashing
-
-FCS_COP.1/Hash Cryptographic Operation - Hashing
-
-FCS_COP.1.1/Hash:: The TSF shall perform [_cryptographic hashing_] in accordance with a specified cryptographic algorithm [*selection*: _SHA-1, SHA-224, SHA-256, SHA-384, SHA-512, SHA-512/224, SHA-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512_] that meets the following: [*selection*: _ISO/IEC 10118-3:2018 [SHA, SHA3], FIPS PUB 180-4 [SHA], FIPS PUB 202 [SHA3]_].
-
-_Application Note {counter:remark_count}_:: _SHA-1 is allowed in cases where collision resistance is not required. SHA-1 may be used for the following applications: generating and verifying hash-based message authentication codes (HMACs), key derivation functions (KDFs), and random bit/number generation. SHA-1 may also be used for verifying old digital signatures and time stamps, if this is explicitly allowed by the application domain._
-
-==== FCS_COP.1/KeyedHash Cryptographic Operation - Keyed Hash
-
-FCS_COP.1/KeyedHash Cryptographic Operation - Keyed Hash
-
-FCS_COP.1.1/KeyedHash:: The TSF shall perform [_keyed hash message authentication_] in accordance with a specified cryptographic algorithm [*selection*: _keyed hash algorithm_] and cryptographic key sizes [*selection*: _cryptographic key size_] that meet the following: [*selection*: _list of standards_].
-
-The following table provides the allowed choices for completion of the selection operations of FCS_COP.1/KeyedHash.
-
-.Allowed choices for FCS_COP.1/KeyedHash
-[[KeyedHashAlgorithms]]
-[cols=".^1,.^1,.^3",options=header]
-|===
-
-|Keyed Hash Algorithm
-|Cryptographic Key Sizes
-|List of Standards
-
-|HMAC-SHA-1
-|[selection: (ISO, FIPS) 160, (FIPS) 128] bits
-|[selection: ISO/IEC 9797-2:2021 (Section 7 "MAC Algorithm 2"); FIPS PUB 198-1]
-
-|HMAC-SHA-224
-|[selection: (ISO, FIPS) 224, (FIPS) 192, 128] bits
-|[selection: ISO/IEC 9797-2:2021 (Section 7 "MAC Algorithm 2"); FIPS PUB 198-1]
-
-|HMAC-SHA-256
-|[selection: (ISO, FIPS) 256, (FIPS) 192, 128] bits
-|[selection: ISO/IEC 9797-2:2021 (Section 7 "MAC Algorithm 2"); FIPS PUB 198-1]
-
-|HMAC-SHA-384
-|[selection: (ISO, FIPS) 384, (FIPS) 256, 192, 128] bits
-|[selection: ISO/IEC 9797-2:2021 (Section 7 "MAC Algorithm 2"); FIPS PUB 198-1]
-
-|HMAC-SHA-512
-|[selection: (ISO, FIPS) 512, (FIPS) 384, 256, 192, 128] bits
-|[selection: ISO/IEC 9797-2:2021 (Section 7 "MAC Algorithm 2"); FIPS PUB 198-1]
-
-|KMAC128
-|128 bits
-|[selection: ISO/IEC 9797-2:2021 (Section 9 "MAC Algorithm 4"); NIST SP 800-185 (Section 4 "KMAC")]
-
-|KMAC256
-|256 bits
-|[selection: ISO/IEC 9797-2:2021 (Section 9 "MAC Algorithm 4"); NIST SP 800-185 (Section 4 "KMAC")]
-
-|KMACXOF128
-|[assignment: integer 256 <= Lk < 2^2040^]
-|[selection: ISO/IEC 9797-2:2021 (Section 9 "MAC Algorithm 4"); NIST SP 800-185 (Section 4 "KMAC")]
-
-|KMACXOF256
-|[assignment: integer 256 <= Lk < 2^2040^]
-|[selection: ISO/IEC 9797-2:2021 (Section 9 "MAC Algorithm 4"); NIST SP 800-185 (Section 4 "KMAC")]
-
-|===
-
-_Application Note {counter:remark_count}_:: _The HMAC minimum key sizes in the table are specified in ISO/IEC 9797-2:2021, which requires that the minimum key size be equal to the digest size. The FIPS standard specifies no minimum or maximum key sizes, so if FIPS PUB 198-1 is selected, larger or smaller key sizes may be used. This is indicted by the parenthesized annotations in the Cryptographic Key Sizes column._
-
-==== FCS_COP.1/SigGen Cryptographic Operation - Signature Generation
-
-FCS_COP.1/SigGen Cryptographic Operation - Signature Generation
-
-FCS_COP.1.1/SigGen:: The TSF shall perform [_digital signature generation_] in accordance with a specified cryptographic algorithm [*selection*: _cryptographic algorithm_] and cryptographic *algorithm parameters* [*selection*: _cryptographic algorithm parameters_] that meet the following: [*selection*: _list of standards_].
-
-The following table provides the allowed choices for completion of the selection operations of FCS_COP.1/SigGen.
-
-.Allowed choices for FCS_COP.1/SigGen
-[[SigGenOps]]
-[cols=".^1,.^2,.^2,.^2",options=header]
-|===
-
-|Identifier
-|Cryptographic Algorithm
-|Cryptographic Algorithm Parameters
-|List of Standards
-
-|RSA-PKCS
-|RSASSA-PKCS1-v1_5
-|Modulus of size [selection: 2048, 3072, 4096] bits, hash or XOF [selection: SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512]
-|RFC 8017 (Section 8.2) [PKCS #1 v2.2]
-
-FIPS PUB 186-5 (Section 5.4) [RSASSA-PKCS1-v1_5]
-
-|RSA-PSS
-|RSASSA-PSS
-|Modulus of size [selection: 2048, 3072, 4096] bits, hash or XOF [selection: SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512, SHAKE128 with 256-bit output, SHAKE256 with 512-bit output]
-|RFC 8017 (Section 8.1) [PKCS #1 v2.2]
-
-FIPS PUB 186-5 (Section 5.4) [RSASSA-PSS]
-
-|ECDSA
-|ECDSA
-|Elliptic Curve [selection: P-256, brainpoolP256r1, P-384, brainpoolP384r1, P-521, brainpoolP512r1], per-message secret number generation [selection: extra random bits, rejection sampling, deterministic] and hash or XOF function using [selection: SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512, SHAKE128 with 256-bit output, SHAKE256 with 512-bit output]
-|[selection: ISO/IEC 14888-3:2018 (Subclause 6.6), FIPS PUB 186-5 (Sections 6.3.1, 6.4.1)] [ECDSA]
-
-[selection: RFC 5639 (Section 3) [Brainpool Curves], NIST SP-800 186 (Section 4) [NIST Curves]]
-
-|KCDSA
-|KCDSA
-|hash function using [selection: SHA-224, SHA-256, SHA-384, SHA-512]
-|ISO/IEC 14888-3:2018 (Subclause 6.3) [KCDSA]
-
-|EC-KCDSA
-|EC-KCDSA 
-|Elliptic Curve [selection: P-224, P-256, B-233, B-283, K-233, K-283] using hash [selection: SHA-224, SHA-256, SHA-384, SHA-512]
-|ISO/IEC 14888-3:2018 (Subclause 6.7) [EC-KCDSA]
-
-NIST SP 800-186 (Section 3) [NIST Curves]
-
-|EdDSA
-|Edwards-Curve Digital Signature Algorithm
-|Domain parameters approved for elliptic curves [selection: Edwards25519, Edwards448]
-|NIST FIPS PUB 186-5 (Section 7.6) [EdDSA]
-
-RFC 8032 [Edwards Curves]
-
-|LMS
-|LMS
-|Private key size = [selection: 192 bits with [selection: SHA-256/192, SHAKE256/192], 256 bits with [selection: SHA-256, SHAKE256]], Winternitz parameter = [selection: 1, 2, 4, 8], and tree height = [selection: 5, 10, 15, 20, 25]
-|RFC 8554 [LMS]
-
-NIST SP 800-208 [parameters]
-
-|HSS
-|Multitree version of LMS
-|Private key size = [selection: 192 bits with [selection: SHA-256/192, SHAKE256/192], 256 bits with [selection: SHA-256, SHAKE256]], Winternitz parameter = [selection: 1, 2, 4, 8], tree height = [selection: 5, 10, 15, 20, 25], and number of levels = [selection: 1, 2, 3, 4, 5, 6, 7, 8]
-|RFC 8554 [HSS]
-
-NIST SP 800-208 [parameters]
-
-|XMSS
-|XMSS
-|Private key size = [selection: 192 bits with [selection: SHA-256/192, SHAKE256/192], 256 bits with [selection: SHA-256, SHAKE256]], tree height = [selection: 10, 16, 20]
-|RFC 8391 [XMSS]
-
-NIST SP 800-208 [parameters]
-
-|XMSS^MT^
-|Multitree version of XMSS
-|Private key size = [selection: 192 bits with [selection: SHA-256/192, SHAKE256/192], 256 bits with [selection: SHA-256, SHAKE256]], (total tree height, number of levels) = [selection: (20, 2), (20, 4), (40, 2), (40, 4), (40, 8), (60, 3), (60, 6), (60, 12)]
-|RFC 8391 [XMSS^MT^]
-
-NIST SP 800-208 [parameters]
-
-|ML-DSA
-|ML-DSA.Sign
-|Parameter set = [selection: ML-DSA-44, ML-DSA-65, ML-DSA-87]
-|NIST FIPS 204 (Section 5.2)
-
-|HashML-DSA
-|HashML-DSA.Sign
-|Parameter set = [selection: ML-DSA-44, ML-DSA-65, ML-DSA-87] and hash function [selection: SHA-256, SHA-512/256, SHA3-256, SHAKE128, SHA-384, SHA3-384, SHA-512, SHA3-512, SHAKE256]
-|NIST FIPS 204 (Section 5.4)
-
-|===
-
-_Application Note {counter:remark_count}_:: _The dependency on FCS_OTV_EXT.1 is needed only for signature schemes that require random bits, such as ECDSA, KCDSA, or EC-KCDSA._
-+
-_For LMS, HSS, XMSS, and XMSS^MT^, the key sizes do not represent the expected security strength. All key sizes given here correspond to an expected security strength of 128 bits, per NIST SP 800-208._
-+
-_For HSS and XMSS^MT^ the same hash or XOF function shall be used at each level. Within each level, the same Winternitz parameter shall be used but can be different for each level. For HSS, within each level, the same tree height shall be used but can be different for each level._
-+
-_Per Section 5.4 of NIST FIPS 204, the collision strength of the hash function selected for the pre-hash of HashML-DSA must be at least the strength of the signature algorithm._
-
-==== FCS_COP.1/SigVer Cryptographic Operation - Signature Verification
-
-FCS_COP.1/SigVer Cryptographic Operation - Signature Verification
-
-FCS_COP.1.1/SigVer:: The TSF shall perform [_digital signature verification_] in accordance with a specified cryptographic algorithm [*selection*: _cryptographic algorithm_] and cryptographic *algorithm parameters* [*selection*: _cryptographic algorithm parameters_] that meet the following: [*selection*: _list of standards_].
-
-
-The following table provides the allowed choices for completion of the selection operations of FCS_COP.1/SigVer.
-
-.Allowed choices for FCS_COP.1/SigVer
-[[SigVerOps]]
-[cols=".^1,.^2,.^2,.^2",options=header]
-|===
-
-|Identifier
-|Cryptographic Algorithm
-|Cryptographic Algorithm Parameters
-|List of Standards
-
-|RSA-PKCS
-|RSASSA-PKCS1-v1_5
-|Modulus of size [selection: 2048, 3072, 4096] bits, hash or XOF [selection: SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512]
-|RFC 8017 (Section 8.2) [PKCS #1 v2.2]
-
-FIPS PUB 186-5 (Section 5.4) [RSASSA-PKCS1-v1_5]
-
-|RSA-PSS
-|RSASSA-PSS
-|Modulus of size [selection: 2048, 3072, 4096] bits, hash or XOF [selection: SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512, SHAKE128 with 256-bit output, SHAKE256 with 512-bit output]
-|RFC 8017 (Section 8.1) [PKCS #1 v2.2]
-
-FIPS PUB 186-5 (Section 5.4) [RSASSA-PSS]
-
-|DSA
-|DSA
-|Domain parameters for (L, N) = [selection: (2048, 224), (2048, 256), (3072, 256)] bits
-|FIPS PUB 186-4 (Section 4.7) [DSA Signature Verification]
-
-|ECDSA
-|ECDSA
-|Elliptic Curve [selection: P-256, brainpoolP256r1, P-384, brainpoolP384r1, P-521, brainpoolP512r1] using hash or XOF function using [selection: SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512, SHAKE128 with 256-bit output, SHAKE256 with 512-bit output]
-|[selection: ISO/IEC 14888-3:2018 (Subclause 6.6), FIPS PUB 186-5 (Section 6.4.2)] [ECDSA]
-
-[selection: RFC 5639 (Section 3) [Brainpool Curves], NIST SP-800 186 (Section 4) [NIST Curves]]
-
-|KCDSA
-|KCDSA
-|hash function using [selection: SHA-224, SHA-256, SHA-384, SHA-512]
-|ISO/IEC 14888-3:2018 (Subclause 6.3) [KCDSA]
-
-|EC-KCDSA
-|EC-KCDSA
-|Elliptic Curve [selection: P-224, P-256, B-233, B-283, K-233, K-283] using hash [selection: SHA-224, SHA-256, SHA-384, SHA-512]
-|ISO/IEC 14888-3:2018 (Subclause 6.7) [EC-KCDSA]
-
-NIST SP 800-186 (Section 3) [NIST Curves]
-
-|EdDSA
-|Edwards-Curve Digital Signature Algorithm
-|Domain parameters approved for elliptic curves [selection: Edwards25519, Edwards448]
-|NIST FIPS PUB 186-5 (Section 7.7) [EdDSA]
-
-RFC 8032 [Edwards Curves]
-
-|LMS
-|LMS
-|Private key size = [selection: 192 bits with [selection: SHA-256/192, SHAKE256/192], 256 bits with [selection: SHA-256, SHAKE256]], Winternitz parameter = [selection: 1, 2, 4, 8], and tree height = [selection: 5, 10, 15, 20, 25]
-|RFC 8554 [LMS]
-
-NIST SP 800-208 [parameters]
-
-|HSS
-|Multitree version of LMS
-|Private key size = [selection: 192 bits with [selection: SHA-256/192, SHAKE256/192], 256 bits with [selection: SHA-256, SHAKE256]], Winternitz parameter = [selection: 1, 2, 4, 8], tree height = [selection: 5, 10, 15, 20, 25], and number of levels = [selection: 1, 2, 3, 4, 5, 6, 7, 8]
-|RFC 8554 [HSS]
-
-NIST SP 800-208 [parameters]
-
-|XMSS
-|XMSS
-|Private key size = [selection: 192 bits with [selection: SHA-256/192, SHAKE256/192], 256 bits with [selection: SHA-256, SHAKE256]], tree height = [selection: 10, 16, 20]
-|RFC 8391 [XMSS]
-
-NIST SP 800-208 [parameters]
-
-|XMSS^MT^
-|Multitree version of XMSS
-|Private key size = [selection: 192 bits with [selection: SHA-256/192, SHAKE256/192], 256 bits with [selection: SHA-256, SHAKE256]], (total tree height, number of levels) = [selection: (20, 2), (20, 4), (40, 2), (40, 4), (40, 8), (60, 3), (60, 6), (60, 12)]
-|RFC 8391 [XMSS^MT^]
-
-NIST SP 800-208 [parameters]
-
-|ML-DSA
-|ML-DSA.Verify
-|Parameter set = [selection: ML-DSA-44, ML-DSA-65, ML-DSA-87]
-|NIST FIPS 204 (Section 5.3)
-
-|HashML-DSA
-|HashML-DSA.Verify
-|Parameter set = [selection: ML-DSA-44, ML-DSA-65, ML-DSA-87] and hash function [selection: SHA-256, SHA-512/256, SHA3-256, SHAKE128, SHA-384, SHA3-384, SHA-512, SHA3-512, SHAKE256]
-|NIST FIPS 204 (Section 5.4)
-
-|===
-
-_Application Note {counter:remark_count}_:: _DSA may only be used to verify signatures generated prior to the implementation date of FIPS 186-5._
-+
-_The TOE may contain a public key which is integrity protected (e.g., in hardware), in which case the FDP_ITC.1 and FDP_ITC.2 dependencies do not apply. In this case, no dependencies may be chosen._
-+
-_For signature verifications, private keys are not necessary, so there are no dependencies required for generating or destroying cryptographic keys._
-+
-_For LMS, HSS, XMSS, and XMSS^MT^, the key sizes do not represent the expected security strength. All key sizes given here correspond to an expected security strength of 128 bits, per NIST SP 800-208._
-+
-_For HSS and XMSS^MT^ the same hash or XOF function shall be used at each level. Within each level, the same Winternitz parameter shall be used but can be different for each level. For HSS, within each level, the same tree height shall be used but can be different for each level._
-+
-_Per Section 5.4 of NIST FIPS 204, the collision strength of the hash function selected for the pre-hash of HashML-DSA must be at least the strength of the signature algorithm._
-
-==== FCS_COP.1/SKC Cryptographic Operation - Symmetric-Key Cryptography
-
-FCS_COP.1/SKC Cryptographic Operation - Symmetric-Key Cryptography
-
-FCS_COP.1.1/SKC:: The TSF shall perform [_symmetric-key encryption/decryption_] in accordance with a specified cryptographic algorithm [*selection*: _cryptographic algorithm_] and cryptographic key sizes [*selection*: _cryptographic key sizes_] that meet the following: [*selection*: _list of standards_].
-
-The following table provides the allowed choices for completion of the selection operations of FCS_COP.1/SKC.
-
-.Allowed choices for FCS_COP.1/SKC
-[[SymmetricKeyCrypto]]
-[cols=".^1,.^2,.^2,.^2",options=header]
-|===
-
-|Identifier
-|Cryptographic Algorithm
-|Cryptographic Key Sizes
-|List of Standards
-
-|AES-CBC
-|AES in CBC mode with IVs generated according to FCS_OTV_EXT.1
-|[selection: 128, 192, 256] bits
-|[selection: ISO/IEC 18033-3:2010 (Subclause 5.2), FIPS PUB 197] [AES]
-
-[selection: ISO/IEC 10116:2017 (Clause 7), NIST SP 800-38A] [CBC]
-
-|XTS-AES
-|AES in XTS mode with tweak values generated according to FCS_OTV_EXT.1
-|[selection: 256, 512] bits
-|[selection: ISO/IEC 18033-3:2010 (Subclause 5.2), FIPS PUB 197] [AES]
-
-[selection: IEEE Std. 1619-2018, NIST SP 800-38E] [XTS]
-
-|AES-CTR
-|AES in CTR mode with counter values generated according to FCS_OTV_EXT.1
-|[selection: 128, 192, 256] bits
-|[selection: ISO/IEC 18033-3:2010 (Subclause 5.2), FIPS PUB 197] [AES]
-
-[selection: ISO/IEC 10116:2017 (Clause 10), NIST SP 800-38A] [CTR]
-
-|CAM-CBC
-|Camellia in CBC mode with IVs generated according to FCS_OTV_EXT.1
-|[selection: 128, 192, 256] bits
-|ISO/IEC 18033-3:2010 (Subclause 5.3) [Camellia]
-
-[selection: ISO/IEC 10116:2017 (Clause 7), NIST SP 800-38A] [CBC]
-
-|CAM-CFB
-|Camellia in CFB mode with IVs generated according to FCS_OTV_EXT.1
-|[selection: 128, 192, 256] bits
-|ISO/IEC 18033-3:2010 (Subclause 5.3) [Camellia]
-
-[selection: ISO/IEC 10116:2017 (Clause 8), NIST SP 800-38A] [CFB]
-
-|CAM-OFB
-|Camellia in OFB mode with IVs generated according to FCS_OTV_EXT.1
-|[selection: 128, 192, 256] bits
-|ISO/IEC 18033-3:2010 (Subclause 5.3) [Camellia]
-
-[selection: ISO/IEC 10116:2017 (Clause 9), NIST SP 800-38A] [CFB]
-
-|XTS-CAM
-|Camellia in XTS mode with tweak values generated according to FCS_OTV_EXT.1
-|[selection: 256, 512] bits
-|ISO/IEC 18033-3:2010 (Subclause 5.3) [Camellia]
-
-[selection: IEEE Std. 1619-2018, NIST SP 800-38E] [XTS]
-
-|CAM-CTR
-|Camellia in CTR mode with counter values generated according to FCS_OTV_EXT.1
-|[selection: 128, 192, 256] bits
-|ISO/IEC 18033-3:2010 (Subclause 5.3) [Camellia]
-
-[selection: ISO/IEC 10116:2017 (Clause 10), NIST SP 800-38A] [CTR]
-
-|SEED-CBC
-|SEED in CBC mode with IVs generated according to FCS_OTV_EXT.1
-|128 bits
-|ISO/IEC 18033-3:2010 (Subclause 5.4) [SEED]
-
-[selection: ISO/IEC 10116:2017 (Clause 7), NIST SP 800-38A] [CBC]
-
-|SEED-CFB
-|SEED in CFB mode with IVs generated according to FCS_OTV_EXT.1
-|128 bits
-|ISO/IEC 18033-3:2010 (Subclause 5.4) [SEED]
-
-[selection: ISO/IEC 10116:2017 (Clause 8), NIST SP 800-38A] [CFB]
-
-|SEED-OFB
-|SEED in OFB mode with IVs generated according to FCS_OTV_EXT.1
-|128 bits
-|ISO/IEC 18033-3:2010 (Subclause 5.4) [SEED]
-
-[selection: ISO/IEC 10116:2017 (Clause 9), NIST SP 800-38A] [OFB]
-
-|SEED-CTR
-|SEED in CTR mode with counter values generated according to FCS_OTV_EXT.1
-|128 bits
-|ISO/IEC 18033-3:2010 (Subclause 5.4) [SEED]
-
-[selection: ISO/IEC 10116:2017 (Clause 10), NIST SP 800-38A] [CTR]
-
-|HIGHT-CBC
-|HIGHT in CBC mode with IVs generated according to FCS_OTV_EXT.1
-|128 bits
-|ISO/IEC 18033-3:2010 (Subclause 4.5) [HIGHT]
-
-[selection: ISO/IEC 10116:2017 (Clause 7), NIST SP 800-38A] [CBC]
-
-|HIGHT-CFB
-|HIGHT in CFB mode with IVs generated according to FCS_OTV_EXT.1
-|128 bits
-|ISO/IEC 18033-3:2010 (Subclause 4.5) [HIGHT]
-
-[selection: ISO/IEC 10116:2017 (Clause 8), NIST SP 800-38A] [CFB]
-
-|HIGHT-OFB
-|HIGHT in OFB mode with IVs generated according to FCS_OTV_EXT.1
-|128 bits
-|ISO/IEC 18033-3:2010 (Subclause 4.5) [HIGHT]
-
-[selection: ISO/IEC 10116:2017 (Clause 9), NIST SP 800-38A] [OFB]
-
-|HIGHT-CTR
-|HIGHT in CTR mode with counter values generated according to FCS_OTV_EXT.1
-|128 bits
-|ISO/IEC 18033-3:2010 (Subclause 4.5) [HIGHT]
-
-[selection: ISO/IEC 10116:2017 (Clause 10), NIST SP 800-38A] [CTR]
-
-|LEA-CBC
-|LEA in CBC mode with IVs generated according to FCS_OTV_EXT.1
-|[selection: 128, 192, 256] bits
-|ISO/IEC 29192-2:2019 (Subclause 6.3) [LEA]
-
-[selection: ISO/IEC 10116:2017 (Clause 7), NIST SP 800-38A] [CBC]
-
-|LEA-CFB
-|LEA in CFB mode with IVs generated according to FCS_OTV_EXT.1
-|[selection: 128, 192, 256] bits
-|ISO/IEC 29192-2:2019 (Subclause 6.3) [LEA]
-
-[selection: ISO/IEC 10116:2017 (Clause 8), NIST SP 800-38A] [CFB]
-
-|LEA-OFB
-|LEA in OFB mode with IVs generated according to FCS_OTV_EXT.1
-|[selection: 128, 192, 256] bits
-|ISO/IEC 29192-2:2019 (Subclause 6.3) [LEA]
-
-[selection: ISO/IEC 10116:2017 (Clause 9), NIST SP 800-38A] [OFB]
-
-|LEA-CTR
-|LEA in CTR mode with counter values generated according to FCS_OTV_EXT.1
-|[selection: 128, 192, 256] bits
-|ISO/IEC 29192-2:2019 (Subclause 6.3) [LEA]
-
-[selection: ISO/IEC 10116:2017 (Clause 10), NIST SP 800-38A] [CTR]
-
-|===
-
 ==== FCS_RBG.1 Random Bit Generation (RBG)
 
 FCS_RBG.1 Random Bit Generation (RBG)
@@ -1674,7 +1227,7 @@ _The SDO.AuthData attribute is data that is required in order to validate author
 +
 _The SDO.Reauth attribute for an individual SDO specifies the conditions where access to the SDO will require reauthorization to continue access to the SDO. Examples of TOE-specified events might be explicit revocation of authorization by a user, expiry of a time interval, or completion of a fixed number of uses since the last authorization. The re-authorization conditions are used in FIA_UAU.6 and FDP_ACF.1. These determine whether a single authorization by the SDO owner will allow any number of uses of the SDO until the end of the user's session (value 'none'), or whether each use of the SDO must be individually authorized (value 'each access'), or whether re-authorization must happen each time one of the TOE-specified events occurs._
 +
-_The SDO.Conf attribute indicates which SDEs, if any, the TOE encrypts when not in operational use. The TOE should use the methods in FCS_COP.1/AEAD, FCS_COP.1/SKC, FCS_STG_EXT.1, or FCS_CKM_EXT.3 to protect the SDEs in this list._
+_The SDO.Conf attribute indicates which SDEs, if any, the TOE encrypts when not in operational use. The TOE should use the methods in FCS_COP.1/AEAD, FCS_COP.1/KeyEncap, FCS_COP.1/KeyWrap, FCS_COP.1/SKC, FCS_STG_EXT.1, or FCS_CKM_EXT.3 to protect the SDEs in this list._
 +
 _The SDO.Integrity attribute includes evidence that the TSF can use to protect and verify the integrity of the SDO._
 +
@@ -1940,15 +1493,21 @@ The following rationale provides justification for each security problem definit
 |FDP_FRS_EXT.1 (selection-based)
 |This requirement ensures that all user-specific SDOs are purged upon factory reset and may indicate any factory default SDOs that are reset to their initial values.
 
-.12+|T.SDE_TRANSIT_COMPROMISE
+.13+|T.SDE_TRANSIT_COMPROMISE
 |FCS_CKM.6
 |This requirement ensures that key data is destroyed in a manner that prevents its future recovery.
 
 |FCS_COP.1/AEAD (selection-based)
-|This requirement provides a cryptographic operation for maintaining the confidentiality and integrity of SDOs.
+|This requirement provides a cryptographic operation for maintaining the confidentiality and integrity of SDEs and SDOs.
 
-|FCS_COP.1/SKC
-|This requirement provides a cryptographic operation for maintaining the confidentiality of SDOs.
+|FCS_COP.1/KeyEncap (selection-based)
+|This requirement provides a cryptographic operation for maintaining the confidentiality of SDEs.
+
+|FCS_COP.1/KeyWrap (selection-based)
+|This requirement provides a cryptographic operation for maintaining the confidentiality of SDEs.
+
+|FCS_COP.1/SKC (selection-based)
+|This requirement provides a cryptographic operation for maintaining the confidentiality of SDEs.
 
 |FDP_ETC_EXT.2
 |This requirement ensures that the confidentiality of protected data propagated outside the TOE is maintained.
@@ -1974,21 +1533,28 @@ The following rationale provides justification for each security problem definit
 |FTP_ITE_EXT.1 (selection-based)
 |This requirement defines the cryptographic method used to transfer data between the TOE and external entities.
 
+.1+|T.SDE_TRANSIT_COMPROMISE
 |FTP_ITP_EXT.1 (selection-based)
 |This requirement defines a physically protected channel that the TSF can use to securely parse data being imported into it.
 
-.9+|T.WEAK_ELEMENT_BINDING
-|FCS_COP.1/Hash
+.10+|T.WEAK_ELEMENT_BINDING
+|FCS_COP.1/CMAC (selection-based)
+|This requirement provides a cryptographic operation for asserting the authenticity of SDOs.
+
+|FCS_COP.1/Hash (selection-based)
 |This requirement provides a cryptographic operation for asserting the integrity of SDOs.
 
-|FCS_COP.1/KeyedHash
+|FCS_COP.1/KeyedHash (selection-based)
 |This requirement provides a cryptographic operation for asserting the authenticity of SDOs.
 
-|FCS_COP.1/SigGen
+|FCS_COP.1/SigGen (selection-based)
 |This requirement provides a cryptographic operation for preserving the authenticity of SDOs.
 
-|FCS_COP.1/SigVer
+|FCS_COP.1/SigVer (selection-based)
 |This requirement provides a cryptographic operation for asserting the authenticity of SDOs.
+
+|FCS_COP.1/XOF (selection-based)
+|This requirement provides a cryptographic operation for asserting the integrity of SDOs.
 
 |FDP_SDI.2
 |This requirement ensures that SDOs are monitored for integrity violations.
@@ -1998,9 +1564,6 @@ The following rationale provides justification for each security problem definit
 
 |FPT_ROT_EXT.2 (selection-based)
 |This requirement ensures that the TSF can measure the integrity of its stored data.
-
-|FCS_COP.1/CMAC (selection-based)
-|This requirement provides a cryptographic operation for asserting the authenticity of SDOs.
 
 |FPT_FLS.1/FW (selection-based)
 |This requirement requires the TSF to take action to preserve its secure operation if any violations to its firmware integrity are detected.
@@ -2040,43 +1603,67 @@ The following rationale provides justification for each security problem definit
 |FPT_RPL.1/FW (selection-based)
 |This requirement ensures that the TSF will not permit loading earlier versions of its firmware.
 
-.11+|T.WEAK_CRYPTO
+.18+|T.WEAK_CRYPTO
 |FCS_CKM.1
 |This requirement specifies the supported methods of key generation.
+
+|FCS_CKM.1/AKG (selection-based)
+|This requirement ensures the generation of strong asymmetric keys.
+
+|FCS_CKM.1/SKG (selection-based)
+|This requirement ensures the generation of strong symmetric keys.
 
 |FCS_CKM.2
 |This requirement specifies the supported methods of key distribution.
 
+|FCS_CKM_EXT.3 (selection-based)
+|This requirement ensures the use of strong methods to perform key encapsulation, key wrawpping, or key encryption when accessing keys.
+
+|FCS_CKM.5 (selection-based)
+|This requirement ensures the use of strong mechanisms to perform key derivation.
+
 |FCS_CKM_EXT.7 
 |This requirement ensures the use of strong key agreement mechanisms.
+
+|FCS_CKM_EXT.8 (selection-based)
+|This requirement ensures the use of strong methods to derive keys from password data.
 
 |FCS_COP.1/AEAD (selection-based)
 |This requirement ensures the use of strong methods to encrypt and authenticate sensitive data.
 
-|FCS_COP.1/Hash 
+|FCS_COP.1/CMAC (selection-based)
+|This requirement ensures the use of strong CMAC mechanisms.
+
+|FCS_COP.1/Hash (selection-based)
 |This requirement ensures the use of strong hash mechanisms.
 
-|FCS_COP.1/KeyedHash 
+|FCS_COP.1/KeyedHash (selection-based)
 |This requirement ensures the use of strong HMAC mechanisms.
 
-|FCS_COP.1/SigGen 
-|This requirement ensures the use of strong digital signature services.
+|FCS_COP.1/KeyEncap (selection-based)
+|This requirement ensures the use of strong methods to perform key encapsulation.
 
-|FCS_COP.1/SigVer 
-|This requirement ensures the use of strong digital signature services.
+|FCS_COP.1/KeyWrap (selection-based)
+|This requirement ensures the use of strong methods to perform key wrapping.
 
-|FCS_COP.1/SKC 
+|FCS_COP.1/SigGen (selection-based)
+|This requirement ensures the use of strong digital signature mechanisms.
+
+|FCS_COP.1/SigVer (selection-based)
+|This requirement ensures the use of strong digital signature mechanisms.
+
+|FCS_COP.1/SKC (selection-based)
 |This requirement ensures the use of strong methods to encrypt sensitive data.
 
-|FCS_RBG.1
-|This requirement ensures the use of strong random bit generation mechanisms.
+|FCS_COP.1/XOF (selection-based)
+|This requirement ensures the use of strong methods to perform XOF.
 
+.8+|T.WEAK_CRYPTO
 |FCS_OTV_EXT.1
 |This requirement ensures that one-time values used by the TOE do not negatively impact key strength.
 
-.10+|T.WEAK_CRYPTO
-|FPT_STM_EXT.1 
-|This requirement provides reliable system time services that may be used as inputs to cryptographic functions.
+|FCS_RBG.1
+|This requirement ensures the use of strong random bit generation mechanisms.
 
 |FCS_RBG.2 (optional)
 |This requirement provides an external interface to seed the random bit generator that enforces strong cryptography by requiring a minimum amount of input.
@@ -2093,33 +1680,8 @@ The following rationale provides justification for each security problem definit
 |FCS_RBG.6 (optional)
 |This requirement provides an interface to access RBG output so that the TSF can support the use of strong cryptography in its operational environment.
 
-|FCS_CKM.1/AKG (selection-based)
-|This requirement ensures the generation of strong asymmetric keys.
-
-|FCS_CKM.1/SKG (selection-based)
-|This requirement ensures the generation of strong symmetric keys.
-
-|FCS_CKM_EXT.3 (selection-based)
-|This requirement ensures the use of strong methods to perform key encapsulation, key wrawpping, or key encryption when accessing keys.
-
-|FCS_CKM.5 (selection-based)
-|This requirement ensures the use of strong mechanisms to perform key derivation.
-
-.5+|T.WEAK_CRYPTO
-|FCS_COP.1/CMAC (selection-based)
-|This requirement ensures the use of strong methods to perform CMAC.
-
-|FCS_COP.1/KeyEncap (selection-based)
-|This requirement ensures the use of strong methods to perform key encapsulation.
-
-|FCS_COP.1/KeyWrap (selection-based)
-|This requirement ensures the use of strong methods to perform key wrapping.
-
-|FCS_COP.1/XOF (selection-based)
-|This requirement ensures the use of strong methods to perform XOF.
-
-|FCS_CKM_EXT.8 (selection-based)
-|This requirement ensures the use of strong methods to derive keys from password data.
+|FPT_STM_EXT.1 
+|This requirement provides reliable system time services that may be used as inputs to cryptographic functions.
 
 |===
 
@@ -2750,6 +2312,71 @@ The following table provides the allowed choices for completion of the selection
 
 |===
 
+==== FCS_COP.1/Hash Cryptographic Operation - Hashing
+
+FCS_COP.1/Hash Cryptographic Operation - Hashing
+
+FCS_COP.1.1/Hash:: The TSF shall perform [_cryptographic hashing_] in accordance with a specified cryptographic algorithm [*selection*: _SHA-1, SHA-224, SHA-256, SHA-384, SHA-512, SHA-512/224, SHA-512/256, SHA3-224, SHA3-256, SHA3-384, SHA3-512_] that meets the following: [*selection*: _ISO/IEC 10118-3:2018 [SHA, SHA3], FIPS PUB 180-4 [SHA], FIPS PUB 202 [SHA3]_].
+
+_Application Note {counter:remark_count}_:: _SHA-1 is allowed in cases where collision resistance is not required. SHA-1 may be used for the following applications: generating and verifying hash-based message authentication codes (HMACs), key derivation functions (KDFs), and random bit/number generation. SHA-1 may also be used for verifying old digital signatures and time stamps, if this is explicitly allowed by the application domain._
+
+==== FCS_COP.1/KeyedHash Cryptographic Operation - Keyed Hash
+
+FCS_COP.1/KeyedHash Cryptographic Operation - Keyed Hash
+
+FCS_COP.1.1/KeyedHash:: The TSF shall perform [_keyed hash message authentication_] in accordance with a specified cryptographic algorithm [*selection*: _keyed hash algorithm_] and cryptographic key sizes [*selection*: _cryptographic key size_] that meet the following: [*selection*: _list of standards_].
+
+The following table provides the allowed choices for completion of the selection operations of FCS_COP.1/KeyedHash.
+
+.Allowed choices for FCS_COP.1/KeyedHash
+[[KeyedHashAlgorithms]]
+[cols=".^1,.^1,.^3",options=header]
+|===
+
+|Keyed Hash Algorithm
+|Cryptographic Key Sizes
+|List of Standards
+
+|HMAC-SHA-1
+|[selection: (ISO, FIPS) 160, (FIPS) 128] bits
+|[selection: ISO/IEC 9797-2:2021 (Section 7 "MAC Algorithm 2"); FIPS PUB 198-1]
+
+|HMAC-SHA-224
+|[selection: (ISO, FIPS) 224, (FIPS) 192, 128] bits
+|[selection: ISO/IEC 9797-2:2021 (Section 7 "MAC Algorithm 2"); FIPS PUB 198-1]
+
+|HMAC-SHA-256
+|[selection: (ISO, FIPS) 256, (FIPS) 192, 128] bits
+|[selection: ISO/IEC 9797-2:2021 (Section 7 "MAC Algorithm 2"); FIPS PUB 198-1]
+
+|HMAC-SHA-384
+|[selection: (ISO, FIPS) 384, (FIPS) 256, 192, 128] bits
+|[selection: ISO/IEC 9797-2:2021 (Section 7 "MAC Algorithm 2"); FIPS PUB 198-1]
+
+|HMAC-SHA-512
+|[selection: (ISO, FIPS) 512, (FIPS) 384, 256, 192, 128] bits
+|[selection: ISO/IEC 9797-2:2021 (Section 7 "MAC Algorithm 2"); FIPS PUB 198-1]
+
+|KMAC128
+|128 bits
+|[selection: ISO/IEC 9797-2:2021 (Section 9 "MAC Algorithm 4"); NIST SP 800-185 (Section 4 "KMAC")]
+
+|KMAC256
+|256 bits
+|[selection: ISO/IEC 9797-2:2021 (Section 9 "MAC Algorithm 4"); NIST SP 800-185 (Section 4 "KMAC")]
+
+|KMACXOF128
+|[assignment: integer 256 <= Lk < 2^2040^]
+|[selection: ISO/IEC 9797-2:2021 (Section 9 "MAC Algorithm 4"); NIST SP 800-185 (Section 4 "KMAC")]
+
+|KMACXOF256
+|[assignment: integer 256 <= Lk < 2^2040^]
+|[selection: ISO/IEC 9797-2:2021 (Section 9 "MAC Algorithm 4"); NIST SP 800-185 (Section 4 "KMAC")]
+
+|===
+
+_Application Note {counter:remark_count}_:: _The HMAC minimum key sizes in the table are specified in ISO/IEC 9797-2:2021, which requires that the minimum key size be equal to the digest size. The FIPS standard specifies no minimum or maximum key sizes, so if FIPS PUB 198-1 is selected, larger or smaller key sizes may be used. This is indicted by the parenthesized annotations in the Cryptographic Key Sizes column._
+
 ==== FCS_COP.1/KeyEncap Cryptographic Operation - Key Encapsulation
 
 FCS_COP.1/KeyEncap Cryptographic Operation - Key Encapsulation
@@ -2764,7 +2391,7 @@ The following table provides the allowed choices for completion of the selection
 |===
 
 |Identifier
-|Cryptographic Algorithm 
+|Cryptographic Algorithm
 |Cryptographic Algorithm Parameters
 |List of Standards
 
@@ -2822,6 +2449,388 @@ FCS_COP.1.1/KeyWrap:: The TSF shall perform [_key wrapping_] in accordance with 
 IV length must be equal to 96 bits; the deterministic IV construction method [SP800-38D, Section 8.2.1] must be used; the MAC length t must be one of the values 96, 104, 112, 120, and 128 bits.
 |[selection: (AES, CAM, SEED, LEA) 128, (AES, CAM, LEA) 192, (AES, CAM, LEA) 256] bits
 |[selection: ISO/IEC 19772:2020 (Clause 10), NIST SP 800-38C] [CCM mode]
+
+|===
+
+==== FCS_COP.1/SigGen Cryptographic Operation - Signature Generation
+
+FCS_COP.1/SigGen Cryptographic Operation - Signature Generation
+
+FCS_COP.1.1/SigGen:: The TSF shall perform [_digital signature generation_] in accordance with a specified cryptographic algorithm [*selection*: _cryptographic algorithm_] and cryptographic *algorithm parameters* [*selection*: _cryptographic algorithm parameters_] that meet the following: [*selection*: _list of standards_].
+
+The following table provides the allowed choices for completion of the selection operations of FCS_COP.1/SigGen.
+
+.Allowed choices for FCS_COP.1/SigGen
+[[SigGenOps]]
+[cols=".^1,.^2,.^2,.^2",options=header]
+|===
+
+|Identifier
+|Cryptographic Algorithm
+|Cryptographic Algorithm Parameters
+|List of Standards
+
+|RSA-PKCS
+|RSASSA-PKCS1-v1_5
+|Modulus of size [selection: 2048, 3072, 4096] bits, hash or XOF [selection: SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512]
+|RFC 8017 (Section 8.2) [PKCS #1 v2.2]
+
+FIPS PUB 186-5 (Section 5.4) [RSASSA-PKCS1-v1_5]
+
+|RSA-PSS
+|RSASSA-PSS
+|Modulus of size [selection: 2048, 3072, 4096] bits, hash or XOF [selection: SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512, SHAKE128 with 256-bit output, SHAKE256 with 512-bit output]
+|RFC 8017 (Section 8.1) [PKCS #1 v2.2]
+
+FIPS PUB 186-5 (Section 5.4) [RSASSA-PSS]
+
+|ECDSA
+|ECDSA
+|Elliptic Curve [selection: P-256, brainpoolP256r1, P-384, brainpoolP384r1, P-521, brainpoolP512r1], per-message secret number generation [selection: extra random bits, rejection sampling, deterministic] and hash or XOF function using [selection: SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512, SHAKE128 with 256-bit output, SHAKE256 with 512-bit output]
+|[selection: ISO/IEC 14888-3:2018 (Subclause 6.6), FIPS PUB 186-5 (Sections 6.3.1, 6.4.1)] [ECDSA]
+
+[selection: RFC 5639 (Section 3) [Brainpool Curves], NIST SP-800 186 (Section 4) [NIST Curves]]
+
+|KCDSA
+|KCDSA
+|hash function using [selection: SHA-224, SHA-256, SHA-384, SHA-512]
+|ISO/IEC 14888-3:2018 (Subclause 6.3) [KCDSA]
+
+|EC-KCDSA
+|EC-KCDSA
+|Elliptic Curve [selection: P-224, P-256, B-233, B-283, K-233, K-283] using hash [selection: SHA-224, SHA-256, SHA-384, SHA-512]
+|ISO/IEC 14888-3:2018 (Subclause 6.7) [EC-KCDSA]
+
+NIST SP 800-186 (Section 3) [NIST Curves]
+
+|EdDSA
+|Edwards-Curve Digital Signature Algorithm
+|Domain parameters approved for elliptic curves [selection: Edwards25519, Edwards448]
+|NIST FIPS PUB 186-5 (Section 7.6) [EdDSA]
+
+RFC 8032 [Edwards Curves]
+
+|LMS
+|LMS
+|Private key size = [selection: 192 bits with [selection: SHA-256/192, SHAKE256/192], 256 bits with [selection: SHA-256, SHAKE256]], Winternitz parameter = [selection: 1, 2, 4, 8], and tree height = [selection: 5, 10, 15, 20, 25]
+|RFC 8554 [LMS]
+
+NIST SP 800-208 [parameters]
+
+|HSS
+|Multitree version of LMS
+|Private key size = [selection: 192 bits with [selection: SHA-256/192, SHAKE256/192], 256 bits with [selection: SHA-256, SHAKE256]], Winternitz parameter = [selection: 1, 2, 4, 8], tree height = [selection: 5, 10, 15, 20, 25], and number of levels = [selection: 1, 2, 3, 4, 5, 6, 7, 8]
+|RFC 8554 [HSS]
+
+NIST SP 800-208 [parameters]
+
+|XMSS
+|XMSS
+|Private key size = [selection: 192 bits with [selection: SHA-256/192, SHAKE256/192], 256 bits with [selection: SHA-256, SHAKE256]], tree height = [selection: 10, 16, 20]
+|RFC 8391 [XMSS]
+
+NIST SP 800-208 [parameters]
+
+|XMSS^MT^
+|Multitree version of XMSS
+|Private key size = [selection: 192 bits with [selection: SHA-256/192, SHAKE256/192], 256 bits with [selection: SHA-256, SHAKE256]], (total tree height, number of levels) = [selection: (20, 2), (20, 4), (40, 2), (40, 4), (40, 8), (60, 3), (60, 6), (60, 12)]
+|RFC 8391 [XMSS^MT^]
+
+NIST SP 800-208 [parameters]
+
+|ML-DSA
+|ML-DSA.Sign
+|Parameter set = [selection: ML-DSA-44, ML-DSA-65, ML-DSA-87]
+|NIST FIPS 204 (Section 5.2)
+
+|HashML-DSA
+|HashML-DSA.Sign
+|Parameter set = [selection: ML-DSA-44, ML-DSA-65, ML-DSA-87] and hash function [selection: SHA-256, SHA-512/256, SHA3-256, SHAKE128, SHA-384, SHA3-384, SHA-512, SHA3-512, SHAKE256]
+|NIST FIPS 204 (Section 5.4)
+
+|===
+
+_Application Note {counter:remark_count}_:: _The dependency on FCS_OTV_EXT.1 is needed only for signature schemes that require random bits, such as ECDSA, KCDSA, or EC-KCDSA._
++
+_For LMS, HSS, XMSS, and XMSS^MT^, the key sizes do not represent the expected security strength. All key sizes given here correspond to an expected security strength of 128 bits, per NIST SP 800-208._
++
+_For HSS and XMSS^MT^ the same hash or XOF function shall be used at each level. Within each level, the same Winternitz parameter shall be used but can be different for each level. For HSS, within each level, the same tree height shall be used but can be different for each level._
++
+_Per Section 5.4 of NIST FIPS 204, the collision strength of the hash function selected for the pre-hash of HashML-DSA must be at least the strength of the signature algorithm._
+
+==== FCS_COP.1/SigVer Cryptographic Operation - Signature Verification
+
+FCS_COP.1/SigVer Cryptographic Operation - Signature Verification
+
+FCS_COP.1.1/SigVer:: The TSF shall perform [_digital signature verification_] in accordance with a specified cryptographic algorithm [*selection*: _cryptographic algorithm_] and cryptographic *algorithm parameters* [*selection*: _cryptographic algorithm parameters_] that meet the following: [*selection*: _list of standards_].
+
+
+The following table provides the allowed choices for completion of the selection operations of FCS_COP.1/SigVer.
+
+.Allowed choices for FCS_COP.1/SigVer
+[[SigVerOps]]
+[cols=".^1,.^2,.^2,.^2",options=header]
+|===
+
+|Identifier
+|Cryptographic Algorithm
+|Cryptographic Algorithm Parameters
+|List of Standards
+
+|RSA-PKCS
+|RSASSA-PKCS1-v1_5
+|Modulus of size [selection: 2048, 3072, 4096] bits, hash or XOF [selection: SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512]
+|RFC 8017 (Section 8.2) [PKCS #1 v2.2]
+
+FIPS PUB 186-5 (Section 5.4) [RSASSA-PKCS1-v1_5]
+
+|RSA-PSS
+|RSASSA-PSS
+|Modulus of size [selection: 2048, 3072, 4096] bits, hash or XOF [selection: SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512, SHAKE128 with 256-bit output, SHAKE256 with 512-bit output]
+|RFC 8017 (Section 8.1) [PKCS #1 v2.2]
+
+FIPS PUB 186-5 (Section 5.4) [RSASSA-PSS]
+
+|DSA
+|DSA
+|Domain parameters for (L, N) = [selection: (2048, 224), (2048, 256), (3072, 256)] bits
+|FIPS PUB 186-4 (Section 4.7) [DSA Signature Verification]
+
+|ECDSA
+|ECDSA
+|Elliptic Curve [selection: P-256, brainpoolP256r1, P-384, brainpoolP384r1, P-521, brainpoolP512r1] using hash or XOF function using [selection: SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512, SHAKE128 with 256-bit output, SHAKE256 with 512-bit output]
+|[selection: ISO/IEC 14888-3:2018 (Subclause 6.6), FIPS PUB 186-5 (Section 6.4.2)] [ECDSA]
+
+[selection: RFC 5639 (Section 3) [Brainpool Curves], NIST SP-800 186 (Section 4) [NIST Curves]]
+
+|KCDSA
+|KCDSA
+|hash function using [selection: SHA-224, SHA-256, SHA-384, SHA-512]
+|ISO/IEC 14888-3:2018 (Subclause 6.3) [KCDSA]
+
+|EC-KCDSA
+|EC-KCDSA
+|Elliptic Curve [selection: P-224, P-256, B-233, B-283, K-233, K-283] using hash [selection: SHA-224, SHA-256, SHA-384, SHA-512]
+|ISO/IEC 14888-3:2018 (Subclause 6.7) [EC-KCDSA]
+
+NIST SP 800-186 (Section 3) [NIST Curves]
+
+|EdDSA
+|Edwards-Curve Digital Signature Algorithm
+|Domain parameters approved for elliptic curves [selection: Edwards25519, Edwards448]
+|NIST FIPS PUB 186-5 (Section 7.7) [EdDSA]
+
+RFC 8032 [Edwards Curves]
+
+|LMS
+|LMS
+|Private key size = [selection: 192 bits with [selection: SHA-256/192, SHAKE256/192], 256 bits with [selection: SHA-256, SHAKE256]], Winternitz parameter = [selection: 1, 2, 4, 8], and tree height = [selection: 5, 10, 15, 20, 25]
+|RFC 8554 [LMS]
+
+NIST SP 800-208 [parameters]
+
+|HSS
+|Multitree version of LMS
+|Private key size = [selection: 192 bits with [selection: SHA-256/192, SHAKE256/192], 256 bits with [selection: SHA-256, SHAKE256]], Winternitz parameter = [selection: 1, 2, 4, 8], tree height = [selection: 5, 10, 15, 20, 25], and number of levels = [selection: 1, 2, 3, 4, 5, 6, 7, 8]
+|RFC 8554 [HSS]
+
+NIST SP 800-208 [parameters]
+
+|XMSS
+|XMSS
+|Private key size = [selection: 192 bits with [selection: SHA-256/192, SHAKE256/192], 256 bits with [selection: SHA-256, SHAKE256]], tree height = [selection: 10, 16, 20]
+|RFC 8391 [XMSS]
+
+NIST SP 800-208 [parameters]
+
+|XMSS^MT^
+|Multitree version of XMSS
+|Private key size = [selection: 192 bits with [selection: SHA-256/192, SHAKE256/192], 256 bits with [selection: SHA-256, SHAKE256]], (total tree height, number of levels) = [selection: (20, 2), (20, 4), (40, 2), (40, 4), (40, 8), (60, 3), (60, 6), (60, 12)]
+|RFC 8391 [XMSS^MT^]
+
+NIST SP 800-208 [parameters]
+
+|ML-DSA
+|ML-DSA.Verify
+|Parameter set = [selection: ML-DSA-44, ML-DSA-65, ML-DSA-87]
+|NIST FIPS 204 (Section 5.3)
+
+|HashML-DSA
+|HashML-DSA.Verify
+|Parameter set = [selection: ML-DSA-44, ML-DSA-65, ML-DSA-87] and hash function [selection: SHA-256, SHA-512/256, SHA3-256, SHAKE128, SHA-384, SHA3-384, SHA-512, SHA3-512, SHAKE256]
+|NIST FIPS 204 (Section 5.4)
+
+|===
+
+_Application Note {counter:remark_count}_:: _DSA may only be used to verify signatures generated prior to the implementation date of FIPS 186-5._
++
+_The TOE may contain a public key which is integrity protected (e.g., in hardware), in which case the FDP_ITC.1 and FDP_ITC.2 dependencies do not apply. In this case, no dependencies may be chosen._
++
+_For signature verifications, private keys are not necessary, so there are no dependencies required for generating or destroying cryptographic keys._
++
+_For LMS, HSS, XMSS, and XMSS^MT^, the key sizes do not represent the expected security strength. All key sizes given here correspond to an expected security strength of 128 bits, per NIST SP 800-208._
++
+_For HSS and XMSS^MT^ the same hash or XOF function shall be used at each level. Within each level, the same Winternitz parameter shall be used but can be different for each level. For HSS, within each level, the same tree height shall be used but can be different for each level._
++
+_Per Section 5.4 of NIST FIPS 204, the collision strength of the hash function selected for the pre-hash of HashML-DSA must be at least the strength of the signature algorithm._
+
+==== FCS_COP.1/SKC Cryptographic Operation - Symmetric-Key Cryptography
+
+FCS_COP.1/SKC Cryptographic Operation - Symmetric-Key Cryptography
+
+FCS_COP.1.1/SKC:: The TSF shall perform [_symmetric-key encryption/decryption_] in accordance with a specified cryptographic algorithm [*selection*: _cryptographic algorithm_] and cryptographic key sizes [*selection*: _cryptographic key sizes_] that meet the following: [*selection*: _list of standards_].
+
+The following table provides the allowed choices for completion of the selection operations of FCS_COP.1/SKC.
+
+.Allowed choices for FCS_COP.1/SKC
+[[SymmetricKeyCrypto]]
+[cols=".^1,.^2,.^2,.^2",options=header]
+|===
+
+|Identifier
+|Cryptographic Algorithm
+|Cryptographic Key Sizes
+|List of Standards
+
+|AES-CBC
+|AES in CBC mode with IVs generated according to FCS_OTV_EXT.1
+|[selection: 128, 192, 256] bits
+|[selection: ISO/IEC 18033-3:2010 (Subclause 5.2), FIPS PUB 197] [AES]
+
+[selection: ISO/IEC 10116:2017 (Clause 7), NIST SP 800-38A] [CBC]
+
+|XTS-AES
+|AES in XTS mode with tweak values generated according to FCS_OTV_EXT.1
+|[selection: 256, 512] bits
+|[selection: ISO/IEC 18033-3:2010 (Subclause 5.2), FIPS PUB 197] [AES]
+
+[selection: IEEE Std. 1619-2018, NIST SP 800-38E] [XTS]
+
+|AES-CTR
+|AES in CTR mode with counter values generated according to FCS_OTV_EXT.1
+|[selection: 128, 192, 256] bits
+|[selection: ISO/IEC 18033-3:2010 (Subclause 5.2), FIPS PUB 197] [AES]
+
+[selection: ISO/IEC 10116:2017 (Clause 10), NIST SP 800-38A] [CTR]
+
+|CAM-CBC
+|Camellia in CBC mode with IVs generated according to FCS_OTV_EXT.1
+|[selection: 128, 192, 256] bits
+|ISO/IEC 18033-3:2010 (Subclause 5.3) [Camellia]
+
+[selection: ISO/IEC 10116:2017 (Clause 7), NIST SP 800-38A] [CBC]
+
+|CAM-CFB
+|Camellia in CFB mode with IVs generated according to FCS_OTV_EXT.1
+|[selection: 128, 192, 256] bits
+|ISO/IEC 18033-3:2010 (Subclause 5.3) [Camellia]
+
+[selection: ISO/IEC 10116:2017 (Clause 8), NIST SP 800-38A] [CFB]
+
+|CAM-OFB
+|Camellia in OFB mode with IVs generated according to FCS_OTV_EXT.1
+|[selection: 128, 192, 256] bits
+|ISO/IEC 18033-3:2010 (Subclause 5.3) [Camellia]
+
+[selection: ISO/IEC 10116:2017 (Clause 9), NIST SP 800-38A] [CFB]
+
+|XTS-CAM
+|Camellia in XTS mode with tweak values generated according to FCS_OTV_EXT.1
+|[selection: 256, 512] bits
+|ISO/IEC 18033-3:2010 (Subclause 5.3) [Camellia]
+
+[selection: IEEE Std. 1619-2018, NIST SP 800-38E] [XTS]
+
+|CAM-CTR
+|Camellia in CTR mode with counter values generated according to FCS_OTV_EXT.1
+|[selection: 128, 192, 256] bits
+|ISO/IEC 18033-3:2010 (Subclause 5.3) [Camellia]
+
+[selection: ISO/IEC 10116:2017 (Clause 10), NIST SP 800-38A] [CTR]
+
+|SEED-CBC
+|SEED in CBC mode with IVs generated according to FCS_OTV_EXT.1
+|128 bits
+|ISO/IEC 18033-3:2010 (Subclause 5.4) [SEED]
+
+[selection: ISO/IEC 10116:2017 (Clause 7), NIST SP 800-38A] [CBC]
+
+|SEED-CFB
+|SEED in CFB mode with IVs generated according to FCS_OTV_EXT.1
+|128 bits
+|ISO/IEC 18033-3:2010 (Subclause 5.4) [SEED]
+
+[selection: ISO/IEC 10116:2017 (Clause 8), NIST SP 800-38A] [CFB]
+
+|SEED-OFB
+|SEED in OFB mode with IVs generated according to FCS_OTV_EXT.1
+|128 bits
+|ISO/IEC 18033-3:2010 (Subclause 5.4) [SEED]
+
+[selection: ISO/IEC 10116:2017 (Clause 9), NIST SP 800-38A] [OFB]
+
+|SEED-CTR
+|SEED in CTR mode with counter values generated according to FCS_OTV_EXT.1
+|128 bits
+|ISO/IEC 18033-3:2010 (Subclause 5.4) [SEED]
+
+[selection: ISO/IEC 10116:2017 (Clause 10), NIST SP 800-38A] [CTR]
+
+|HIGHT-CBC
+|HIGHT in CBC mode with IVs generated according to FCS_OTV_EXT.1
+|128 bits
+|ISO/IEC 18033-3:2010 (Subclause 4.5) [HIGHT]
+
+[selection: ISO/IEC 10116:2017 (Clause 7), NIST SP 800-38A] [CBC]
+
+|HIGHT-CFB
+|HIGHT in CFB mode with IVs generated according to FCS_OTV_EXT.1
+|128 bits
+|ISO/IEC 18033-3:2010 (Subclause 4.5) [HIGHT]
+
+[selection: ISO/IEC 10116:2017 (Clause 8), NIST SP 800-38A] [CFB]
+
+|HIGHT-OFB
+|HIGHT in OFB mode with IVs generated according to FCS_OTV_EXT.1
+|128 bits
+|ISO/IEC 18033-3:2010 (Subclause 4.5) [HIGHT]
+
+[selection: ISO/IEC 10116:2017 (Clause 9), NIST SP 800-38A] [OFB]
+
+|HIGHT-CTR
+|HIGHT in CTR mode with counter values generated according to FCS_OTV_EXT.1
+|128 bits
+|ISO/IEC 18033-3:2010 (Subclause 4.5) [HIGHT]
+
+[selection: ISO/IEC 10116:2017 (Clause 10), NIST SP 800-38A] [CTR]
+
+|LEA-CBC
+|LEA in CBC mode with IVs generated according to FCS_OTV_EXT.1
+|[selection: 128, 192, 256] bits
+|ISO/IEC 29192-2:2019 (Subclause 6.3) [LEA]
+
+[selection: ISO/IEC 10116:2017 (Clause 7), NIST SP 800-38A] [CBC]
+
+|LEA-CFB
+|LEA in CFB mode with IVs generated according to FCS_OTV_EXT.1
+|[selection: 128, 192, 256] bits
+|ISO/IEC 29192-2:2019 (Subclause 6.3) [LEA]
+
+[selection: ISO/IEC 10116:2017 (Clause 8), NIST SP 800-38A] [CFB]
+
+|LEA-OFB
+|LEA in OFB mode with IVs generated according to FCS_OTV_EXT.1
+|[selection: 128, 192, 256] bits
+|ISO/IEC 29192-2:2019 (Subclause 6.3) [LEA]
+
+[selection: ISO/IEC 10116:2017 (Clause 9), NIST SP 800-38A] [OFB]
+
+|LEA-CTR
+|LEA in CTR mode with counter values generated according to FCS_OTV_EXT.1
+|[selection: 128, 192, 256] bits
+|ISO/IEC 29192-2:2019 (Subclause 6.3) [LEA]
+
+[selection: ISO/IEC 10116:2017 (Clause 10), NIST SP 800-38A] [CTR]
 
 |===
 
@@ -3905,7 +3914,7 @@ FCS_CKM_EXT.7 - (selection-based SFR) included
 
 FCS_CKM_EXT.8 - (selection-based SFR) included
 
-FCS_COP.1 - included
+FCS_COP.1 - (selection-based SFR) included
 
 FCS_RBG.1 - included
 
@@ -3938,78 +3947,6 @@ FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data
 FCS_CKM.1 - included
 
 FCS_CKM.5 - (selection-based SFR) included
-
-|FCS_COP.1/Hash 
-|No dependencies.
-|There are no keys involved with hashing, so no cryptograhpic key-based dependencies are necessary.
-
-|FCS_COP.1/KeyedHash 
-|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7 or FCS_CKM_EXT.8] 
-
-FCS_CKM.6 
-|FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
-
-FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
-
-FCS_CKM.1 - included
-
-FCS_CKM.5 - (selection-based SFR) included
-
-FCS_CKM_EXT.7 - (selection-based SFR) included
-
-FCS_CKM_EXT.8 - (selection-based SFR) included
-
-FCS_CKM.6 - included
-
-|FCS_COP.1/SigGen 
-|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1/AKG, or FCS_CKM.5] 
-
-FCS_CKM.6 
-|FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
-
-FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
-
-FCS_CKM.1/AKG - (selection-based SFR) included
-
-FCS_CKM.5 - (selection-based SFR) included
-
-FCS_CKM.6 - included
-
-|FCS_COP.1/SigVer 
-|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, or FCS_CKM.5] 
-
-FCS_CKM.6 
-|FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
-
-FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
-
-FCS_CKM.1 - included
-
-FCS_CKM.5 - (selection-based SFR) included
-
-FCS_CKM.6 - included
-
-|FCS_COP.1/SKC 
-|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7 or FCS_CKM_EXT.8] 
-
-FCS_CKM.6 
-
-FCS_OTV_EXT.1
-|FDP_ITC_EXT.1 satisfies FDP_ITC.1 related to a mechanism by which key data can be imported into the TSF - included
-
-FDP_ITC_EXT.2 satisfies FDP_ITC.2 related to a mechanism by which key data can be imported into the TSF - included
-
-FCS_CKM.1 - included
-
-FCS_CKM.5 - (selection-based SFR) included
-
-FCS_CKM_EXT.7 - (selection-based SFR) included
-
-FCS_CKM_EXT.8 - (selection-based SFR) included
-
-FCS_CKM.6 - included
-
-FCS_OTV_EXT.1 - included
 
 |FCS_RBG.1 
 |[FCS_RBG.2 or FCS_RBG.3]
@@ -4048,13 +3985,13 @@ FMT_MSA.3 - included
 
 |FDP_ETC_EXT.2 
 |FCS_COP.1 
-|FCS_COP.1 - included
+|FCS_COP.1 - (selection-based SFR) included
 
 |FDP_ITC_EXT.1 
 |FCS_COP.1 
 
 [FTP_ITC_EXT.1, FTP_ITE_EXT.1, or FTP_ITP_EXT.1] 
-|FCS_COP.1 - included
+|FCS_COP.1 - (selection-based SFR) included
 
 FTP_ITC_EXT.1 - (selection-based SFR) included
 
@@ -4066,7 +4003,7 @@ FTP_ITP_EXT.1 - (selection-based SFR) included
 |FCS_COP.1 
 
 [FTP_ITC_EXT.1, FTP_ITE_EXT.1, or FTP_ITP_EXT.1] 
-|FCS_COP.1 - included
+|FCS_COP.1 - (selection-based SFR) included
 
 FTP_ITC_EXT.1 - (selection-based SFR) included
 
@@ -4080,7 +4017,7 @@ FTP_ITP_EXT.1 - (selection-based SFR) included
 
 |FDP_SDC.2 
 |FCS_COP.1
-|FCS_COP.1 - included
+|FCS_COP.1 - (selection-based SFR) included
 
 |FDP_SDI.2 
 |No dependencies
@@ -4228,7 +4165,7 @@ FCS_RBG.4 - (optional SFR) included
 |Rationale Statement
 
 |FCS_CKM.1/AKG 
-|[FCS_CKM.2, FCS_CKM.5 or FCS_COP.1]
+|[FCS_CKM.2, FCS_CKM.5, or FCS_COP.1]
 
 [FCS_RBG.1 or FCS_RNG.1]
 
@@ -4237,7 +4174,7 @@ FCS_CKM.6
 
 FCS_CKM.5 - (selection-based SFR) included
 
-FCS_COP.1 - included
+FCS_COP.1 - (selection-based SFR) included
 
 FCS_RBG.1 - included
 
@@ -4246,7 +4183,7 @@ FCS_RNG.1 is satisfied by FCS_RBG.1 - included
 FCS_CKM.6 - included
 
 |FCS_CKM.1/SKG 
-|[FCS_CKM.2, FCS_CKM.5, FCS_CKM_EXT.7 or FCS_COP.1]
+|[FCS_CKM.2, FCS_CKM.5, FCS_CKM_EXT.7, or FCS_COP.1]
 
 [FCS_RBG.1 or FCS_RNG.1]
 
@@ -4257,7 +4194,7 @@ FCS_CKM.5 - (selection-based SFR) included
 
 FCS_CKM_EXT.7 - (selection-based SFR) included
 
-FCS_COP.1 - included
+FCS_COP.1 - (selection-based SFR) included
 
 FCS_RBG.1 - included
 
@@ -4340,7 +4277,7 @@ FCS_CKM.6 - included
 FCS_OTV_EXT.1 - included
 
 |FCS_COP.1/AEAD
-|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7 or FCS_CKM_EXT.8]
+|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7, or FCS_CKM_EXT.8]
 
 FCS_CKM.6
 
@@ -4362,7 +4299,7 @@ FCS_CKM.6 - included
 FCS_OTV_EXT.1 - included
 
 |FCS_COP.1/CMAC
-|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7 or FCS_CKM_EXT.8]
+|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7, or FCS_CKM_EXT.8]
 
 FCS_CKM.6
 
@@ -4380,10 +4317,38 @@ FCS_CKM_EXT.8 - (selection-based SFR) included
 
 FCS_CKM.6 - included
 
+|FCS_COP.1/Hash
+|No dependencies.
+|There are no keys involved with hashing, so no cryptograhpic key-based dependencies are necessary.
+
+|FCS_COP.1/KeyedHash
+|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7, or FCS_CKM_EXT.8]
+
+FCS_CKM.6
+
+[FCS_COP.1/Hash or FCS_COP.1/XOF]
+|FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
+
+FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
+
+FCS_CKM.1 - included
+
+FCS_CKM.5 - (selection-based SFR) included
+
+FCS_CKM_EXT.7 - (selection-based SFR) included
+
+FCS_CKM_EXT.8 - (selection-based SFR) included
+
+FCS_CKM.6 - included
+
+FCS_COP.1/Hash - (selection-based SFR) included
+
+FCS_COP.1/XOF - (selection-based SFR) included
+
 |FCS_COP.1/KeyEncap
 |[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7, or FCS_CKM_EXT.8]
 
-FCS_CKM.6 
+FCS_CKM.6
 
 FCS_OTV_EXT.1
 |FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
@@ -4405,7 +4370,9 @@ FCS_OTV_EXT.1 - included
 |FCS_COP.1/KeyWrap
 |[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7, or FCS_CKM_EXT.8]
 
-FCS_CKM.6 
+FCS_CKM.6
+
+FCS_COP.1/SKC
 |FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
 
 FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
@@ -4419,6 +4386,74 @@ FCS_CKM_EXT.7 - (selection-based SFR) included
 FCS_CKM_EXT.8 - (selection-based SFR) included
 
 FCS_CKM.6 - included
+
+FCS_COP.1/SKC - (selection-based SFR) included
+
+|FCS_COP.1/SigGen
+|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1/AKG, or FCS_CKM.5]
+
+[FCS_COP.1/Hash or FCS_COP.1/XOF]
+
+FCS_OTV_EXT.1
+
+FCS_CKM.6
+|FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
+
+FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
+
+FCS_CKM.1/AKG - (selection-based SFR) included
+
+FCS_CKM.5 - (selection-based SFR) included
+
+FCS_COP.1/Hash - (selection-based SFR) included
+
+FCS_COP.1/XOF - (selection-based SFR) included
+
+FCS_OTV_EXT.1 - included
+
+FCS_CKM.6 - included
+
+|FCS_COP.1/SigVer
+|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, or FCS_CKM.5]
+
+[FCS_COP.1/Hash or FCS_COP.1/XOF]
+
+FCS_CKM.6
+|FDP_ITC.1 is satisfied by FDP_ITC_EXT.1 related to a mechanism by which key data can be imported into the TSF - included
+
+FDP_ITC.2 is satisfied by FDP_ITC_EXT.2 related to a mechanism by which key data can be imported into the TSF - included
+
+FCS_CKM.1 - included
+
+FCS_CKM.5 - (selection-based SFR) included
+
+FCS_COP.1/Hash - (selection-based SFR) included
+
+FCS_COP.1/XOF - (selection-based SFR) included
+
+FCS_CKM.6 - included
+
+|FCS_COP.1/SKC
+|[FDP_ITC.1, FDP_ITC.2, FCS_CKM.1, FCS_CKM.5, FCS_CKM_EXT.7, or FCS_CKM_EXT.8]
+
+FCS_CKM.6
+
+FCS_OTV_EXT.1
+|FDP_ITC_EXT.1 satisfies FDP_ITC.1 related to a mechanism by which key data can be imported into the TSF - included
+
+FDP_ITC_EXT.2 satisfies FDP_ITC.2 related to a mechanism by which key data can be imported into the TSF - included
+
+FCS_CKM.1 - included
+
+FCS_CKM.5 - (selection-based SFR) included
+
+FCS_CKM_EXT.7 - (selection-based SFR) included
+
+FCS_CKM_EXT.8 - (selection-based SFR) included
+
+FCS_CKM.6 - included
+
+FCS_OTV_EXT.1 - included
 
 |FDP_DAU.1/Prove 
 |No dependencies
@@ -4442,7 +4477,7 @@ FCS_CKM.6 - included
 FCS_COP.1
 |FPT_MFW_EXT.1 - included
 
-FCS_COP.1 - included
+FCS_COP.1 - (selection-based SFR) included
 
 |FPT_ROT_EXT.2
 |FPT_ROT_EXT.1
@@ -4454,7 +4489,7 @@ FCS_COP.1 - included
 FCS_COP.1
 |FPT_ROT_EXT.2 - (selection-based SFR) included
 
-FCS_COP.1 - included
+FCS_COP.1 - (selection-based SFR) included
 
 |FPT_ROT_EXT.4
 |FPT_ROT_EXT.1
@@ -4462,7 +4497,7 @@ FCS_COP.1 - included
 FCS_COP.1
 |FPT_ROT_EXT.1 - included
 
-FCS_COP.1 - included
+FCS_COP.1 - (selection-based SFR) included
 
 |FPT_RPL.1/FW
 |No dependencies
@@ -4472,13 +4507,13 @@ FCS_COP.1 - included
 |No dependencies
 |N/A
 
-|FTP_ITC_EXT.1 
-|FCS_COP.1 
-|FCS_COP.1 - included
+|FTP_ITC_EXT.1
+|FCS_COP.1
+|FCS_COP.1 - (selection-based SFR) included
 
-|FTP_ITE_EXT.1 
-|FCS_COP.1 
-|FCS_COP.1 - included
+|FTP_ITE_EXT.1
+|FCS_COP.1
+|FCS_COP.1 - (selection-based SFR) included
 
 |FTP_ITP_EXT.1 
 |No dependencies
@@ -4511,11 +4546,11 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/AEAD !Cryptographic Operation (Authenticated Encryption with Associated Data)
 
+!FCS_COP.1/CMAC !Cryptographic Operation - CMAC
+
 !FCS_COP.1/Hash !Cryptographic Operation - Hashing
 
 !FCS_COP.1/KeyedHash !Cryptographic Operation - Keyed Hash
-
-!FCS_COP.1/CMAC !Cryptographic Operation - CMAC
 
 !FCS_COP.1/KeyEncap !Cryptographic Operation - Key Encapsulation
 
@@ -4549,11 +4584,11 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/AEAD !Cryptographic Operation (Authenticated Encryption with Associated Data)
 
+!FCS_COP.1/CMAC !Cryptographic Operation - CMAC
+
 !FCS_COP.1/Hash !Cryptographic Operation - Hashing
 
 !FCS_COP.1/KeyedHash !Cryptographic Operation - Keyed Hash
-
-!FCS_COP.1/CMAC !Cryptographic Operation - CMAC
 
 !FCS_COP.1/SKC !Cryptographic Operation - Symmetric-Key Cryptography
 
@@ -4589,11 +4624,11 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/AEAD !Cryptographic Operation (Authenticated Encryption with Associated Data)
 
+!FCS_COP.1/CMAC !Cryptographic Operation - CMAC
+
 !FCS_COP.1/Hash !Cryptographic Operation - Hashing
 
 !FCS_COP.1/KeyedHash !Cryptographic Operation - Keyed Hash
-
-!FCS_COP.1/CMAC !Cryptographic Operation - CMAC
 
 !FCS_COP.1/SKC !Cryptographic Operation - Symmetric-Key Cryptography
 
@@ -4629,13 +4664,15 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 
 !FCS_COP.1/AEAD !Cryptographic Operation (Authenticated Encryption with Associated Data)
 
+!FCS_COP.1/CMAC !Cryptographic Operation - CMAC
+
 !FCS_COP.1/Hash !Cryptographic Operation - Hashing
 
 !FCS_COP.1/KeyedHash !Cryptographic Operation - Keyed Hash
 
-!FCS_COP.1/CMAC !Cryptographic Operation - CMAC
+!FCS_COP.1/KeyEncap !Cryptographic Operation - Key Encapsulation
 
-!FCS_COP.1/KeyEnc !Cryptographic Operation (Key Encryption)
+!FCS_COP.1/KeyWrap !Cryptographic Operation - Key Wrapping
 
 !FCS_COP.1/SigGen !Cryptographic Operation - Signature Generation
 
@@ -4683,11 +4720,15 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 !===
 
+!FCS_COP.1/CMAC !Cryptographic Operation - CMAC
+
 !FCS_COP.1/Hash !Cryptographic Operation - Hashing
 
 !FCS_COP.1/KeyedHash !Cryptographic Operation - Keyed Hash
 
-!FCS_COP.1/CMAC !Cryptographic Operation - CMAC
+!FCS_COP.1/SigGen !Cryptographic Operation - Signature Generation
+
+!FCS_COP.1/SigVer !Cryptographic Operation - Signature Verification
 
 !FCS_RBG.1 !Random Bit Generation (RBG)
 
@@ -4725,15 +4766,17 @@ a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 a|[cols=".^1,3",options=noheader,grid="none",frame="none"]
 !===
 
+!FCS_COP.1/CMAC !Cryptographic Operation - CMAC
+
 !FCS_COP.1/AEAD !Cryptographic Operation (Authenticated Encryption with Associated Data)
 
 !FCS_COP.1/Hash !Cryptographic Operation - Hashing
 
 !FCS_COP.1/KeyedHash !Cryptographic Operation - Keyed Hash
 
-!FCS_COP.1/CMAC !Cryptographic Operation - CMAC
+!FCS_COP.1/KeyEncap !Cryptographic Operation - Key Encapsulation
 
-!FCS_COP.1/KeyEnc !Cryptographic Operation (Key Encryption)
+!FCS_COP.1/KeyWrap !Cryptographic Operation - Key Wrapping
 
 !FCS_COP.1/SKC !Cryptographic Operation - Symmetric-Key Cryptography
 


### PR DESCRIPTION
Now that the FDP_* SFRs include selections for the various cryptographic algorithms, move them to the selection-based section. This makes the cPP more flexible in allowing DSCs that don't implement any of the previously mandatory algorithms, ...