### PR TITLE
Update for Errata v1.2

### DIFF
--- a/SD_DSC.adoc
+++ b/SD_DSC.adoc
@@ -2953,7 +2953,7 @@ The supplementary information required by this SD are:
 |https://www.commoncriteriaportal.org/cc/index.cfm
 
 |[CC-E&I]
-|Errata and Interpretation for CC:2022 (Release 1) and CEM:2022 (Release 1), 001, Version 1.1, February 1, 2024
+|Errata and Interpretation for CC:2022 (Release 1) and CEM:2022 (Release 1), 001, Version 1.2, October 15, 2025
 |https://www.commoncriteriaportal.org/cc/index.cfm
 
 |[ISO-TR]

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -1134,7 +1134,7 @@ The following table provides the allowed choices for completion of the selection
 
 FCS_RBG.1 Random Bit Generation (RBG)
 
-FCS_RBG.1.1:: The TSF shall perform deterministic random bit generation services using [*selection*: _DRBG algorithm_] in accordance with [*selection*: _list of standards_] after initialization with a seed.
+FCS_RBG.1.1:: The TSF shall perform deterministic random bit generation services using [*selection*: _DRBG algorithm_] in accordance with [*selection*: _list of standards_] after initialization.
 
 The following table provides the recommended choices for completion of the selection operations of FCS_RBG.1.
 
@@ -1165,9 +1165,9 @@ FIPS PUB 202 [SHA3]
 |===
 
 
-FCS_RBG.1.2:: The TSF shall use a {empty}[selection: _TSF *entropy* source [assignment: name of *entropy* source], TSF interface for obtaining entropy_] for initialization and reseeding.
+FCS_RBG.1.2:: The TSF shall use a {empty}[selection: _TSF entropy source [assignment: name of entropy source], TSF interface for obtaining entropy_] for initialization and reseeding.
 
