### PR TITLE
Fix missing ML-KEM.Decaps

### DIFF
--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -2807,7 +2807,7 @@ The following table provides the allowed choices for completion of the selection
 |NIST SP 800-56B Revision 2 (Section 7.2.2.3 & 7.2.2.4)
 
 |ML-KEM
-|ML-KEM.Encaps
+|ML-KEM.Encaps & ML-KEM.Decaps [ML-KEM]
 |Parameter set = [selection: ML-KEM-512, ML-KEM-768, ML-KEM-1024]
 |NIST FIPS 203 (Section 7.2)
 


### PR DESCRIPTION
To be applied to v2.1 before release.

Decaps is missing which could cause confusion (the intent is to allow both).