-FCS_RBG.1.3:: The TSF shall update the *DRBG* state by [selection: _reseeding, uninstantiating and re-instantiating_] using a {empty}[selection: _TSF *entropy* source [assignment: name of *entropy* source], TSF interface for obtaining entropy [assignment: name of the interface]_] in the following situations: [selection:
+FCS_RBG.1.3:: The TSF shall update the DRBG state by [selection: _reseeding, uninstantiating and re-instantiating_] using a {empty}[selection: _TSF entropy source [assignment: name of entropy source], TSF interface for obtaining entropy [assignment: name of the interface]_] in the following situations: [selection:
 +
 * _never_,
 * _on demand,_
@@ -2269,7 +2269,7 @@ As with ATE_IND, the evaluator shall generate a report to document their finding
 
 FCS_RBG.2 Random Bit Generation (External Seeding)
 
-FCS_RBG.2.1:: The TSF shall be able to accept a minimum input of [assignment: _minimum input length greater than zero_] from a TSF interface for the purpose of *obtaining entropy*.
+FCS_RBG.2.1:: The TSF shall be able to accept a minimum input of [assignment: _minimum input length greater than zero_] from a TSF interface for obtaining entropy.
 
 _Application Note {counter:remark_count}_:: _In order to maintain compliance with NIST SP 800-90A Revision 1, the TSF accepts enough bits input from an external entropy source to satisfy the entropy requirements of the DRBG._
 +
@@ -2279,7 +2279,7 @@ _The TSF interface for the purpose of seeding here is the interface used to gath
 
 FCS_RBG.3 Random Bit Generation (Internal Seeding - Single Source)
 
-FCS_RBG.3.1:: The TSF shall be able to seed the *DRBG* using a [selection: choose one of: _TSF software-based *entropy* source, TSF hardware-based *entropy* source_] [assignment: _name of *entropy* source_] with [assignment: _number of bits_] bits of min-entropy.
+FCS_RBG.3.1:: The TSF shall be able to seed the DRBG using a [selection: choose one of: _TSF software-based entropy source, TSF hardware-based entropy source_] [assignment: _name of entropy source_] with [assignment: _number of bits_] bits of min-entropy.
 
 _Application Note {counter:remark_count}_:: _If an ST Author wishes to use multiple internal entropy sources, they iterate this requirement for each entropy source used by the TSF._
 
@@ -2287,13 +2287,13 @@ _Application Note {counter:remark_count}_:: _If an ST Author wishes to use multi
 
 FCS_RBG.4 Random Bit Generation (Internal Seeding - Multiple Sources)
 
-FCS_RBG.4.1:: The TSF shall be able to seed the *DRBG* using [selection: _[assignment: number] TSF software-based *entropy* source(s), [assignment: number] TSF hardware-based *entropy* source(s)_].
+FCS_RBG.4.1:: The TSF shall be able to seed the DRBG using [selection: _[assignment: number] TSF software-based entropy source(s), [assignment: number] TSF hardware-based entropy source(s)_].
 
 ==== FCS_RBG.5 Random Bit Generation (Combining Entropy Sources)
 
 FCS_RBG.5 Random Bit Generation (Combining Entropy Sources)
 
-FCS_RBG.5.1:: The TSF shall {empty}[*selection*: _hash, concatenate and hash, xor, input into a linear feedback shift register, [assignment: combining operation]_] [selection: _output from TSF *entropy* source(s), input from TSF interface(s) for_ *_obtaining entropy_*] to create the entropy input into the derivation function as defined in [*selection*: _ISO/IEC 18031: 2011, NIST SP 800-90A Revision 1_] resulting in a minimum of [assignment: _number of bits_] bits of min-entropy.
+FCS_RBG.5.1:: The TSF shall {empty}[*selection*: _hash, concatenate and hash, xor, input into a linear feedback shift register, [assignment: combining operation]_] [selection: _output from TSF entropy source(s), input from TSF interface(s) for obtaining entropy_] resulting in a minimum of [assignment: _number of bits_] bits of min-entropy to create the entropy input into the derivation function as defined in [*selection*: _ISO/IEC 18031: 2011, NIST SP 800-90A Revision 1_].
 
 _Application Note {counter:remark_count}_:: _One can apply NIST SP 800-90B (or AIS-31) statistical tests against internal entropy sources (a.k.a. raw entropy) to confirm the min-entropy of the entropy sources either in aggregate or individually. NIST SP 800-90B (or AIS-31) statistical tests against external entropy sources are not needed since the TOE is unable to enforce entropy requirements or conditioning requirements against external sources of entropy. However, the TSS may include estimates for min-entropy from external sources that contribute to the overall entropy requirements for either the DRBG or for FCS_OTV_EXT.1._
 +
@@ -2305,7 +2305,7 @@ _The TSF interface(s) for seeding here is the interface used to gather entropy f
 
 FCS_RBG.6 Random Bit Generation Service
 
-FCS_RBG.6.1:: The TSF shall provide a [selection: _hardware, software, [assignment: other interface type]_] interface to make the *DRBG* output, as specified in FCS_RBG.1 Random Bit Generation (RBG), available as a service to entities outside of the TOE.
+FCS_RBG.6.1:: The TSF shall provide a [selection: _hardware, software, [assignment: other interface type]_] interface to make the DRBG output, as specified in FCS_RBG.1 Random Bit Generation (RBG), available as a service to entities outside of the TOE.
 
 === Protection of the TSF
 ==== FPT_ITT.1 Basic Internal TSF Data Transfer Protection

--- a/cPP_DSC.adoc
+++ b/cPP_DSC.adoc
@@ -92,7 +92,7 @@ The target audiences of this cPP are developers, CC consumers, system integrator
 |https://www.commoncriteriaportal.org/cc/index.cfm
 
 |[CC-E&I]
-|Errata and Interpretation for CC:2022 (Release 1) and CEM:2022 (Release 1), 002, Version 1.1, July 22, 2024
+|Errata and Interpretation for CC:2022 (Release 1) and CEM:2022 (Release 1), 001, Version 1.2, October 15, 2025
 |https://www.commoncriteriaportal.org/cc/index.cfm
 
 |[DSC SD]


### PR DESCRIPTION
Based on https://www.commoncriteriaportal.org/files/ccfiles/CCMB-2025-001-v1_2-Errata_Interpretation_CC_CEM_2022.pdf

The only changes are editorial, related to the DRBG requirements. We already had most of these changes due to the Crypto Catalog, but they were applied in our cPP as refinements. Now that they're "official", we can remove the refinement (bold) tags.

I don't think this is worth issuing a TD or new version of the cPP.